### PR TITLE
enhance BraintrustSpanProcessor to support custom exporters

### DIFF
--- a/py/src/braintrust/otel/__init__.py
+++ b/py/src/braintrust/otel/__init__.py
@@ -210,6 +210,7 @@ def add_braintrust_span_processor(
     filter_ai_spans: bool = False,
     custom_filter=None,
     headers: dict[str, str] | None = None,
+    exporter=None,
 ):
     processor = BraintrustSpanProcessor(
         api_key=api_key,
@@ -218,6 +219,7 @@ def add_braintrust_span_processor(
         filter_ai_spans=filter_ai_spans,
         custom_filter=custom_filter,
         headers=headers,
+        exporter=exporter,
     )
     tracer_provider.add_span_processor(processor)
 
@@ -235,6 +237,10 @@ class BraintrustSpanProcessor:
 
         > processor = BraintrustSpanProcessor(filter_ai_spans=True)
         > provider.add_span_processor(processor)
+
+        > custom_exporter = OTLPSpanExporter(endpoint="http://localhost:4318/v1/traces")
+        > processor = BraintrustSpanProcessor(exporter=custom_exporter)
+        > provider.add_span_processor(processor)
     """
 
     def __init__(
@@ -245,6 +251,7 @@ class BraintrustSpanProcessor:
         filter_ai_spans: bool = False,
         custom_filter=None,
         headers: dict[str, str] | None = None,
+        exporter=None,
         SpanProcessor: type | None = None,
     ):
         """
@@ -257,22 +264,26 @@ class BraintrustSpanProcessor:
             filter_ai_spans: Whether to enable AI span filtering. Defaults to False.
             custom_filter: Optional custom filter function for filtering.
             headers: Additional headers to include in requests.
+            exporter: Optional pre-configured OpenTelemetry exporter instance.
+                     When provided, api_key/parent/api_url/headers are ignored.
             SpanProcessor: Optional span processor class (BatchSpanProcessor or SimpleSpanProcessor). Defaults to BatchSpanProcessor.
         """
-        # Create the exporter
-        # Convert api_url to the full endpoint URL that OtelExporter expects
-        exporter_url = None
-        if api_url:
-            exporter_url = f"{api_url.rstrip('/')}/otel/v1/traces"
-
-        self._exporter = OtelExporter(url=exporter_url, api_key=api_key, parent=parent, headers=headers)
-
-        # Create the processor chain
         if not OTEL_AVAILABLE:
             raise ImportError(
                 "OpenTelemetry packages are not installed. "
                 "Install optional OpenTelemetry dependencies with: pip install braintrust[otel]"
             )
+
+        if exporter is not None:
+            self._exporter = exporter
+        else:
+            # Create the default Braintrust exporter.
+            # Convert api_url to the full endpoint URL that OtelExporter expects.
+            exporter_url = None
+            if api_url:
+                exporter_url = f"{api_url.rstrip('/')}/otel/v1/traces"
+
+            self._exporter = OtelExporter(url=exporter_url, api_key=api_key, parent=parent, headers=headers)
 
         if SpanProcessor is None:
             SpanProcessor = BatchSpanProcessor
@@ -355,7 +366,7 @@ class BraintrustSpanProcessor:
 
     @property
     def exporter(self):
-        """Access to the underlying OtelExporter."""
+        """Access to the underlying span exporter."""
         return self._exporter
 
     @property

--- a/py/src/braintrust/test_otel.py
+++ b/py/src/braintrust/test_otel.py
@@ -209,6 +209,8 @@ def test_braintrust_span_processor_class():
         pytest.skip("OpenTelemetry SDK not fully installed, skipping test")
 
     from braintrust.otel import BraintrustSpanProcessor
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
     # Test basic processor without filtering
     with pytest.MonkeyPatch.context() as m:
@@ -242,6 +244,18 @@ def test_braintrust_span_processor_class():
         assert hasattr(processor_with_filtering, "_on_ending")
         assert hasattr(processor_with_filtering, "shutdown")
         assert hasattr(processor_with_filtering, "force_flush")
+
+    # Test processor with custom exporter injection
+    custom_exporter = InMemorySpanExporter()
+    with pytest.MonkeyPatch.context() as m:
+        m.delenv("BRAINTRUST_API_KEY", raising=False)
+        m.delenv("BRAINTRUST_PARENT", raising=False)
+        processor_with_custom_exporter = BraintrustSpanProcessor(
+            exporter=custom_exporter,
+            SpanProcessor=SimpleSpanProcessor,
+        )
+
+        assert processor_with_custom_exporter.exporter is custom_exporter
 
     # Test processor with custom parameters
     with pytest.MonkeyPatch.context() as m:


### PR DESCRIPTION
This change makes `BraintrustSpanProcessor` support custom OpenTelemetry exporters in addition to the default Braintrust export path.  Some users need to route traces through their existing OTEL pipeline (e.g. vendor-specific exporters, internal collectors, or multi-destination export) while still using Braintrust instrumentation. Previously, `BraintrustSpanProcessor` did not make that customization path explicit/easy.

- Added `exporter=None` to:
  - `BraintrustSpanProcessor(...)`
  - `add_braintrust_span_processor(...)`
- If `exporter` is provided, the processor uses it directly.
- In that case, `api_key`, `parent`, `api_url`, and `headers` are ignored.
- If `exporter` is not provided, behavior is unchanged (the default Braintrust `OtelExporter` is still created).

You can create your exporter as usual, then pass it via the new `exporter` argument.

```
from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
from braintrust.otel import BraintrustSpanProcessor

custom_exporter = OTLPSpanExporter(endpoint="http://localhost:4318/v1/traces")
processor = BraintrustSpanProcessor(exporter=custom_exporter)
```
Or with the helper:

```
from braintrust.otel import add_braintrust_span_processor
add_braintrust_span_processor(
    tracer_provider=provider,
    exporter=custom_exporter,
)
```
