### PR TITLE
fix: Declare `merged_git_metadata_settings` before usage

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1639,6 +1639,7 @@ def init(
         if description is not None:
             args["description"] = description
 
+        merged_git_metadata_settings = None
         if repo_info:
             repo_info_arg = repo_info
         else:


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk-python/issues/8

### AI Summary

**Fix**: One-line initialization at `logger.py:1642` — `merged_git_metadata_settings = None`

**Bug**: When `repo_info` is passed to `braintrust.init()`, the code skips the `else` block where `merged_git_metadata_settings` gets assigned (line 1646), but later references it unconditionally on line 1660. This causes an `UnboundLocalError` whenever `base_experiment_id` and `base_experiment` are both `None` (the default).

**Fix behavior**: Initializing to `None` before the `if/else` ensures the variable is always defined. Since `None` is falsy, the `elif` on line 1660 short-circuits correctly — skipping ancestor commit collection, which is the right behavior when the user explicitly provides `repo_info`.

**Test**: Added `test_init_with_repo_info_does_not_raise` in `test_logger.py` that calls `braintrust.init(project=..., repo_info=RepoInfo(...))` and forces `compute_metadata()` to execute. Verified it fails with `UnboundLocalError` without the fix and passes with it.