### PR TITLE
feat: Implement wrapper for message-stream-based tool span tracking

### DIFF
--- a/py/src/braintrust/wrappers/claude_agent_sdk/__init__.py
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/__init__.py
@@ -19,7 +19,7 @@ import logging
 
 from braintrust.logger import NOOP_SPAN, current_span, init_logger
 
-from ._wrapper import _create_client_wrapper_class, _create_tool_wrapper_class, _wrap_tool_factory
+from ._wrapper import _create_client_wrapper_class
 
 logger = logging.getLogger(__name__)
 
@@ -66,10 +66,8 @@ def setup_claude_agent_sdk(
 
         import claude_agent_sdk
 
-        # Store original classes before patching
+        # Store original class before patching
         original_client = claude_agent_sdk.ClaudeSDKClient if hasattr(claude_agent_sdk, "ClaudeSDKClient") else None
-        original_tool_class = claude_agent_sdk.SdkMcpTool if hasattr(claude_agent_sdk, "SdkMcpTool") else None
-        original_tool_fn = claude_agent_sdk.tool if hasattr(claude_agent_sdk, "tool") else None
 
         # Patch ClaudeSDKClient
         if original_client:
@@ -81,28 +79,6 @@ def setup_claude_agent_sdk(
                 if module and hasattr(module, "ClaudeSDKClient"):
                     if getattr(module, "ClaudeSDKClient", None) is original_client:
                         setattr(module, "ClaudeSDKClient", wrapped_client)
-
-        # Patch SdkMcpTool
-        if original_tool_class:
-            wrapped_tool_class = _create_tool_wrapper_class(original_tool_class)
-            claude_agent_sdk.SdkMcpTool = wrapped_tool_class
-
-            # Update all modules that already imported SdkMcpTool
-            for module in list(sys.modules.values()):
-                if module and hasattr(module, "SdkMcpTool"):
-                    if getattr(module, "SdkMcpTool", None) is original_tool_class:
-                        setattr(module, "SdkMcpTool", wrapped_tool_class)
-
-        # Patch tool() decorator
-        if original_tool_fn:
-            wrapped_tool_fn = _wrap_tool_factory(original_tool_fn)
-            claude_agent_sdk.tool = wrapped_tool_fn
-
-            # Update all modules that already imported tool
-            for module in list(sys.modules.values()):
-                if module and hasattr(module, "tool"):
-                    if getattr(module, "tool", None) is original_tool_fn:
-                        setattr(module, "tool", wrapped_tool_fn)
 
         return True
     except ImportError:

--- a/py/src/braintrust/wrappers/claude_agent_sdk/_wrapper.py
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/_wrapper.py
@@ -1,8 +1,8 @@
 import dataclasses
 import logging
-import threading
+import re
 import time
-from collections.abc import AsyncGenerator, AsyncIterable, Callable
+from collections.abc import AsyncGenerator, AsyncIterable
 from typing import Any
 
 from braintrust.logger import start_span
@@ -11,10 +11,23 @@ from braintrust.wrappers._anthropic_utils import Wrapper, extract_anthropic_usag
 
 log = logging.getLogger(__name__)
 
-# Thread-local storage to propagate parent span export to tool handlers
-# The Claude Agent SDK may execute tools in separate async contexts that don't
-# preserve contextvars, so we use threading.local()
-_thread_local = threading.local()
+
+def _parse_tool_name(raw_tool_name: str) -> dict[str, str]:
+    """Parse MCP tool names (mcp__<server>__<tool>) into components."""
+    match = re.match(r"^mcp__([^_]+)__(.+)$", raw_tool_name)
+    if match:
+        mcp_server, tool_name = match.group(1), match.group(2)
+        return {
+            "display_name": f"tool: {mcp_server}/{tool_name}",
+            "tool_name": tool_name,
+            "mcp_server": mcp_server,
+            "raw_tool_name": raw_tool_name,
+        }
+    return {
+        "display_name": raw_tool_name,
+        "tool_name": raw_tool_name,
+        "raw_tool_name": raw_tool_name,
+    }
 
 
 class ClaudeAgentSDKWrapper(Wrapper):
@@ -30,18 +43,6 @@ class ClaudeAgentSDKWrapper(Wrapper):
         return self.__sdk.query
 
     @property
-    def SdkMcpTool(self) -> Any:
-        """Intercept SdkMcpTool to wrap handlers."""
-        return _create_tool_wrapper_class(self.__sdk.SdkMcpTool)
-
-    @property
-    def tool(self) -> Any:
-        """Intercept tool() function if it exists."""
-        if hasattr(self.__sdk, "tool"):
-            return _wrap_tool_factory(self.__sdk.tool)
-        raise AttributeError("tool")
-
-    @property
     def ClaudeSDKClient(self) -> Any:
         """Intercept ClaudeSDKClient class to wrap its methods."""
         if hasattr(self.__sdk, "ClaudeSDKClient"):
@@ -49,86 +50,65 @@ class ClaudeAgentSDKWrapper(Wrapper):
         raise AttributeError("ClaudeSDKClient")
 
 
-def _create_tool_wrapper_class(original_tool_class: Any) -> Any:
-    """Creates a wrapper class for SdkMcpTool that wraps handlers."""
+class ToolSpanTracker:
+    """Manages TOOL span lifecycle by observing message stream content blocks.
 
-    class WrappedSdkMcpTool(original_tool_class):  # type: ignore[valid-type,misc]
-        def __init__(
-            self,
-            name: Any,
-            description: Any,
-            input_schema: Any,
-            handler: Any,
-            **kwargs: Any,
-        ):
-            wrapped_handler = _wrap_tool_handler(handler, name)
-            super().__init__(name, description, input_schema, wrapped_handler, **kwargs)  # type: ignore[call-arg]
-
-        # Preserve generic typing support
-        __class_getitem__ = classmethod(lambda cls, params: cls)  # type: ignore[assignment]
-
-    return WrappedSdkMcpTool
-
-
-def _wrap_tool_factory(tool_fn: Any) -> Callable[..., Any]:
-    """Wraps the tool() factory function to return wrapped tools."""
-
-    def wrapped_tool(*args: Any, **kwargs: Any) -> Any:
-        result = tool_fn(*args, **kwargs)
-
-        # The tool() function returns a decorator, not a tool definition
-        # We need to wrap the decorator to intercept the final tool definition
-        if not callable(result):
-            return result
-
-        def wrapped_decorator(handler_fn: Any) -> Any:
-            tool_def = result(handler_fn)
-
-            # Now we have the actual tool definition, wrap its handler
-            if tool_def and hasattr(tool_def, "handler"):
-                tool_name = getattr(tool_def, "name", "unknown")
-                original_handler = tool_def.handler
-                tool_def.handler = _wrap_tool_handler(original_handler, tool_name)
-
-            return tool_def
-
-        return wrapped_decorator
-
-    return wrapped_tool
-
-
-def _wrap_tool_handler(handler: Any, tool_name: Any) -> Callable[..., Any]:
-    """Wraps a tool handler to add tracing.
-
-    Uses start_span context manager which automatically:
-    - Handles exceptions and logs them to the span
-    - Sets the span as current for nested operations
-    - Nests under the parent span (TASK span) via the parent parameter
-
-    The Claude Agent SDK may execute tool handlers in a separate async context,
-    so we try the context variable first, then fall back to current_span export.
+    Flow: AssistantMessage(ToolUseBlock) -> start span, UserMessage(ToolResultBlock) -> end span.
+    Traces ALL tools including built-in SDK tools and remote MCP tools.
     """
-    # Check if already wrapped to prevent double-wrapping
-    if hasattr(handler, "_braintrust_wrapped"):
-        return handler
 
-    async def wrapped_handler(args: Any) -> Any:
-        # Get parent span export from thread-local storage
-        parent_export = getattr(_thread_local, "parent_span_export", None)
+    def __init__(self) -> None:
+        self.active_spans: dict[str, Any] = {}  # tool_use_id -> span
 
-        with start_span(
-            name=str(tool_name),
-            span_attributes={"type": SpanTypeAttribute.TOOL},
-            input=args,
-            parent=parent_export,
-        ) as span:
-            result = await handler(args)
-            span.log(output=result)
-            return result
+    def on_assistant_message(self, message: Any, parent_export: str | None) -> None:
+        """Extract ToolUseBlocks and start TOOL spans."""
+        if not hasattr(message, "content") or not isinstance(message.content, list):
+            return
+        for block in message.content:
+            if type(block).__name__ != "ToolUseBlock":
+                continue
+            tool_use_id = getattr(block, "id", None)
+            if not tool_use_id:
+                continue
+            parsed = _parse_tool_name(str(getattr(block, "name", "unknown")))
+            metadata: dict[str, Any] = {
+                "gen_ai.tool.name": parsed["tool_name"],
+                "gen_ai.tool.call.id": tool_use_id,
+            }
+            if "mcp_server" in parsed:
+                metadata["mcp.server"] = parsed["mcp_server"]
+            self.active_spans[tool_use_id] = start_span(
+                name=parsed["display_name"],
+                span_attributes={"type": SpanTypeAttribute.TOOL},
+                input=getattr(block, "input", None),
+                metadata=metadata,
+                parent=parent_export,
+                start_time=time.time(),
+            )
 
-    # Mark as wrapped to prevent double-wrapping
-    wrapped_handler._braintrust_wrapped = True  # type: ignore[attr-defined]
-    return wrapped_handler
+    def on_user_message(self, message: Any) -> None:
+        """Extract ToolResultBlocks and end matching TOOL spans."""
+        if not hasattr(message, "content") or not isinstance(message.content, list):
+            return
+        for block in message.content:
+            if type(block).__name__ != "ToolResultBlock":
+                continue
+            tool_use_id = getattr(block, "tool_use_id", None)
+            if not tool_use_id or tool_use_id not in self.active_spans:
+                continue
+            tool_span = self.active_spans.pop(tool_use_id)
+            result_content = getattr(block, "content", None)
+            is_error = getattr(block, "is_error", None)
+            if is_error:
+                tool_span.log(output=result_content, error=result_content)
+            else:
+                tool_span.log(output=result_content)
+            tool_span.end()
+
+    def cleanup(self) -> None:
+        for tool_span in self.active_spans.values():
+            tool_span.end()
+        self.active_spans.clear()
 
 
 def _create_client_wrapper_class(original_client_class: Any) -> Any:
@@ -246,11 +226,11 @@ def _create_client_wrapper_class(original_client_class: Any) -> Any:
             ) as span:
                 # If we're capturing async messages, we'll update input after they're consumed
                 input_needs_update = self.__captured_messages is not None
-                # Store the parent span export in thread-local storage for tool handlers
-                _thread_local.parent_span_export = span.export()
 
                 final_results: list[dict[str, Any]] = []
                 llm_tracker = LLMSpanTracker(query_start_time=self.__query_start_time)
+                tool_tracker = ToolSpanTracker()
+                parent_export = span.export()
 
                 try:
                     async for message in generator:
@@ -264,10 +244,12 @@ def _create_client_wrapper_class(original_client_class: Any) -> Any:
                         message_type = type(message).__name__
 
                         if message_type == "AssistantMessage":
+                            tool_tracker.on_assistant_message(message, parent_export)
                             final_content = llm_tracker.start_llm_span(message, self.__last_prompt, final_results)
                             if final_content:
                                 final_results.append(final_content)
                         elif message_type == "UserMessage":
+                            tool_tracker.on_user_message(message)
                             if hasattr(message, "content"):
                                 content = _serialize_content_blocks(message.content)
                                 final_results.append({"content": content, "role": "user"})
@@ -294,9 +276,8 @@ def _create_client_wrapper_class(original_client_class: Any) -> Any:
                 except Exception as e:
                     log.warning("Error in tracing code", exc_info=e)
                 finally:
+                    tool_tracker.cleanup()
                     llm_tracker.cleanup()
-                    if hasattr(_thread_local, "parent_span_export"):
-                        delattr(_thread_local, "parent_span_export")
 
         async def __aenter__(self) -> "WrappedClaudeSDKClient":
             await self.__client.__aenter__()

--- a/py/src/braintrust/wrappers/claude_agent_sdk/test_wrapper.py
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/test_wrapper.py
@@ -27,8 +27,9 @@ from braintrust.span_types import SpanTypeAttribute
 from braintrust.test_helpers import init_test_logger
 from braintrust.wrappers.claude_agent_sdk import setup_claude_agent_sdk
 from braintrust.wrappers.claude_agent_sdk._wrapper import (
+    ToolSpanTracker,
     _create_client_wrapper_class,
-    _create_tool_wrapper_class,
+    _parse_tool_name,
 )
 from braintrust.wrappers.test_utils import verify_autoinstrument_script
 
@@ -60,10 +61,8 @@ async def test_calculator_with_multiple_operations(memory_logger):
 
     # Patch claude_agent_sdk for tracing (logger already initialized by fixture)
     original_client = claude_agent_sdk.ClaudeSDKClient
-    original_tool_class = claude_agent_sdk.SdkMcpTool
 
     claude_agent_sdk.ClaudeSDKClient = _create_client_wrapper_class(original_client)
-    claude_agent_sdk.SdkMcpTool = _create_tool_wrapper_class(original_tool_class)
 
     # Create calculator tool
     async def calculator_handler(args):
@@ -406,3 +405,177 @@ async def test_setup_claude_agent_sdk_repro_import_before_setup(memory_logger, m
     assert len(task_spans) == 1
     assert task_spans[0]["span_attributes"]["name"] == "Claude Agent"
     assert task_spans[0]["input"] == "Hello"
+
+
+def _make_type(type_name: str, **fields):
+    """Create a duck-typed mock object with the given class name and fields."""
+    obj = type(type_name, (), {})()
+    for k, v in fields.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def test_parse_tool_name_regular():
+    """Plain tool name passes through unchanged."""
+    result = _parse_tool_name("calculator")
+    assert result["display_name"] == "calculator"
+    assert result["tool_name"] == "calculator"
+    assert result["raw_tool_name"] == "calculator"
+    assert "mcp_server" not in result
+
+
+def test_parse_tool_name_mcp():
+    """MCP-formatted tool name is parsed into components."""
+    result = _parse_tool_name("mcp__myserver__my_tool")
+    assert result["display_name"] == "tool: myserver/my_tool"
+    assert result["tool_name"] == "my_tool"
+    assert result["mcp_server"] == "myserver"
+    assert result["raw_tool_name"] == "mcp__myserver__my_tool"
+
+
+def test_tool_span_tracker_creates_spans(memory_logger):
+    """ToolSpanTracker creates a TOOL span from ToolUseBlock and ends it on ToolResultBlock."""
+    tracker = ToolSpanTracker()
+
+    assistant_msg = _make_type(
+        "AssistantMessage",
+        content=[
+            _make_type(
+                "ToolUseBlock",
+                id="call_123",
+                name="calculator",
+                input={"operation": "add", "a": 1, "b": 2},
+            )
+        ],
+    )
+    user_msg = _make_type(
+        "UserMessage",
+        content=[
+            _make_type(
+                "ToolResultBlock",
+                tool_use_id="call_123",
+                content="3",
+                is_error=None,
+            )
+        ],
+    )
+
+    tracker.on_assistant_message(assistant_msg, None)
+    assert "call_123" in tracker.active_spans
+
+    tracker.on_user_message(user_msg)
+    assert "call_123" not in tracker.active_spans
+
+    spans = memory_logger.pop()
+    tool_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.TOOL]
+    assert len(tool_spans) == 1
+    tool_span = tool_spans[0]
+    assert tool_span["span_attributes"]["name"] == "calculator"
+    assert tool_span["input"] == {"operation": "add", "a": 1, "b": 2}
+    assert tool_span["output"] == "3"
+    assert tool_span["metadata"]["gen_ai.tool.name"] == "calculator"
+    assert tool_span["metadata"]["gen_ai.tool.call.id"] == "call_123"
+
+
+def test_tool_span_tracker_mcp_tool(memory_logger):
+    """ToolSpanTracker correctly handles MCP-formatted tool names."""
+    tracker = ToolSpanTracker()
+
+    assistant_msg = _make_type(
+        "AssistantMessage",
+        content=[
+            _make_type(
+                "ToolUseBlock",
+                id="call_mcp",
+                name="mcp__fileserver__read_file",
+                input={"path": "/tmp/test.txt"},
+            )
+        ],
+    )
+    user_msg = _make_type(
+        "UserMessage",
+        content=[
+            _make_type(
+                "ToolResultBlock",
+                tool_use_id="call_mcp",
+                content="file contents",
+                is_error=None,
+            )
+        ],
+    )
+
+    tracker.on_assistant_message(assistant_msg, None)
+    tracker.on_user_message(user_msg)
+
+    spans = memory_logger.pop()
+    tool_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.TOOL]
+    assert len(tool_spans) == 1
+    tool_span = tool_spans[0]
+    assert tool_span["span_attributes"]["name"] == "tool: fileserver/read_file"
+    assert tool_span["metadata"]["gen_ai.tool.name"] == "read_file"
+    assert tool_span["metadata"]["mcp.server"] == "fileserver"
+
+
+def test_tool_span_tracker_error(memory_logger):
+    """ToolSpanTracker logs error when is_error=True."""
+    tracker = ToolSpanTracker()
+
+    assistant_msg = _make_type(
+        "AssistantMessage",
+        content=[
+            _make_type(
+                "ToolUseBlock",
+                id="call_err",
+                name="calculator",
+                input={"operation": "divide", "a": 1, "b": 0},
+            )
+        ],
+    )
+    user_msg = _make_type(
+        "UserMessage",
+        content=[
+            _make_type(
+                "ToolResultBlock",
+                tool_use_id="call_err",
+                content="Division by zero",
+                is_error=True,
+            )
+        ],
+    )
+
+    tracker.on_assistant_message(assistant_msg, None)
+    tracker.on_user_message(user_msg)
+
+    spans = memory_logger.pop()
+    tool_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.TOOL]
+    assert len(tool_spans) == 1
+    tool_span = tool_spans[0]
+    assert tool_span["output"] == "Division by zero"
+    assert tool_span["error"] == "Division by zero"
+
+
+def test_tool_span_tracker_cleanup(memory_logger):
+    """ToolSpanTracker ends unclosed spans on cleanup."""
+    tracker = ToolSpanTracker()
+
+    assistant_msg = _make_type(
+        "AssistantMessage",
+        content=[
+            _make_type(
+                "ToolUseBlock",
+                id="call_unclosed",
+                name="calculator",
+                input={},
+            )
+        ],
+    )
+
+    tracker.on_assistant_message(assistant_msg, None)
+    assert len(tracker.active_spans) == 1
+
+    tracker.cleanup()
+    assert len(tracker.active_spans) == 0
+
+    spans = memory_logger.pop()
+    tool_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.TOOL]
+    assert len(tool_spans) == 1


### PR DESCRIPTION
Traces ALL tools (built-in SDK, remote MCP) by observing ToolUseBlock/ ToolResultBlock content blocks in the message stream instead of wrapping tool handler functions.

- Add _parse_tool_name() to handle mcp__<server>__<tool> format
- Add ToolSpanTracker class to manage TOOL span lifecycle
- Remove _wrap_tool_handler, _create_tool_wrapper_class, _wrap_tool_factory
- Remove SdkMcpTool/tool patching from setup_claude_agent_sdk()
- Add unit tests for _parse_tool_name and ToolSpanTracker