### PR TITLE
chore: Bump SDK version to 0.8.0

### DIFF
--- a/py/src/braintrust/version.py
+++ b/py/src/braintrust/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.0"
+VERSION = "0.8.0"
 
 # this will be templated during the build
 GIT_COMMIT = "__GIT_COMMIT__"


### PR DESCRIPTION
Includes
- https://github.com/braintrustdata/braintrust-sdk-python/pull/20
- https://github.com/braintrustdata/braintrust-sdk-python/pull/23
- https://github.com/braintrustdata/braintrust-sdk-python/pull/41
- https://github.com/braintrustdata/braintrust-sdk-python/pull/46
- https://github.com/braintrustdata/braintrust-sdk-python/pull/50
- https://github.com/braintrustdata/braintrust-sdk-python/pull/25