### PR TITLE
ref: Remove dead code from claude agent sdk integration

### DIFF
--- a/py/src/braintrust/wrappers/claude_agent_sdk/_wrapper.py
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/_wrapper.py
@@ -17,38 +17,6 @@ log = logging.getLogger(__name__)
 _thread_local = threading.local()
 
 
-class ClaudeAgentSDKWrapper(Wrapper):
-    """Main wrapper for claude_agent_sdk module. Intercepts query and tool creation."""
-
-    def __init__(self, sdk: Any):
-        super().__init__(sdk)
-        self.__sdk = sdk
-
-    @property
-    def query(self) -> Any:
-        """Pass through query without wrapping - use ClaudeSDKClient for tracing."""
-        return self.__sdk.query
-
-    @property
-    def SdkMcpTool(self) -> Any:
-        """Intercept SdkMcpTool to wrap handlers."""
-        return _create_tool_wrapper_class(self.__sdk.SdkMcpTool)
-
-    @property
-    def tool(self) -> Any:
-        """Intercept tool() function if it exists."""
-        if hasattr(self.__sdk, "tool"):
-            return _wrap_tool_factory(self.__sdk.tool)
-        raise AttributeError("tool")
-
-    @property
-    def ClaudeSDKClient(self) -> Any:
-        """Intercept ClaudeSDKClient class to wrap its methods."""
-        if hasattr(self.__sdk, "ClaudeSDKClient"):
-            return _create_client_wrapper_class(self.__sdk.ClaudeSDKClient)
-        raise AttributeError("ClaudeSDKClient")
-
-
 def _create_tool_wrapper_class(original_tool_class: Any) -> Any:
     """Creates a wrapper class for SdkMcpTool that wraps handlers."""
 

--- a/py/src/braintrust/wrappers/claude_agent_sdk/test_wrapper.py
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/test_wrapper.py
@@ -302,6 +302,7 @@ async def _multi_message_generator():
 class TestAutoInstrumentClaudeAgentSDK:
     """Tests for auto_instrument() with Claude Agent SDK."""
 
+    @pytest.mark.skipif(not CLAUDE_SDK_AVAILABLE, reason="Claude Agent SDK not installed")
     def test_auto_instrument_claude_agent_sdk(self):
         """Test auto_instrument patches Claude Agent SDK and creates spans."""
         verify_autoinstrument_script("test_auto_claude_agent_sdk.py")


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk-python/issues/64

~In this PR, we try to make some improvements to tests in preparation for the work in https://github.com/braintrustdata/braintrust-sdk-python/pull/63~

~This change also adds deterministic fake-stream coverage for `TASK` / `LLM` / `TOOL` span hierarchy, fixes the token-metric assertion so it no longer depends on the last span carrying usage, improves test failure messages, removes dead wrapper code, and consolidates the fake test setup into one shared model.~

With the changes in https://github.com/braintrustdata/braintrust-sdk-python/pull/68 merged in, this PR just removes some dead code in prep for merging in https://github.com/braintrustdata/braintrust-sdk-python/pull/66.