### PR TITLE
feat: Allow passing tags for evals and experiments

### DIFF
--- a/py/src/braintrust/cli/eval.py
+++ b/py/src/braintrust/cli/eval.py
@@ -138,6 +138,7 @@ async def run_evaluator_task(evaluator, position, opts: EvaluatorOpts):
             experiment_name=evaluator.experiment_name,
             description=evaluator.description,
             metadata=evaluator.metadata,
+            tags=evaluator.tags,
             is_public=evaluator.is_public,
             update=evaluator.update,
             base_experiment=base_experiment_name,

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -359,6 +359,11 @@ class Evaluator(Generic[Input, Output]):
     JSON-serializable type, but its keys must be strings.
     """
 
+    tags: list[str] | None = None
+    """
+    Optional list of tags for the experiment
+    """
+
     trial_count: int = 1
     """
     The number of times to run the evaluator per input. This is useful for evaluating applications that
@@ -654,6 +659,7 @@ def _EvalCommon(
     experiment_name: str | None,
     trial_count: int,
     metadata: Metadata | None,
+    tags: list[str] | None,
     is_public: bool,
     update: bool,
     reporter: ReporterDef[Input, Output, EvalReport] | None,
@@ -695,6 +701,7 @@ def _EvalCommon(
         experiment_name=experiment_name,
         trial_count=trial_count,
         metadata=metadata,
+        tags=tags,
         is_public=is_public,
         update=update,
         timeout=timeout,
@@ -743,6 +750,7 @@ def _EvalCommon(
                 experiment_name=evaluator.experiment_name,
                 description=evaluator.description,
                 metadata=evaluator.metadata,
+                tags=evaluator.tags,
                 is_public=evaluator.is_public,
                 update=evaluator.update,
                 base_experiment=base_experiment_name,
@@ -780,6 +788,7 @@ async def EvalAsync(
     experiment_name: str | None = None,
     trial_count: int = 1,
     metadata: Metadata | None = None,
+    tags: list[str] | None = None,
     is_public: bool = False,
     update: bool = False,
     reporter: ReporterDef[Input, Output, EvalReport] | None = None,
@@ -833,6 +842,7 @@ async def EvalAsync(
     anything else that's relevant, that you can use to help find and analyze examples later. For example, you could log
     the `prompt`, example's `id`, or anything else that would be useful to slice/dice later. The values in `metadata`
     can be any JSON-serializable type, but its keys must be strings.
+    :param tags: (Optional) A list of tags to associate with the experiment.
     :param is_public: (Optional) Whether the experiment should be public. Defaults to false.
     :param reporter: (Optional) A reporter that takes an evaluator and its result and returns a report.
     :param timeout: (Optional) The duration, in seconds, after which to time out the evaluation.
@@ -869,6 +879,7 @@ async def EvalAsync(
         experiment_name=experiment_name,
         trial_count=trial_count,
         metadata=metadata,
+        tags=tags,
         is_public=is_public,
         update=update,
         reporter=reporter,
@@ -904,6 +915,7 @@ def Eval(
     experiment_name: str | None = None,
     trial_count: int = 1,
     metadata: Metadata | None = None,
+    tags: list[str] | None = None,
     is_public: bool = False,
     update: bool = False,
     reporter: ReporterDef[Input, Output, EvalReport] | None = None,
@@ -957,6 +969,7 @@ def Eval(
     anything else that's relevant, that you can use to help find and analyze examples later. For example, you could log
     the `prompt`, example's `id`, or anything else that would be useful to slice/dice later. The values in `metadata`
     can be any JSON-serializable type, but its keys must be strings.
+    :param tags: (Optional) A list of tags to associate with the experiment.
     :param is_public: (Optional) Whether the experiment should be public. Defaults to false.
     :param reporter: (Optional) A reporter that takes an evaluator and its result and returns a report.
     :param timeout: (Optional) The duration, in seconds, after which to time out the evaluation.
@@ -994,6 +1007,7 @@ def Eval(
         experiment_name=experiment_name,
         trial_count=trial_count,
         metadata=metadata,
+        tags=tags,
         is_public=is_public,
         update=update,
         reporter=reporter,

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1506,6 +1506,7 @@ def init(
     api_key: str | None = ...,
     org_name: str | None = ...,
     metadata: Metadata | None = ...,
+    tags: list[str] | None = ...,
     git_metadata_settings: GitMetadataSettings | None = ...,
     set_current: bool = ...,
     update: bool | None = ...,
@@ -1529,6 +1530,7 @@ def init(
     api_key: str | None = ...,
     org_name: str | None = ...,
     metadata: Metadata | None = ...,
+    tags: list[str] | None = ...,
     git_metadata_settings: GitMetadataSettings | None = ...,
     set_current: bool = ...,
     update: bool | None = ...,
@@ -1551,6 +1553,7 @@ def init(
     api_key: str | None = None,
     org_name: str | None = None,
     metadata: Metadata | None = None,
+    tags: list[str] | None = None,
     git_metadata_settings: GitMetadataSettings | None = None,
     set_current: bool = True,
     update: bool | None = None,
@@ -1575,6 +1578,7 @@ def init(
     key is specified, will prompt the user to login.
     :param org_name: (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
     :param metadata: (Optional) a dictionary with additional data about the test example, model outputs, or just about anything else that's relevant, that you can use to help find and analyze examples later. For example, you could log the `prompt`, example's `id`, or anything else that would be useful to slice/dice later. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
+    :param tags: (Optional) a list of strings to tag the experiment with. Tags can be used to filter and organize experiments.
     :param git_metadata_settings: (Optional) Settings for collecting git metadata. By default, will collect all git metadata fields allowed in org-level settings.
     :param set_current: If true (the default), set the global current-experiment to the newly-created one.
     :param open: If the experiment already exists, open it in read-only mode. Throws an error if the experiment does not already exist.
@@ -1622,6 +1626,9 @@ def init(
 
         lazy_metadata = LazyValue(compute_metadata, use_mutex=True)
         return ReadonlyExperiment(lazy_metadata=lazy_metadata, state=state)
+
+    if tags is not None:
+        validate_tags(tags)
 
     # pylint: disable=function-redefined
     def compute_metadata():
@@ -1675,6 +1682,9 @@ def init(
 
         if metadata is not None:
             args["metadata"] = metadata
+
+        if tags is not None:
+            args["tags"] = tags
 
         while True:
             try:

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -59,6 +59,14 @@ class TestInit(TestCase):
 
         assert str(cm.exception) == "Cannot open an experiment without specifying its name"
 
+        # duplicate tags
+        tag = "Exp1"
+        with self.assertRaises(ValueError) as cm:
+            braintrust.init(project="project", tags=[tag, tag])
+
+        assert str(cm.exception) == f"duplicate tag: {tag}"
+
+
     def test_init_with_dataset_id_only(self):
         """Test that init accepts dataset={'id': '...'} parameter"""
         # Test the logic that extracts dataset_id from the dict


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk-python/issues/6

supercedes https://github.com/braintrustdata/braintrust-sdk-python/pull/14

All credit to @Mahhheshh for the PR!

Based on https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1389, which added the same functionality to the JS SDK.