### PR TITLE
ci: add label-gated CI for fork PRs 

### DIFF
--- a/.github/workflows/adk-py-test.yaml
+++ b/.github/workflows/adk-py-test.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || '' }}
+          ref: ${{ inputs.ref }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v3

--- a/.github/workflows/fork-pr-notice.yaml
+++ b/.github/workflows/fork-pr-notice.yaml
@@ -15,6 +15,8 @@ on:
       - "integrations/adk-py/**"
       - ".github/workflows/py.yaml"
       - ".github/workflows/py-fork.yaml"
+      - ".github/workflows/py-build-test.yaml"
+      - ".github/workflows/py-upload-wheel.yaml"
       - ".github/workflows/adk-py-test.yaml"
       - ".github/workflows/langchain-py-test.yaml"
 

--- a/.github/workflows/langchain-py-test.yaml
+++ b/.github/workflows/langchain-py-test.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || '' }}
+          ref: ${{ inputs.ref }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v3

--- a/.github/workflows/py-build-test.yaml
+++ b/.github/workflows/py-build-test.yaml
@@ -1,0 +1,52 @@
+name: py-build-test
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
+      os:
+        required: true
+        type: string
+      shard:
+        required: true
+        type: number
+      ref:
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  test:
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: 30
+
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Install dependencies
+        run: |
+          cd py && make install-dev
+      - name: Test whether the Python SDK can be installed
+        run: |
+          # This is already done by make install-dev, but we're keeping this as a separate step
+          # to explicitly verify that installation works
+          python -m uv pip install -e ./py[all]
+      - name: Test whether the Python SDK can be imported
+        run: |
+          python -c 'import braintrust'
+      - name: Run nox tests (shard ${{ inputs.shard }}/2)
+        shell: bash
+        run: |
+          cd py && ./scripts/nox-matrix.sh ${{ inputs.shard }} 2

--- a/.github/workflows/py-fork.yaml
+++ b/.github/workflows/py-fork.yaml
@@ -17,8 +17,9 @@ on:
       - "py/**"
       - "integrations/langchain-py/**"
       - "integrations/adk-py/**"
-      - ".github/workflows/py.yaml"
       - ".github/workflows/py-fork.yaml"
+      - ".github/workflows/py-build-test.yaml"
+      - ".github/workflows/py-upload-wheel.yaml"
       - ".github/workflows/adk-py-test.yaml"
       - ".github/workflows/langchain-py-test.yaml"
 
@@ -28,42 +29,19 @@ jobs:
     if: >-
       contains(github.event.pull_request.labels.*.name, 'safe-to-run-ci')
       && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
-
+    uses: ./.github/workflows/py-build-test.yaml
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest]
         shard: [0, 1]
-
-    env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          cd py && make install-dev
-      - name: Test whether the Python SDK can be installed
-        run: |
-          python -m uv pip install -e ./py[all]
-      - name: Test whether the Python SDK can be imported
-        run: |
-          python -c 'import braintrust'
-      - name: Run nox tests (shard ${{ matrix.shard }}/2)
-        shell: bash
-        run: |
-          cd py && ./scripts/nox-matrix.sh ${{ matrix.shard }} 2
+    with:
+      python-version: ${{ matrix.python-version }}
+      os: ${{ matrix.os }}
+      shard: ${{ matrix.shard }}
+      ref: ${{ github.event.pull_request.head.sha }}
+    secrets: inherit
 
   adk-py:
     if: >-
@@ -99,22 +77,6 @@ jobs:
 
   upload-wheel:
     needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Install build dependencies and build wheel
-        run: |
-          cd py && make install-build-deps && make build
-      - name: Upload wheel as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-wheel
-          path: py/dist/*.whl
-          retention-days: 5
+    uses: ./.github/workflows/py-upload-wheel.yaml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/py-upload-wheel.yaml
+++ b/.github/workflows/py-upload-wheel.yaml
@@ -1,0 +1,31 @@
+name: py-upload-wheel
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install build dependencies and build wheel
+        run: |
+          cd py && make install-build-deps && make build
+      - name: Upload wheel as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-wheel
+          path: py/dist/*.whl
+          retention-days: 5

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -7,6 +7,8 @@ on:
       - "integrations/langchain-py/**"
       - "integrations/adk-py/**"
       - ".github/workflows/py.yaml"
+      - ".github/workflows/py-build-test.yaml"
+      - ".github/workflows/py-upload-wheel.yaml"
       - ".github/workflows/adk-py-test.yaml"
       - ".github/workflows/langchain-py-test.yaml"
   push:
@@ -16,42 +18,18 @@ jobs:
   build:
     # Skip on fork PRs — secrets are unavailable. See py-fork.yaml instead.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
-
+    uses: ./.github/workflows/py-build-test.yaml
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest]
         shard: [0, 1]
-
-    env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          cd py && make install-dev
-      - name: Test whether the Python SDK can be installed
-        run: |
-          # This is already done by make install-dev, but we're keeping this as a separate step
-          # to explicitly verify that installation works
-          python -m uv pip install -e ./py[all]
-      - name: Test whether the Python SDK can be imported
-        run: |
-          python -c 'import braintrust'
-      - name: Run nox tests (shard ${{ matrix.shard }}/2)
-        shell: bash
-        run: |
-          cd py && ./scripts/nox-matrix.sh ${{ matrix.shard }} 2
+    with:
+      python-version: ${{ matrix.python-version }}
+      os: ${{ matrix.os }}
+      shard: ${{ matrix.shard }}
+    secrets: inherit
 
   adk-py:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
@@ -82,20 +60,4 @@ jobs:
   upload-wheel:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Install build dependencies and build wheel
-        run: |
-          cd py && make install-build-deps && make build
-      - name: Upload wheel as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-wheel
-          path: py/dist/*.whl
-          retention-days: 5
+    uses: ./.github/workflows/py-upload-wheel.yaml


### PR DESCRIPTION
Fork PRs can't access repository secrets, so the regular py.yaml workflow fails for external contributions. This adds a `safe-to-run-ci` label gate so maintainers can opt-in to running CI on fork PRs after reviewing the code.

Changes:
- Add `py-fork.yaml`: `pull_request_target` workflow that runs the full test suite for fork PRs labeled `safe-to-run-ci`
- Add `fork-pr-notice.yaml`: notifies fork PR authors that a maintainer must add the label, and auto-removes the label on new pushes
- Skip `py.yaml` jobs on fork PRs (they'd fail without secrets anyway)
- Add optional `ref` input to adk-py-test.yaml and langchain-py-test.yaml so the fork workflow can checkout the PR head SHA