### PR TITLE
fix: Add performance extra to braintrust package

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -29,6 +29,8 @@ extras_require = {
     "doc": ["pydoc-markdown"],
     "openai-agents": ["openai-agents"],
     "otel": ["opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp-proto-http"],
+    # orjson is not compatible with PyPy, so we exclude it for that platform
+    "performance": ["orjson; platform_python_implementation != 'PyPy'"],
     "temporal": ["temporalio>=1.19.0; python_version>='3.10'"],
 }
 


### PR DESCRIPTION
In https://github.com/braintrustdata/braintrust-sdk-python/blob/33cfa00beffa04151a7d874d5671b720bb49dbe8/py/README.md, we document that you can install a performance extra `pip install braintrust[performance]`, but this actually doesn't exist in the current version of the SDK.

This adds that performance extra so it matches up with our docs.