### PR TITLE
chore: Bump version to 0.6.0 for new release

### DIFF
--- a/py/src/braintrust/version.py
+++ b/py/src/braintrust/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.5.6"
+VERSION = "0.6.0"
 
 # this will be templated during the build
 GIT_COMMIT = "__GIT_COMMIT__"


### PR DESCRIPTION
includes https://github.com/braintrustdata/braintrust-sdk-python/pull/2