### PR TITLE
chore: use Python 3.14 for local development

### DIFF
--- a/.github/workflows/adk-py-test.yaml
+++ b/.github/workflows/adk-py-test.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       python-version:
-        required: true
+        required: false
         type: string
 
 jobs:
@@ -20,25 +20,25 @@ jobs:
         with:
           cache: true
           experimental: true
-          install_args: python@${{ inputs.python-version }} uv
+          install_args: uv
 
       - name: Install deprecated package compatibility dependencies
         working-directory: integrations/adk-py
         run: |
-          mise exec python@${{ inputs.python-version }} -- uv sync
+          mise exec -- uv sync
 
       - name: Lint deprecated compatibility package
         working-directory: integrations/adk-py
         run: |
-          mise exec python@${{ inputs.python-version }} -- uv run ruff check $(git ls-files '*.py' | grep -v 'examples/')
+          mise exec -- uv run ruff check $(git ls-files '*.py' | grep -v 'examples/')
 
       - name: Run deprecated compatibility tests
         working-directory: integrations/adk-py
         run: |
-          mise exec python@${{ inputs.python-version }} -- uv run pytest src/tests/test_reexports.py
+          mise exec -- uv run pytest src/tests/test_reexports.py
 
       - name: Test deprecated package import
         working-directory: integrations/adk-py
         run: |
-          mise exec python@${{ inputs.python-version }} -- uv run python -c "import braintrust_adk; print('braintrust_adk imported successfully')"
-          mise exec python@${{ inputs.python-version }} -- uv run python -c "from braintrust_adk import setup_braintrust; print('setup_braintrust imported successfully')"
+          mise exec -- uv run python -c "import braintrust_adk; print('braintrust_adk imported successfully')"
+          mise exec -- uv run python -c "from braintrust_adk import setup_braintrust; print('setup_braintrust imported successfully')"

--- a/.github/workflows/publish-py-sdk.yaml
+++ b/.github/workflows/publish-py-sdk.yaml
@@ -51,10 +51,9 @@ jobs:
         with:
           cache: true
           experimental: true
-          install_args: python@3.13
       - name: Build and verify
         run: |
-          mise exec python@3.13 -- make -C py install-dev verify-build
+          mise exec -- make -C py install-dev verify-build
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/py.yaml
+++ b/.github/workflows/py.yaml
@@ -50,8 +50,6 @@ jobs:
 
   adk-py:
     uses: ./.github/workflows/adk-py-test.yaml
-    with:
-      python-version: "3.13"
 
   langchain-py:
     uses: ./.github/workflows/langchain-py-test.yaml
@@ -75,10 +73,9 @@ jobs:
         with:
           cache: true
           experimental: true
-          install_args: python@3.13
       - name: Install build dependencies and build wheel
         run: |
-          mise exec python@3.13 -- make -C py install-build-deps build
+          mise exec -- make -C py install-build-deps build
       - name: Upload wheel as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-publish-py-sdk.yaml
+++ b/.github/workflows/test-publish-py-sdk.yaml
@@ -38,13 +38,12 @@ jobs:
         with:
           cache: true
           experimental: true
-          install_args: python@3.13
       - name: Install build dependencies
         run: |
-          mise exec python@3.13 -- make -C py install-dev
+          mise exec -- make -C py install-dev
       - name: Build and verify
         run: |
-          mise exec python@3.13 -- make -C py verify-build
+          mise exec -- make -C py verify-build
       - name: Get version from built wheel
         id: get_version
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-python 3.13.3
+python 3.14.3
 pre-commit 4.2.0
 uv 0.7.8


### PR DESCRIPTION
https://github.com/braintrustdata/braintrust-sdk-python/pull/48 tests 3.14 in CI, and we have it out with a release, so we can probably make the swap here.

This also refactors our github workflows so that everything just points to `.tool-versions` instead of hardcoding python versions.