### PR TITLE
feat: Add extraction of default and descriptions for fields in Pydantic models

### DIFF
--- a/py/src/braintrust/parameters.py
+++ b/py/src/braintrust/parameters.py
@@ -34,25 +34,22 @@ def _pydantic_to_json_schema(model: Any) -> dict[str, Any]:
         raise ValueError(f"Cannot convert {model} to JSON schema - not a pydantic model")
 
 
-def _extract_pydantic_fields(schema: dict[str, dict[str, Any]]) -> tuple[Any, Any] | tuple[dict[str, Any], dict[str, Any]]:
+def _extract_pydantic_fields(
+    schema: dict[str, dict[str, Any]],
+) -> tuple[Any, Any] | tuple[dict[str, Any], dict[str, Any]]:
     """Extract pydantic fields default and description metadata"""
     flatten_defaults = {}
     flatten_description = {}
     schema_items = schema.items()
-    if len(schema_items) == 1:
+    if len(schema_items) == 1 and "value" in schema:
         for _, field_metadata in schema_items:
-            return (
-                field_metadata.get("default"),
-                field_metadata.get("description")
-            )
+            return (field_metadata.get("default"), field_metadata.get("description"))
 
     for field_name, field_metadata in schema_items:
         flatten_defaults[field_name] = field_metadata.get("default")
         flatten_description[field_name] = field_metadata.get("description")
-    return (
-        flatten_defaults,
-        flatten_description
-    )
+    return (flatten_defaults, flatten_description)
+
 
 def validate_parameters(
     parameters: dict[str, Any],
@@ -169,7 +166,7 @@ def parameters_to_json_schema(parameters: EvalParameters) -> dict[str, Any]:
                     "type": "data",
                     "schema": pydantic_schema,
                     "default": model_defaults,
-                    "description": model_descriptions
+                    "description": model_descriptions,
                 }
             except ValueError:
                 # Not a pydantic model, skip

--- a/py/src/braintrust/test_pydantic_parameters.py
+++ b/py/src/braintrust/test_pydantic_parameters.py
@@ -8,6 +8,7 @@ DEFAULT_DESCRIPTION = "System prompt for the model"
 SCHEMA_TITLE = "SystemPrompt"
 PARAM_NAME = "system_prompt"
 
+
 def test_extract_single_field_with_default_and_description():
     schema = {
         "value": {"type": "string", "default": DEFAULT_VALUE, "description": DEFAULT_DESCRIPTION},
@@ -63,6 +64,7 @@ def v2_model():
         }
         del model.get
         return model
+
     return _make
 
 
@@ -78,6 +80,7 @@ def v1_model():
         }
         del model.get
         return model
+
     return _make
 
 
@@ -95,6 +98,7 @@ def v2_multi_field_model():
         }
         del model.get
         return model
+
     return _make
 
 
@@ -113,6 +117,7 @@ def v1_multi_field_model():
         }
         del model.get
         return model
+
     return _make
 
 
@@ -138,7 +143,10 @@ def test_pydantic_v2_multi_field_model(v2_multi_field_model):
     assert schema[PARAM_NAME]["type"] == "data"
     assert schema[PARAM_NAME]["schema"]["title"] == "ModelConfig"
     assert schema[PARAM_NAME]["default"] == {"temperature": 0.7, "max_tokens": 1024}
-    assert schema[PARAM_NAME]["description"] == {"temperature": "Sampling temperature", "max_tokens": "Maximum tokens to generate"}
+    assert schema[PARAM_NAME]["description"] == {
+        "temperature": "Sampling temperature",
+        "max_tokens": "Maximum tokens to generate",
+    }
 
 
 def test_pydantic_v1_multi_field_model(v1_multi_field_model):


### PR DESCRIPTION
fixes #31 

Adds:
- test_parameters.py to test_core
- `_extract_pydantic_fields` method in `py/src/braintrustdata/parameters.py` file.

Question: 
I should have asked this before; will there be multiple Pydantic fields for a Single Model? How do we need to handle that.

closure:
AI helped me with the tests