### PR TITLE
ref: Enable claude agent sdk tests in CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ VCR cassette directories:
 - `py/src/braintrust/cassettes/`
 - `py/src/braintrust/wrappers/cassettes/`
 - `py/src/braintrust/devserver/cassettes/`
+- `py/src/braintrust/wrappers/claude_agent_sdk/cassettes/` for Claude Agent SDK subprocess transport recordings
 
 Behavior from `py/src/braintrust/conftest.py`:
 
@@ -108,7 +109,18 @@ nox -s "test_openai(latest)" -- --disable-vcr
 nox -s "test_openai(latest)" -- --vcr-record=all -k "test_openai_chat_metrics"
 ```
 
-Only re-record cassettes when the behavior change is intentional. If in doubt, ask the user.
+Claude Agent SDK does not use VCR because the SDK talks to the bundled `claude` subprocess over stdin/stdout. Those tests use a transport-level cassette helper instead.
+
+Common Claude Agent SDK cassette commands:
+
+```bash
+cd py
+nox -s "test_claude_agent_sdk(latest)"
+BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE=all nox -s "test_claude_agent_sdk(latest)"
+BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE=all nox -s "test_claude_agent_sdk(latest)" -- -k "test_calculator_with_multiple_operations"
+```
+
+Only re-record HTTP or subprocess cassettes when the behavior change is intentional. If in doubt, ask the user.
 
 ## Build Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,28 @@ cd py
 nox -s "test_openai(latest)" -- --vcr-record=all -k "test_openai_chat_metrics"
 ```
 
+### Claude Agent SDK Subprocess Cassettes
+
+`claude_agent_sdk` tests use the real SDK and bundled `claude` CLI, but they do not use VCR. Instead they record and replay the SDK/CLI JSON transport under:
+
+- `py/src/braintrust/wrappers/claude_agent_sdk/cassettes/`
+
+Behavior:
+
+- Locally, subprocess cassettes default to `once`.
+- In CI, subprocess cassettes default to `none`.
+- Override with `BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE=all` when you need to re-record.
+
+Useful examples:
+
+```bash
+cd py
+nox -s "test_claude_agent_sdk(latest)"
+BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE=all nox -s "test_claude_agent_sdk(latest)"
+BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE=all \
+  nox -s "test_claude_agent_sdk(latest)" -- -k "test_calculator_with_multiple_operations"
+```
+
 ### Fixtures
 
 Shared test fixtures live in `py/src/braintrust/conftest.py`.
@@ -138,13 +160,13 @@ Main workflows:
 - `publish-py-sdk.yaml`: PyPI release
 - `test-publish-py-sdk.yaml`: TestPyPI release validation
 
-CI uses VCR cassettes and dummy credentials, so forks do not need provider API secrets for normal test runs.
+CI uses committed HTTP VCR cassettes and Claude Agent SDK subprocess cassettes, so forks do not need provider API secrets for normal replayed test runs.
 
 ## Submitting Changes
 
 1. Make your change in the narrowest relevant area.
 2. Add or update tests.
-3. Re-record cassettes if the HTTP behavior change is intentional.
+3. Re-record HTTP or Claude Agent SDK subprocess cassettes if the provider interaction change is intentional.
 4. Run the smallest relevant local checks first, then broader ones if needed.
 5. Run `make fixup` before opening a PR.
 6. Open a pull request against `main`.

--- a/docs/vcr-testing.md
+++ b/docs/vcr-testing.md
@@ -1,21 +1,32 @@
-# VCR Testing
+# VCR And Cassette Testing
 
-This repo uses [VCR.py](https://github.com/kevin1024/vcrpy) to record and replay HTTP interactions in tests. This lets the test suite run without real API keys or network access in most cases.
+This repo uses two recording/replay mechanisms for provider-backed tests:
+
+- [VCR.py](https://github.com/kevin1024/vcrpy) for HTTP interactions
+- a Claude Agent SDK subprocess cassette transport for `claude_agent_sdk` tests
+
+Both approaches let CI replay committed request/response traffic without making live provider calls.
 
 ## How It Works
 
-Tests decorated with `@pytest.mark.vcr` record HTTP requests/responses into YAML "cassette" files on first run. Subsequent runs replay from the cassette instead of making real API calls.
+HTTP tests decorated with `@pytest.mark.vcr` record requests/responses into YAML cassette files. Subsequent runs replay from the cassette instead of making real API calls.
+
+Claude Agent SDK tests do not use VCR because the SDK communicates with the bundled `claude` subprocess over a JSON stdin/stdout protocol rather than direct HTTP from the test process. Those tests instead record the raw transport conversation into JSON cassette files and replay that transport stream in CI.
 
 ### Cassette Locations
 
 | Test suite | Cassette directory |
 |---|---|
 | Python SDK (wrappers) | `py/src/braintrust/wrappers/cassettes/` |
+| Claude Agent SDK subprocess tests | `py/src/braintrust/wrappers/claude_agent_sdk/cassettes/` |
 | Langchain integration | `integrations/langchain-py/src/tests/cassettes/` |
 
 ## Local Development vs CI
 
-The key difference between local and CI is the VCR **record mode**, controlled by the `CI` / `GITHUB_ACTIONS` environment variables.
+The key difference between local and CI is the cassette record mode.
+
+- VCR uses `CI` / `GITHUB_ACTIONS` to choose `once` locally and `none` in CI.
+- Claude Agent SDK subprocess cassettes use `BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE`, defaulting to `once` locally and `none` in CI.
 
 ### Local Development
 
@@ -32,6 +43,20 @@ export OPENAI_API_KEY="sk-..."
 nox -s "test_openai(latest)" -- --vcr-record=all -k "test_openai_chat_metrics"
 ```
 
+Claude Agent SDK subprocess cassette examples:
+
+```bash
+# Record or replay the real Claude subprocess transport
+nox -s "test_claude_agent_sdk(latest)"
+
+# Force re-recording of the subprocess cassette files
+BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE=all nox -s "test_claude_agent_sdk(latest)"
+
+# Re-record a focused Claude Agent SDK test
+BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE=all \
+  nox -s "test_claude_agent_sdk(latest)" -- -k "test_calculator_with_multiple_operations"
+```
+
 ### CI (GitHub Actions)
 
 - **Record mode:** `none` -- only replays existing cassettes; fails if a cassette is missing.
@@ -39,6 +64,7 @@ nox -s "test_openai(latest)" -- --vcr-record=all -k "test_openai_chat_metrics"
   - `OPENAI_API_KEY` -> `sk-test-dummy-api-key-for-vcr-tests`
   - `ANTHROPIC_API_KEY` -> `sk-ant-test-dummy-api-key-for-vcr-tests`
   - `GOOGLE_API_KEY` -> `your_google_api_key_here`
+- **Claude Agent SDK tests:** Replay committed subprocess cassettes from `py/src/braintrust/wrappers/claude_agent_sdk/cassettes/`.
 - **`test_latest_wrappers_novcr` session:** Automatically skipped in CI since it disables VCR and would need real keys.
 - **No secrets needed:** CI workflows do not pass `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY` as secrets. This means forks and external contributors can run CI without configuring any API key secrets.
 
@@ -63,6 +89,13 @@ Or disable VCR entirely with `--disable-vcr` (requires real API keys):
 nox -s "test_openai(latest)" -- --disable-vcr
 ```
 
+For Claude Agent SDK subprocess cassettes, override with `BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE`:
+
+```bash
+BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE=all nox -s "test_claude_agent_sdk(latest)"
+BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE=none nox -s "test_claude_agent_sdk(latest)"
+```
+
 ## Sensitive Data Filtering
 
 Cassettes automatically filter out sensitive headers so API keys are never stored:
@@ -72,6 +105,8 @@ Cassettes automatically filter out sensitive headers so API keys are never store
 - `openai-api-key`, `openai-organization`
 - `x-goog-api-key`
 - `x-bt-auth-token`
+
+Claude Agent SDK subprocess cassettes do not store HTTP headers. They store the JSON control protocol exchanged between the SDK and the `claude` subprocess. Re-record them only when the SDK/CLI behavior change is intentional.
 
 ## Adding Tests That Need VCR
 
@@ -92,6 +127,25 @@ def test_my_new_feature(memory_logger):
     assert len(spans) == 1
 ```
 
+## Claude Agent SDK Subprocess Cassettes
+
+Use the subprocess cassette transport for tests that exercise the real `claude_agent_sdk` without mocks.
+
+Guidelines:
+
+1. Keep using the real SDK and bundled CLI.
+2. Route the test through `make_cassette_transport(...)`.
+3. Record locally with a real Anthropic-capable environment.
+4. Commit the generated JSON cassette files under `py/src/braintrust/wrappers/claude_agent_sdk/cassettes/`.
+
+Example workflow:
+
+```bash
+cd py
+BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE=all \
+  nox -s "test_claude_agent_sdk(latest)" -- -k "test_query_async_iterable"
+```
+
 ## For External Contributors
 
 **When do I need an API key?**
@@ -101,11 +155,13 @@ You need a real API key only when the HTTP interactions in a cassette need to ch
 - Write a new VCR test (new cassette needed)
 - Change a test's API call (different model, prompt, parameters, etc.)
 - Delete a cassette and need to re-record it
+- Re-record Claude Agent SDK subprocess cassette files
 
 You do **not** need an API key when you:
 
 - Add assertions to existing test responses
 - Refactor test logic without changing the API call
+- Refactor Claude Agent SDK assertions without changing the subprocess conversation
 - Work on non-VCR tests (core SDK, CLI, OTel, etc.)
 
 **Workflow for re-recording cassettes:**
@@ -121,4 +177,19 @@ nox -s "test_openai(latest)" -- --vcr-record=all -k "test_my_changed_test"
 git add py/src/braintrust/wrappers/cassettes/test_my_changed_test.yaml
 ```
 
-**CI will work without secrets.** Forks do not need to configure any API key secrets — CI replays from committed cassettes using dummy keys. Just make sure any new or modified cassettes are committed.
+For Claude Agent SDK subprocess cassettes:
+
+```bash
+# 1. Ensure your Anthropic credentials work with the bundled Claude CLI
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# 2. Re-record the subprocess cassette
+cd py
+BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE=all \
+  nox -s "test_claude_agent_sdk(latest)" -- -k "test_calculator_with_multiple_operations"
+
+# 3. Commit the JSON cassette
+git add py/src/braintrust/wrappers/claude_agent_sdk/cassettes/
+```
+
+**CI will work without secrets.** Forks do not need to configure provider API secrets for replayed cassette runs. Just make sure any new or modified YAML/JSON cassette files are committed.

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -128,11 +128,8 @@ def test_pydantic_ai_logfire(session):
 @nox.parametrize("version", CLAUDE_AGENT_SDK_VERSIONS, ids=CLAUDE_AGENT_SDK_VERSIONS)
 def test_claude_agent_sdk(session, version):
     # claude_agent_sdk requires Python >= 3.10
-    # These tests use the Claude Code CLI subprocess transport and still require
-    # live API behavior; they are intentionally skipped in CI until we add a
-    # subprocess-safe recording/replay strategy.
-    if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
-        session.skip("Skipping claude_agent_sdk tests in CI (requires live API/subprocess transport)")
+    # These tests use subprocess-transport cassettes, so they can replay in CI
+    # while still exercising the real Claude Agent SDK control protocol.
     _install_test_deps(session)
     _install(session, "claude_agent_sdk", version)
     _run_tests(session, f"{WRAPPER_DIR}/claude_agent_sdk/test_wrapper.py")

--- a/py/src/braintrust/wrappers/auto_test_scripts/test_auto_claude_agent_sdk.py
+++ b/py/src/braintrust/wrappers/auto_test_scripts/test_auto_claude_agent_sdk.py
@@ -1,6 +1,7 @@
 """Test auto_instrument for Claude Agent SDK (no uninstrument available)."""
 
 from braintrust.auto import auto_instrument
+from braintrust.wrappers.claude_agent_sdk._test_transport import make_cassette_transport
 from braintrust.wrappers.test_utils import autoinstrument_test_context
 
 # 1. Instrument
@@ -12,13 +13,21 @@ results2 = auto_instrument()
 assert results2.get("claude_agent_sdk") == True
 
 # 3. Make API call and verify span
-with autoinstrument_test_context("test_auto_claude_agent_sdk") as memory_logger:
+with autoinstrument_test_context("test_auto_claude_agent_sdk", use_vcr=False) as memory_logger:
     import claude_agent_sdk  # pylint: disable=import-error
 
-    options = claude_agent_sdk.ClaudeAgentOptions(model="claude-3-5-haiku-20241022")
+    options = claude_agent_sdk.ClaudeAgentOptions(
+        model="claude-3-5-haiku-20241022",
+        permission_mode="bypassPermissions",
+    )
+    transport = make_cassette_transport(
+        cassette_name="test_auto_claude_agent_sdk",
+        prompt="",
+        options=options,
+    )
 
     async def run_agent():
-        async with claude_agent_sdk.ClaudeSDKClient(options=options) as client:
+        async with claude_agent_sdk.ClaudeSDKClient(options=options, transport=transport) as client:
             await client.query("Say hi")
             async for message in client.receive_response():
                 if type(message).__name__ == "ResultMessage":
@@ -26,6 +35,7 @@ with autoinstrument_test_context("test_auto_claude_agent_sdk") as memory_logger:
         return None
 
     import asyncio
+
     result = asyncio.run(run_agent())
     assert result is not None
 

--- a/py/src/braintrust/wrappers/claude_agent_sdk/_test_transport.py
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/_test_transport.py
@@ -1,0 +1,357 @@
+"""Test-only cassette transport for Claude Agent SDK subprocess traffic."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import anyio
+
+try:
+    import claude_agent_sdk
+    from claude_agent_sdk._internal.transport import Transport
+    from claude_agent_sdk._internal.transport.subprocess_cli import SubprocessCLITransport
+
+    _CLAUDE_AGENT_SDK_IMPORT_ERROR: ImportError | None = None
+except ImportError as exc:
+    claude_agent_sdk = None
+    Transport = object
+    SubprocessCLITransport = None
+    _CLAUDE_AGENT_SDK_IMPORT_ERROR = exc
+
+if TYPE_CHECKING:
+    from claude_agent_sdk.types import ClaudeAgentOptions
+
+CASSETTES_DIR = Path(
+    os.environ.get(
+        "BRAINTRUST_CLAUDE_AGENT_SDK_CASSETTES_DIR",
+        Path(__file__).resolve().parent / "cassettes",
+    )
+)
+
+
+def get_record_mode() -> str:
+    """Match VCR-like defaults for subprocess transport cassettes."""
+    mode = os.environ.get("BRAINTRUST_CLAUDE_AGENT_SDK_RECORD_MODE")
+    if mode:
+        return mode
+    if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
+        return "none"
+    return "once"
+
+
+def _version_suffix() -> str:
+    version = getattr(claude_agent_sdk, "__version__", "unknown")
+    return version.replace(".", "_")
+
+
+def _require_sdk() -> None:
+    if _CLAUDE_AGENT_SDK_IMPORT_ERROR is not None:
+        raise ImportError(
+            "claude_agent_sdk is required to use braintrust.wrappers.claude_agent_sdk._test_transport"
+        ) from _CLAUDE_AGENT_SDK_IMPORT_ERROR
+
+
+def cassette_path(name: str) -> Path:
+    return CASSETTES_DIR / f"{name}__sdk_{_version_suffix()}.json"
+
+
+def _normalize_write(data: str, *, sanitize: bool = False) -> dict[str, Any]:
+    payload = data.rstrip("\n")
+    try:
+        value = json.loads(payload)
+        if sanitize:
+            value = _normalize_for_match(value)
+        return {"kind": "json", "value": value}
+    except json.JSONDecodeError:
+        return {"kind": "raw", "value": payload}
+
+
+async def _empty_stream():
+    return
+    yield {}  # type: ignore[unreachable]
+
+
+def _normalize_for_match(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_normalize_for_match(item) for item in value]
+    if isinstance(value, dict):
+        normalized = {key: _normalize_for_match(item) for key, item in value.items()}
+        if normalized.get("type") == "control_request" and isinstance(normalized.get("request_id"), str):
+            normalized["request_id"] = "CONTROL_REQUEST_ID"
+        return normalized
+    return value
+
+
+def _sanitize_json_for_storage(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_sanitize_json_for_storage(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _sanitize_field_for_storage(key, item) for key, item in value.items()}
+    if isinstance(value, str):
+        return _sanitize_string_for_storage(value)
+    return value
+
+
+def _sanitize_field_for_storage(key: str, value: Any) -> Any:
+    if not isinstance(value, str):
+        return _sanitize_json_for_storage(value)
+    if key == "cwd":
+        return "<REDACTED_CWD>"
+    if key == "signature":
+        return "<REDACTED_SIGNATURE>"
+    if key.lower() in _SENSITIVE_FIELDS:
+        return "<REDACTED>"
+    return _sanitize_string_for_storage(value)
+
+
+def _sanitize_string_for_storage(value: str) -> str:
+    sanitized = _PATH_RE.sub("<REDACTED_PATH>", value)
+    sanitized = _sanitize_url_string(sanitized)
+    sanitized = _AUTH_BEARER_RE.sub("Bearer <REDACTED>", sanitized)
+    sanitized = _API_KEY_RE.sub("sk-<REDACTED>", sanitized)
+    return sanitized
+
+
+def _sanitize_url_string(value: str) -> str:
+    if "?" not in value or "://" not in value:
+        return value
+
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return value
+
+    if not parts.query:
+        return value
+
+    query = []
+    changed = False
+    for key, item in parse_qsl(parts.query, keep_blank_values=True):
+        if _SENSITIVE_QUERY_PARAM_RE.search(key):
+            query.append((key, "<REDACTED>"))
+            changed = True
+        else:
+            query.append((key, item))
+
+    if not changed:
+        return value
+
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query, doseq=True), parts.fragment))
+
+
+_PATH_RE = re.compile(r"(?:(?:/Users|/home)/[^\s\"']+|[A-Za-z]:\\\\[^\s\"']+)")
+_AUTH_BEARER_RE = re.compile(r"Bearer\s+[A-Za-z0-9._-]+")
+_API_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]+\b")
+_SENSITIVE_FIELDS = {
+    "authorization",
+    "openai-organization",
+    "x-api-key",
+    "api-key",
+    "openai-api-key",
+    "x-goog-api-key",
+    "x-bt-auth-token",
+}
+_SENSITIVE_QUERY_PARAM_RE = re.compile(
+    r"(?:^|[_-])(token|api[_-]?key|auth|signature|sig|key)(?:$|[_-])",
+    re.IGNORECASE,
+)
+
+
+class ClaudeAgentSdkCassetteTransport(Transport):
+    """Record or replay the SDK<->CLI JSON protocol at the transport layer."""
+
+    def __init__(
+        self,
+        *,
+        cassette_name: str,
+        prompt: str | Any,
+        options: ClaudeAgentOptions,
+        record_mode: str | None = None,
+    ) -> None:
+        _require_sdk()
+        self._cassette_name = cassette_name
+        self._cassette_path = cassette_path(cassette_name)
+        self._prompt = prompt
+        self._options = options
+        self._record_mode = record_mode or get_record_mode()
+        self._delegate: SubprocessCLITransport | None = None
+        self._recording = False
+        self._events: list[dict[str, Any]] = []
+        self._cursor = 0
+        self._ready = False
+        self._cursor_lock = anyio.Lock()
+        self._cursor_changed = anyio.Event()
+        self._control_request_ids: dict[str, str] = {}
+
+    async def connect(self) -> None:
+        if self._ready:
+            return
+
+        if self._should_replay():
+            cassette = json.loads(self._cassette_path.read_text(encoding="utf-8"))
+            self._events = cassette.get("events", [])
+            self._ready = True
+            return
+
+        if self._record_mode not in {"once", "all"}:
+            raise FileNotFoundError(
+                f"Cassette missing for {self._cassette_name}: {self._cassette_path}"
+            )
+
+        self._cassette_path.parent.mkdir(parents=True, exist_ok=True)
+        prompt = _empty_stream() if self._prompt == "" else self._prompt
+        assert SubprocessCLITransport is not None
+        self._delegate = SubprocessCLITransport(prompt=prompt, options=self._options)
+        await self._delegate.connect()
+        self._recording = True
+        self._ready = True
+
+    async def write(self, data: str) -> None:
+        if self._recording:
+            assert self._delegate is not None
+            await self._delegate.write(data)
+            self._events.append({"op": "write", "payload": _normalize_write(data)})
+            return
+
+        recorded = await self._wait_for_event("write")
+        actual_raw = _normalize_write(data)
+        actual = _normalize_write(data, sanitize=True)
+        expected = _normalize_for_match(recorded["payload"])
+        self._maybe_remap_control_request_id(recorded["payload"], actual_raw)
+        if expected != actual:
+            raise AssertionError(
+                f"Write mismatch for {self._cassette_name}\nexpected: {expected}\nactual: {actual}"
+            )
+
+    def read_messages(self):
+        return self._read_messages_impl()
+
+    async def _read_messages_impl(self):
+        if self._recording:
+            assert self._delegate is not None
+            async for message in self._delegate.read_messages():
+                self._events.append({"op": "read", "payload": message})
+                yield message
+            return
+
+        while True:
+            event = await self._wait_for_event("read", allow_eof=True)
+            if event is None:
+                return
+            yield self._remap_read_message(event["payload"])
+
+    async def close(self) -> None:
+        self._ready = False
+        if self._recording:
+            assert self._delegate is not None
+            await self._delegate.close()
+            payload = {
+                "sdk_version": getattr(claude_agent_sdk, "__version__", "unknown"),
+                "cassette_name": self._cassette_name,
+                "events": _sanitize_json_for_storage(self._events),
+            }
+            self._cassette_path.write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+
+    def is_ready(self) -> bool:
+        return self._ready
+
+    async def end_input(self) -> None:
+        if self._recording:
+            assert self._delegate is not None
+            await self._delegate.end_input()
+
+    def _should_replay(self) -> bool:
+        if self._record_mode == "all":
+            return False
+        if self._record_mode in {"once", "none"} and self._cassette_path.exists():
+            return True
+        return False
+
+    async def _wait_for_event(
+        self, op: str, *, allow_eof: bool = False
+    ) -> dict[str, Any] | None:
+        while True:
+            async with self._cursor_lock:
+                if self._cursor >= len(self._events):
+                    if allow_eof:
+                        return None
+                    raise AssertionError(
+                        f"Replay for {self._cassette_name} exhausted before expected {op}"
+                    )
+
+                event = self._events[self._cursor]
+                if event["op"] == op:
+                    self._cursor += 1
+                    old_event = self._cursor_changed
+                    self._cursor_changed = anyio.Event()
+                    old_event.set()
+                    return event
+
+                waiter = self._cursor_changed
+
+            await waiter.wait()
+
+    def _maybe_remap_control_request_id(
+        self, recorded_payload: dict[str, Any], actual_payload: dict[str, Any]
+    ) -> None:
+        if recorded_payload.get("kind") != "json" or actual_payload.get("kind") != "json":
+            return
+
+        recorded_value = recorded_payload.get("value")
+        actual_value = actual_payload.get("value")
+        if not isinstance(recorded_value, dict) or not isinstance(actual_value, dict):
+            return
+        if recorded_value.get("type") != "control_request" or actual_value.get("type") != "control_request":
+            return
+
+        recorded_id = recorded_value.get("request_id")
+        actual_id = actual_value.get("request_id")
+        if isinstance(recorded_id, str) and isinstance(actual_id, str):
+            self._control_request_ids[recorded_id] = actual_id
+
+    def _remap_read_message(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if payload.get("type") != "control_response":
+            return payload
+
+        response = payload.get("response")
+        if not isinstance(response, dict):
+            return payload
+
+        recorded_id = response.get("request_id")
+        if not isinstance(recorded_id, str):
+            return payload
+
+        actual_id = self._control_request_ids.get(recorded_id)
+        if not actual_id:
+            return payload
+
+        return {
+            **payload,
+            "response": {
+                **response,
+                "request_id": actual_id,
+            },
+        }
+
+
+def make_cassette_transport(
+    *,
+    cassette_name: str,
+    prompt: str | Any,
+    options: "ClaudeAgentOptions",
+    record_mode: str | None = None,
+) -> ClaudeAgentSdkCassetteTransport:
+    return ClaudeAgentSdkCassetteTransport(
+        cassette_name=cassette_name,
+        prompt=prompt,
+        options=options,
+        record_mode=record_mode,
+    )

--- a/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_auto_claude_agent_sdk__sdk_0_1_10.json
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_auto_claude_agent_sdk__sdk_0_1_10.json
@@ -1,0 +1,253 @@
+{
+  "cassette_name": "test_auto_claude_agent_sdk",
+  "events": [
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "request": {
+            "hooks": null,
+            "subtype": "initialize"
+          },
+          "request_id": "req_1_d4224e8b",
+          "type": "control_request"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "response": {
+          "request_id": "req_1_d4224e8b",
+          "response": {
+            "account": {
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "tokenSource": "none"
+            },
+            "available_output_styles": [
+              "default",
+              "Explanatory",
+              "Learning"
+            ],
+            "commands": [
+              {
+                "argumentHint": "<optional custom summarization instructions>",
+                "description": "Clear conversation history but keep a summary in context. Optional: /compact [instructions for summarization]",
+                "name": "compact"
+              },
+              {
+                "argumentHint": "",
+                "description": "Visualize current context usage as a colored grid",
+                "name": "context"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show the total cost and duration of the current session",
+                "name": "cost"
+              },
+              {
+                "argumentHint": "",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "name": "init"
+              },
+              {
+                "argumentHint": "",
+                "description": "Get comments from a GitHub pull request",
+                "name": "pr-comments"
+              },
+              {
+                "argumentHint": "",
+                "description": "View release notes",
+                "name": "release-notes"
+              },
+              {
+                "argumentHint": "",
+                "description": "List current todo items",
+                "name": "todos"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review a pull request",
+                "name": "review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "name": "security-review"
+              }
+            ],
+            "models": [
+              {
+                "description": "Use the default model (currently Sonnet 4.5) \u00b7 $3/$15 per Mtok",
+                "displayName": "Default (recommended)",
+                "value": "default"
+              },
+              {
+                "description": "Opus 4.5 \u00b7 Most capable for complex work \u00b7 $5/$25 per Mtok",
+                "displayName": "Opus",
+                "value": "opus"
+              },
+              {
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+                "displayName": "Haiku",
+                "value": "haiku"
+              },
+              {
+                "description": "Custom model",
+                "displayName": "claude-3-5-haiku-20241022",
+                "value": "claude-3-5-haiku-20241022"
+              }
+            ],
+            "output_style": "default"
+          },
+          "subtype": "success"
+        },
+        "type": "control_response"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "Say hi",
+            "role": "user"
+          },
+          "parent_tool_use_id": null,
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "agents": [
+          "general-purpose",
+          "statusline-setup",
+          "Explore",
+          "Plan"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.0.53",
+        "cwd": "<REDACTED_CWD>",
+        "mcp_servers": [],
+        "model": "claude-3-5-haiku-20241022",
+        "output_style": "default",
+        "permissionMode": "bypassPermissions",
+        "plugins": [],
+        "session_id": "bd0f8f04-78fd-44fc-8aea-1b11a87cd63d",
+        "skills": [],
+        "slash_commands": [
+          "compact",
+          "context",
+          "cost",
+          "init",
+          "pr-comments",
+          "release-notes",
+          "todos",
+          "review",
+          "security-review"
+        ],
+        "subtype": "init",
+        "tools": [
+          "Task",
+          "Bash",
+          "Glob",
+          "Grep",
+          "ExitPlanMode",
+          "Read",
+          "Edit",
+          "Write",
+          "NotebookEdit",
+          "WebFetch",
+          "TodoWrite",
+          "WebSearch",
+          "BashOutput",
+          "KillShell",
+          "Skill",
+          "SlashCommand",
+          "EnterPlanMode"
+        ],
+        "type": "system",
+        "uuid": "54e0b263-025a-4de8-b4b5-d09783b053a4"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "error": "unknown",
+        "message": {
+          "container": null,
+          "content": [
+            {
+              "text": "API Error: 404 {\"type\":\"error\",\"error\":{\"type\":\"not_found_error\",\"message\":\"model: claude-3-5-haiku-20241022\"},\"request_id\":\"req_011CYvJGzWBz7oifGm9o8gpg\"}",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "3cce00aa-b48d-4674-8be9-4502bbecdf57",
+          "model": "<synthetic>",
+          "role": "assistant",
+          "stop_reason": "stop_sequence",
+          "stop_sequence": "",
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 0
+            },
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "server_tool_use": {
+              "web_fetch_requests": 0,
+              "web_search_requests": 0
+            },
+            "service_tier": null
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "bd0f8f04-78fd-44fc-8aea-1b11a87cd63d",
+        "type": "assistant",
+        "uuid": "2530bd82-4687-409b-a1b5-f38c57ac06de"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "duration_api_ms": 0,
+        "duration_ms": 415,
+        "is_error": true,
+        "modelUsage": {},
+        "num_turns": 1,
+        "permission_denials": [],
+        "result": "API Error: 404 {\"type\":\"error\",\"error\":{\"type\":\"not_found_error\",\"message\":\"model: claude-3-5-haiku-20241022\"},\"request_id\":\"req_011CYvJGzWBz7oifGm9o8gpg\"}",
+        "session_id": "bd0f8f04-78fd-44fc-8aea-1b11a87cd63d",
+        "subtype": "success",
+        "total_cost_usd": 0,
+        "type": "result",
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 0
+          },
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0
+          },
+          "service_tier": "standard"
+        },
+        "uuid": "9a8bad13-6c95-4e9b-be7f-18c5b1287e9b"
+      }
+    }
+  ],
+  "sdk_version": "0.1.10"
+}

--- a/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_auto_claude_agent_sdk__sdk_0_1_48.json
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_auto_claude_agent_sdk__sdk_0_1_48.json
@@ -1,0 +1,381 @@
+{
+  "cassette_name": "test_auto_claude_agent_sdk",
+  "events": [
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "request": {
+            "hooks": null,
+            "subtype": "initialize"
+          },
+          "request_id": "req_1_25b53356",
+          "type": "control_request"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "response": {
+          "request_id": "req_1_25b53356",
+          "response": {
+            "account": {
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "tokenSource": "none"
+            },
+            "agents": [
+              {
+                "description": "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you.",
+                "name": "general-purpose"
+              },
+              {
+                "description": "Use this agent to configure the user's Claude Code status line setting.",
+                "model": "sonnet",
+                "name": "statusline-setup"
+              },
+              {
+                "description": "Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. \"src/components/**/*.tsx\"), search code for keywords (eg. \"API endpoints\"), or answer questions about the codebase (eg. \"how do API endpoints work?\"). When calling this agent, specify the desired thoroughness level: \"quick\" for basic searches, \"medium\" for moderate exploration, or \"very thorough\" for comprehensive analysis across multiple locations and naming conventions.",
+                "model": "haiku",
+                "name": "Explore"
+              },
+              {
+                "description": "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.",
+                "name": "Plan"
+              }
+            ],
+            "available_output_styles": [
+              "default",
+              "Explanatory",
+              "Learning"
+            ],
+            "commands": [
+              {
+                "argumentHint": "",
+                "description": "Use when the user wants to customize keyboard shortcuts, rebind keys, add chord bindings, or modify ~/.claude/keybindings.json. Examples: \"rebind ctrl+s\", \"add a chord shortcut\", \"change the submit key\", \"customize keybindings\". (bundled)",
+                "name": "keybindings-help"
+              },
+              {
+                "argumentHint": "[issue description]",
+                "description": "Enable debug logging for this session and help diagnose issues (bundled)",
+                "name": "debug"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review changed code for reuse, quality, and efficiency, then fix any issues found. (bundled)",
+                "name": "simplify"
+              },
+              {
+                "argumentHint": "<instruction>",
+                "description": "Research and plan a large-scale change, then execute it in parallel across 5\u201330 isolated worktree agents that each open a PR. (bundled)",
+                "name": "batch"
+              },
+              {
+                "argumentHint": "[interval] <prompt>",
+                "description": "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo, defaults to 10m) (bundled)",
+                "name": "loop"
+              },
+              {
+                "argumentHint": "",
+                "description": "Build apps with the Claude API or Anthropic SDK.\nTRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK.\nDO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks. (bundled)",
+                "name": "claude-api"
+              },
+              {
+                "argumentHint": "<optional custom summarization instructions>",
+                "description": "Clear conversation history but keep a summary in context. Optional: /compact [instructions for summarization]",
+                "name": "compact"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show current context usage",
+                "name": "context"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show the total cost and duration of the current session",
+                "name": "cost"
+              },
+              {
+                "argumentHint": "",
+                "description": "Dump the JS heap to ~/Desktop",
+                "name": "heapdump"
+              },
+              {
+                "argumentHint": "",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "name": "init"
+              },
+              {
+                "argumentHint": "",
+                "description": "Get comments from a GitHub pull request",
+                "name": "pr-comments"
+              },
+              {
+                "argumentHint": "",
+                "description": "View release notes",
+                "name": "release-notes"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review a pull request",
+                "name": "review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "name": "security-review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Generate a report analyzing your Claude Code sessions",
+                "name": "insights"
+              }
+            ],
+            "models": [
+              {
+                "description": "Use the default model (currently Sonnet 4.6) \u00b7 $3/$15 per Mtok",
+                "displayName": "Default (recommended)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "value": "default"
+              },
+              {
+                "description": "Sonnet 4.6 for long sessions \u00b7 $6/$22.50 per Mtok",
+                "displayName": "Sonnet (1M context)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "value": "sonnet[1m]"
+              },
+              {
+                "description": "Opus 4.6 \u00b7 Most capable for complex work \u00b7 $5/$25 per Mtok",
+                "displayName": "Opus",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "supportsFastMode": true,
+                "value": "opus"
+              },
+              {
+                "description": "Opus 4.6 for long sessions \u00b7 $10/$37.50 per Mtok",
+                "displayName": "Opus (1M context)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "supportsFastMode": true,
+                "value": "opus[1m]"
+              },
+              {
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+                "displayName": "Haiku",
+                "value": "haiku"
+              },
+              {
+                "description": "Newer version available \u00b7 select Haiku for Haiku 4.5",
+                "displayName": "Claude 3.5 Haiku",
+                "value": "claude-3-5-haiku-20241022"
+              }
+            ],
+            "output_style": "default",
+            "pid": 521
+          },
+          "subtype": "success"
+        },
+        "type": "control_response"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "Say hi",
+            "role": "user"
+          },
+          "parent_tool_use_id": null,
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "agents": [
+          "general-purpose",
+          "statusline-setup",
+          "Explore",
+          "Plan"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.71",
+        "cwd": "<REDACTED_CWD>",
+        "fast_mode_state": "off",
+        "mcp_servers": [],
+        "model": "claude-3-5-haiku-20241022",
+        "output_style": "default",
+        "permissionMode": "bypassPermissions",
+        "plugins": [],
+        "session_id": "7d364a6b-d0b7-4992-9513-617c5fdaafa8",
+        "skills": [
+          "keybindings-help",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "claude-api"
+        ],
+        "slash_commands": [
+          "keybindings-help",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "claude-api",
+          "compact",
+          "context",
+          "cost",
+          "heapdump",
+          "init",
+          "pr-comments",
+          "release-notes",
+          "review",
+          "security-review",
+          "insights"
+        ],
+        "subtype": "init",
+        "tools": [
+          "Task",
+          "TaskOutput",
+          "Bash",
+          "Glob",
+          "Grep",
+          "ExitPlanMode",
+          "Read",
+          "Edit",
+          "Write",
+          "NotebookEdit",
+          "WebFetch",
+          "TodoWrite",
+          "WebSearch",
+          "TaskStop",
+          "AskUserQuestion",
+          "Skill",
+          "EnterPlanMode",
+          "EnterWorktree",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "ToolSearch"
+        ],
+        "type": "system",
+        "uuid": "c791f4b3-400e-4d34-bd0e-0a370e960b59"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "error": "invalid_request",
+        "message": {
+          "container": null,
+          "content": [
+            {
+              "text": "There's an issue with the selected model (claude-3-5-haiku-20241022). It may not exist or you may not have access to it. Run --model to pick a different model.",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "74e468a5-ac6f-4d56-86ce-75a0bd3568fd",
+          "model": "<synthetic>",
+          "role": "assistant",
+          "stop_reason": "stop_sequence",
+          "stop_sequence": "",
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 0
+            },
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "inference_geo": null,
+            "input_tokens": 0,
+            "iterations": null,
+            "output_tokens": 0,
+            "server_tool_use": {
+              "web_fetch_requests": 0,
+              "web_search_requests": 0
+            },
+            "service_tier": null,
+            "speed": null
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "7d364a6b-d0b7-4992-9513-617c5fdaafa8",
+        "type": "assistant",
+        "uuid": "e0bec5a6-6f57-470d-a506-a3225c70cef1"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "duration_api_ms": 0,
+        "duration_ms": 426,
+        "fast_mode_state": "off",
+        "is_error": true,
+        "modelUsage": {},
+        "num_turns": 1,
+        "permission_denials": [],
+        "result": "There's an issue with the selected model (claude-3-5-haiku-20241022). It may not exist or you may not have access to it. Run --model to pick a different model.",
+        "session_id": "7d364a6b-d0b7-4992-9513-617c5fdaafa8",
+        "stop_reason": "stop_sequence",
+        "subtype": "success",
+        "total_cost_usd": 0,
+        "type": "result",
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 0
+          },
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "inference_geo": "",
+          "input_tokens": 0,
+          "iterations": [],
+          "output_tokens": 0,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0
+          },
+          "service_tier": "standard",
+          "speed": "standard"
+        },
+        "uuid": "68e781e7-c30a-42b0-bfa6-0b79db1d8e88"
+      }
+    }
+  ],
+  "sdk_version": "0.1.48"
+}

--- a/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_calculator_with_multiple_operations__sdk_0_1_10.json
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_calculator_with_multiple_operations__sdk_0_1_10.json
@@ -1,0 +1,910 @@
+{
+  "cassette_name": "test_calculator_with_multiple_operations",
+  "events": [
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "request": {
+            "hooks": null,
+            "subtype": "initialize"
+          },
+          "request_id": "req_1_0c20d744",
+          "type": "control_request"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "id": 0,
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "params": {
+              "capabilities": {},
+              "clientInfo": {
+                "name": "claude-code",
+                "version": "2.0.53"
+              },
+              "protocolVersion": "2025-06-18"
+            }
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "9230a3c8-1b50-49d2-a49a-b7434a62deff",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "9230a3c8-1b50-49d2-a49a-b7434a62deff",
+            "response": {
+              "mcp_response": {
+                "id": 0,
+                "jsonrpc": "2.0",
+                "result": {
+                  "capabilities": {
+                    "tools": {}
+                  },
+                  "protocolVersion": "2024-11-05",
+                  "serverInfo": {
+                    "name": "calculator",
+                    "version": "1.0.0"
+                  }
+                }
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "response": {
+          "request_id": "req_1_0c20d744",
+          "response": {
+            "account": {
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "tokenSource": "none"
+            },
+            "available_output_styles": [
+              "default",
+              "Explanatory",
+              "Learning"
+            ],
+            "commands": [
+              {
+                "argumentHint": "<optional custom summarization instructions>",
+                "description": "Clear conversation history but keep a summary in context. Optional: /compact [instructions for summarization]",
+                "name": "compact"
+              },
+              {
+                "argumentHint": "",
+                "description": "Visualize current context usage as a colored grid",
+                "name": "context"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show the total cost and duration of the current session",
+                "name": "cost"
+              },
+              {
+                "argumentHint": "",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "name": "init"
+              },
+              {
+                "argumentHint": "",
+                "description": "Get comments from a GitHub pull request",
+                "name": "pr-comments"
+              },
+              {
+                "argumentHint": "",
+                "description": "View release notes",
+                "name": "release-notes"
+              },
+              {
+                "argumentHint": "",
+                "description": "List current todo items",
+                "name": "todos"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review a pull request",
+                "name": "review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "name": "security-review"
+              }
+            ],
+            "models": [
+              {
+                "description": "Use the default model (currently Sonnet 4.5) \u00b7 $3/$15 per Mtok",
+                "displayName": "Default (recommended)",
+                "value": "default"
+              },
+              {
+                "description": "Opus 4.5 \u00b7 Most capable for complex work \u00b7 $5/$25 per Mtok",
+                "displayName": "Opus",
+                "value": "opus"
+              },
+              {
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+                "displayName": "Haiku",
+                "value": "haiku"
+              },
+              {
+                "description": "Custom model",
+                "displayName": "claude-haiku-4-5-20251001",
+                "value": "claude-haiku-4-5-20251001"
+              }
+            ],
+            "output_style": "default"
+          },
+          "subtype": "success"
+        },
+        "type": "control_response"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "What is 15 multiplied by 7? Then subtract 5 from the result.",
+            "role": "user"
+          },
+          "parent_tool_use_id": null,
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "801e3b05-8152-4349-8d6d-af4bf91544ab",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "id": 0,
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "params": {
+              "capabilities": {},
+              "clientInfo": {
+                "name": "claude-code",
+                "version": "2.0.53"
+              },
+              "protocolVersion": "2025-06-18"
+            }
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "946f085c-e65f-4e55-8b22-24449b0781d0",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "801e3b05-8152-4349-8d6d-af4bf91544ab",
+            "response": {
+              "mcp_response": {
+                "jsonrpc": "2.0",
+                "result": {}
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "946f085c-e65f-4e55-8b22-24449b0781d0",
+            "response": {
+              "mcp_response": {
+                "id": 0,
+                "jsonrpc": "2.0",
+                "result": {
+                  "capabilities": {
+                    "tools": {}
+                  },
+                  "protocolVersion": "2024-11-05",
+                  "serverInfo": {
+                    "name": "calculator",
+                    "version": "1.0.0"
+                  }
+                }
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "id": 1,
+            "jsonrpc": "2.0",
+            "method": "tools/list"
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "c6146719-2daa-4747-9ee6-11783868e8d0",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "c6146719-2daa-4747-9ee6-11783868e8d0",
+            "response": {
+              "mcp_response": {
+                "id": 1,
+                "jsonrpc": "2.0",
+                "result": {
+                  "tools": [
+                    {
+                      "description": "Performs basic arithmetic operations",
+                      "inputSchema": {
+                        "properties": {
+                          "a": {
+                            "description": "First number",
+                            "type": "number"
+                          },
+                          "b": {
+                            "description": "Second number",
+                            "type": "number"
+                          },
+                          "operation": {
+                            "description": "The arithmetic operation to perform",
+                            "enum": [
+                              "add",
+                              "subtract",
+                              "multiply",
+                              "divide"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "operation",
+                          "a",
+                          "b"
+                        ],
+                        "type": "object"
+                      },
+                      "name": "calculator"
+                    }
+                  ]
+                }
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "d4daa9cc-4d34-4f43-b2f7-c525a7db2cc3",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "d4daa9cc-4d34-4f43-b2f7-c525a7db2cc3",
+            "response": {
+              "mcp_response": {
+                "jsonrpc": "2.0",
+                "result": {}
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "id": 1,
+            "jsonrpc": "2.0",
+            "method": "tools/list"
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "1914635c-c1eb-43b5-b35e-ee3dc29fcd1d",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "1914635c-c1eb-43b5-b35e-ee3dc29fcd1d",
+            "response": {
+              "mcp_response": {
+                "id": 1,
+                "jsonrpc": "2.0",
+                "result": {
+                  "tools": [
+                    {
+                      "description": "Performs basic arithmetic operations",
+                      "inputSchema": {
+                        "properties": {
+                          "a": {
+                            "description": "First number",
+                            "type": "number"
+                          },
+                          "b": {
+                            "description": "Second number",
+                            "type": "number"
+                          },
+                          "operation": {
+                            "description": "The arithmetic operation to perform",
+                            "enum": [
+                              "add",
+                              "subtract",
+                              "multiply",
+                              "divide"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "operation",
+                          "a",
+                          "b"
+                        ],
+                        "type": "object"
+                      },
+                      "name": "calculator"
+                    }
+                  ]
+                }
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "agents": [
+          "general-purpose",
+          "statusline-setup",
+          "Explore",
+          "Plan"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.0.53",
+        "cwd": "<REDACTED_CWD>",
+        "mcp_servers": [
+          {
+            "name": "calculator",
+            "status": "connected"
+          }
+        ],
+        "model": "claude-haiku-4-5-20251001",
+        "output_style": "default",
+        "permissionMode": "bypassPermissions",
+        "plugins": [],
+        "session_id": "7388c564-487e-451f-865d-757bf0122afe",
+        "skills": [],
+        "slash_commands": [
+          "compact",
+          "context",
+          "cost",
+          "init",
+          "pr-comments",
+          "release-notes",
+          "todos",
+          "review",
+          "security-review"
+        ],
+        "subtype": "init",
+        "tools": [
+          "Task",
+          "Bash",
+          "Glob",
+          "Grep",
+          "ExitPlanMode",
+          "Read",
+          "Edit",
+          "Write",
+          "NotebookEdit",
+          "WebFetch",
+          "TodoWrite",
+          "WebSearch",
+          "BashOutput",
+          "KillShell",
+          "Skill",
+          "SlashCommand",
+          "EnterPlanMode",
+          "mcp__calculator__calculator"
+        ],
+        "type": "system",
+        "uuid": "e020a28d-7993-4e1e-a829-99a0d327d349"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "I'll help you with that calculation. Let me first multiply 15 by 7, then subtract 5 from the result.",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_017F32N8ghRVakXtFJYxMRnZ",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 14015
+            },
+            "cache_creation_input_tokens": 14015,
+            "cache_read_input_tokens": 0,
+            "inference_geo": "not_available",
+            "input_tokens": 3,
+            "output_tokens": 5,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "7388c564-487e-451f-865d-757bf0122afe",
+        "type": "assistant",
+        "uuid": "34bd1986-f756-439f-b792-f97ee641cdcf"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "caller": {
+                "type": "direct"
+              },
+              "id": "toolu_01K6fcD1aZeYkN9AVAX8AU5M",
+              "input": {
+                "a": 15,
+                "b": 7,
+                "operation": "multiply"
+              },
+              "name": "mcp__calculator__calculator",
+              "type": "tool_use"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_017F32N8ghRVakXtFJYxMRnZ",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 14015
+            },
+            "cache_creation_input_tokens": 14015,
+            "cache_read_input_tokens": 0,
+            "inference_geo": "not_available",
+            "input_tokens": 3,
+            "output_tokens": 119,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "7388c564-487e-451f-865d-757bf0122afe",
+        "type": "assistant",
+        "uuid": "821087f9-6b60-4e08-b780-cd74ccf51eba"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "id": 2,
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+              "_meta": {
+                "claudecode/toolUseId": "toolu_01K6fcD1aZeYkN9AVAX8AU5M"
+              },
+              "arguments": {
+                "a": 15,
+                "b": 7,
+                "operation": "multiply"
+              },
+              "name": "calculator"
+            }
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "15fa3d33-0028-44ff-9a64-fd9831fbc7cb",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "15fa3d33-0028-44ff-9a64-fd9831fbc7cb",
+            "response": {
+              "mcp_response": {
+                "id": 2,
+                "jsonrpc": "2.0",
+                "result": {
+                  "content": [
+                    {
+                      "text": "The result of multiply(15, 7) is 105",
+                      "type": "text"
+                    }
+                  ]
+                }
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "The result of multiply(15, 7) is 105",
+                  "type": "text"
+                }
+              ],
+              "tool_use_id": "toolu_01K6fcD1aZeYkN9AVAX8AU5M",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "7388c564-487e-451f-865d-757bf0122afe",
+        "tool_use_result": [
+          {
+            "text": "The result of multiply(15, 7) is 105",
+            "type": "text"
+          }
+        ],
+        "type": "user",
+        "uuid": "45f4901b-a992-409a-8974-61718f0bd709"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "Now let me subtract 5 from that result:",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_017YZdFndE8zj9aTno3Q8E5C",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 141
+            },
+            "cache_creation_input_tokens": 141,
+            "cache_read_input_tokens": 14015,
+            "inference_geo": "not_available",
+            "input_tokens": 6,
+            "output_tokens": 2,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "7388c564-487e-451f-865d-757bf0122afe",
+        "type": "assistant",
+        "uuid": "d2c7719f-0e47-484f-a0bb-0aaaa368032b"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "caller": {
+                "type": "direct"
+              },
+              "id": "toolu_01HkzvMnStwuQLnuhAefWfpa",
+              "input": {
+                "a": 105,
+                "b": 5,
+                "operation": "subtract"
+              },
+              "name": "mcp__calculator__calculator",
+              "type": "tool_use"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_017YZdFndE8zj9aTno3Q8E5C",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 141
+            },
+            "cache_creation_input_tokens": 141,
+            "cache_read_input_tokens": 14015,
+            "inference_geo": "not_available",
+            "input_tokens": 6,
+            "output_tokens": 2,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "7388c564-487e-451f-865d-757bf0122afe",
+        "type": "assistant",
+        "uuid": "4847dde4-a017-4065-8de3-9f6656352a66"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "id": 3,
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+              "_meta": {
+                "claudecode/toolUseId": "toolu_01HkzvMnStwuQLnuhAefWfpa"
+              },
+              "arguments": {
+                "a": 105,
+                "b": 5,
+                "operation": "subtract"
+              },
+              "name": "calculator"
+            }
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "8085b52c-99d9-4e78-9900-e07f0f8c46f6",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "8085b52c-99d9-4e78-9900-e07f0f8c46f6",
+            "response": {
+              "mcp_response": {
+                "id": 3,
+                "jsonrpc": "2.0",
+                "result": {
+                  "content": [
+                    {
+                      "text": "The result of subtract(105, 5) is 100",
+                      "type": "text"
+                    }
+                  ]
+                }
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "The result of subtract(105, 5) is 100",
+                  "type": "text"
+                }
+              ],
+              "tool_use_id": "toolu_01HkzvMnStwuQLnuhAefWfpa",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "7388c564-487e-451f-865d-757bf0122afe",
+        "tool_use_result": [
+          {
+            "text": "The result of subtract(105, 5) is 100",
+            "type": "text"
+          }
+        ],
+        "type": "user",
+        "uuid": "bca777bc-06a9-4957-83ca-2b11700ab5fb"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "**The answer is 100.**\n\nHere's the breakdown:\n- 15 \u00d7 7 = 105\n- 105 - 5 = 100",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_018YckGW4fMsPGHS288TRaPf",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 127
+            },
+            "cache_creation_input_tokens": 127,
+            "cache_read_input_tokens": 14156,
+            "inference_geo": "not_available",
+            "input_tokens": 6,
+            "output_tokens": 1,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "7388c564-487e-451f-865d-757bf0122afe",
+        "type": "assistant",
+        "uuid": "1d9e74aa-ace1-4a18-a9e2-1e64bb2ee6dc"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "duration_api_ms": 8137,
+        "duration_ms": 5529,
+        "is_error": false,
+        "modelUsage": {
+          "claude-haiku-4-5-20251001": {
+            "cacheCreationInputTokens": 14283,
+            "cacheReadInputTokens": 28171,
+            "contextWindow": 200000,
+            "costUSD": 0.02362985,
+            "inputTokens": 979,
+            "outputTokens": 396,
+            "webSearchRequests": 0
+          }
+        },
+        "num_turns": 3,
+        "permission_denials": [],
+        "result": "**The answer is 100.**\n\nHere's the breakdown:\n- 15 \u00d7 7 = 105\n- 105 - 5 = 100",
+        "session_id": "7388c564-487e-451f-865d-757bf0122afe",
+        "subtype": "success",
+        "total_cost_usd": 0.02362985,
+        "type": "result",
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 14283
+          },
+          "cache_creation_input_tokens": 14283,
+          "cache_read_input_tokens": 28171,
+          "input_tokens": 15,
+          "output_tokens": 261,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0
+          },
+          "service_tier": "standard"
+        },
+        "uuid": "552114b7-46af-4323-b4e3-07c8d71eaa38"
+      }
+    }
+  ],
+  "sdk_version": "0.1.10"
+}

--- a/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_calculator_with_multiple_operations__sdk_0_1_48.json
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_calculator_with_multiple_operations__sdk_0_1_48.json
@@ -1,0 +1,1006 @@
+{
+  "cassette_name": "test_calculator_with_multiple_operations",
+  "events": [
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "request": {
+            "hooks": null,
+            "subtype": "initialize"
+          },
+          "request_id": "req_1_48c9b054",
+          "type": "control_request"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "id": 0,
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "params": {
+              "capabilities": {},
+              "clientInfo": {
+                "name": "claude-code",
+                "version": "2.1.71"
+              },
+              "protocolVersion": "2025-11-25"
+            }
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "5f7e9e7e-4a24-41b7-8a68-63a1bfbbd56b",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "5f7e9e7e-4a24-41b7-8a68-63a1bfbbd56b",
+            "response": {
+              "mcp_response": {
+                "id": 0,
+                "jsonrpc": "2.0",
+                "result": {
+                  "capabilities": {
+                    "tools": {}
+                  },
+                  "protocolVersion": "2024-11-05",
+                  "serverInfo": {
+                    "name": "calculator",
+                    "version": "1.0.0"
+                  }
+                }
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "response": {
+          "request_id": "req_1_48c9b054",
+          "response": {
+            "account": {
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "tokenSource": "none"
+            },
+            "agents": [
+              {
+                "description": "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you.",
+                "name": "general-purpose"
+              },
+              {
+                "description": "Use this agent to configure the user's Claude Code status line setting.",
+                "model": "sonnet",
+                "name": "statusline-setup"
+              },
+              {
+                "description": "Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. \"src/components/**/*.tsx\"), search code for keywords (eg. \"API endpoints\"), or answer questions about the codebase (eg. \"how do API endpoints work?\"). When calling this agent, specify the desired thoroughness level: \"quick\" for basic searches, \"medium\" for moderate exploration, or \"very thorough\" for comprehensive analysis across multiple locations and naming conventions.",
+                "model": "haiku",
+                "name": "Explore"
+              },
+              {
+                "description": "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.",
+                "name": "Plan"
+              }
+            ],
+            "available_output_styles": [
+              "default",
+              "Explanatory",
+              "Learning"
+            ],
+            "commands": [
+              {
+                "argumentHint": "",
+                "description": "Use when the user wants to customize keyboard shortcuts, rebind keys, add chord bindings, or modify ~/.claude/keybindings.json. Examples: \"rebind ctrl+s\", \"add a chord shortcut\", \"change the submit key\", \"customize keybindings\". (bundled)",
+                "name": "keybindings-help"
+              },
+              {
+                "argumentHint": "[issue description]",
+                "description": "Enable debug logging for this session and help diagnose issues (bundled)",
+                "name": "debug"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review changed code for reuse, quality, and efficiency, then fix any issues found. (bundled)",
+                "name": "simplify"
+              },
+              {
+                "argumentHint": "<instruction>",
+                "description": "Research and plan a large-scale change, then execute it in parallel across 5\u201330 isolated worktree agents that each open a PR. (bundled)",
+                "name": "batch"
+              },
+              {
+                "argumentHint": "[interval] <prompt>",
+                "description": "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo, defaults to 10m) (bundled)",
+                "name": "loop"
+              },
+              {
+                "argumentHint": "",
+                "description": "Build apps with the Claude API or Anthropic SDK.\nTRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK.\nDO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks. (bundled)",
+                "name": "claude-api"
+              },
+              {
+                "argumentHint": "<optional custom summarization instructions>",
+                "description": "Clear conversation history but keep a summary in context. Optional: /compact [instructions for summarization]",
+                "name": "compact"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show current context usage",
+                "name": "context"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show the total cost and duration of the current session",
+                "name": "cost"
+              },
+              {
+                "argumentHint": "",
+                "description": "Dump the JS heap to ~/Desktop",
+                "name": "heapdump"
+              },
+              {
+                "argumentHint": "",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "name": "init"
+              },
+              {
+                "argumentHint": "",
+                "description": "Get comments from a GitHub pull request",
+                "name": "pr-comments"
+              },
+              {
+                "argumentHint": "",
+                "description": "View release notes",
+                "name": "release-notes"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review a pull request",
+                "name": "review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "name": "security-review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Generate a report analyzing your Claude Code sessions",
+                "name": "insights"
+              }
+            ],
+            "models": [
+              {
+                "description": "Use the default model (currently Sonnet 4.6) \u00b7 $3/$15 per Mtok",
+                "displayName": "Default (recommended)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "value": "default"
+              },
+              {
+                "description": "Sonnet 4.6 for long sessions \u00b7 $6/$22.50 per Mtok",
+                "displayName": "Sonnet (1M context)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "value": "sonnet[1m]"
+              },
+              {
+                "description": "Opus 4.6 \u00b7 Most capable for complex work \u00b7 $5/$25 per Mtok",
+                "displayName": "Opus",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "supportsFastMode": true,
+                "value": "opus"
+              },
+              {
+                "description": "Opus 4.6 for long sessions \u00b7 $10/$37.50 per Mtok",
+                "displayName": "Opus (1M context)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "supportsFastMode": true,
+                "value": "opus[1m]"
+              },
+              {
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+                "displayName": "Haiku",
+                "value": "haiku"
+              },
+              {
+                "description": "claude-haiku-4-5-20251001",
+                "displayName": "Haiku 4.5",
+                "value": "claude-haiku-4-5-20251001"
+              }
+            ],
+            "output_style": "default",
+            "pid": 99859
+          },
+          "subtype": "success"
+        },
+        "type": "control_response"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "What is 15 multiplied by 7? Then subtract 5 from the result.",
+            "role": "user"
+          },
+          "parent_tool_use_id": null,
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "2f3de201-ca0a-4364-9045-e4b758b11e8b",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "2f3de201-ca0a-4364-9045-e4b758b11e8b",
+            "response": {
+              "mcp_response": {
+                "jsonrpc": "2.0",
+                "result": {}
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "id": 0,
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "params": {
+              "capabilities": {},
+              "clientInfo": {
+                "name": "claude-code",
+                "version": "2.1.71"
+              },
+              "protocolVersion": "2025-11-25"
+            }
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "b29e4751-1bd0-43ec-a1ef-0247078a6666",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "b29e4751-1bd0-43ec-a1ef-0247078a6666",
+            "response": {
+              "mcp_response": {
+                "id": 0,
+                "jsonrpc": "2.0",
+                "result": {
+                  "capabilities": {
+                    "tools": {}
+                  },
+                  "protocolVersion": "2024-11-05",
+                  "serverInfo": {
+                    "name": "calculator",
+                    "version": "1.0.0"
+                  }
+                }
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "id": 1,
+            "jsonrpc": "2.0",
+            "method": "tools/list"
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "eac5a619-8a6a-419c-8709-384f4c82efe9",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "eac5a619-8a6a-419c-8709-384f4c82efe9",
+            "response": {
+              "mcp_response": {
+                "id": 1,
+                "jsonrpc": "2.0",
+                "result": {
+                  "tools": [
+                    {
+                      "description": "Performs basic arithmetic operations",
+                      "inputSchema": {
+                        "properties": {
+                          "a": {
+                            "description": "First number",
+                            "type": "number"
+                          },
+                          "b": {
+                            "description": "Second number",
+                            "type": "number"
+                          },
+                          "operation": {
+                            "description": "The arithmetic operation to perform",
+                            "enum": [
+                              "add",
+                              "subtract",
+                              "multiply",
+                              "divide"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "operation",
+                          "a",
+                          "b"
+                        ],
+                        "type": "object"
+                      },
+                      "name": "calculator"
+                    }
+                  ]
+                }
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "f2642205-be77-47a9-9d38-c4724c49f4f4",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "f2642205-be77-47a9-9d38-c4724c49f4f4",
+            "response": {
+              "mcp_response": {
+                "jsonrpc": "2.0",
+                "result": {}
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "agents": [
+          "general-purpose",
+          "statusline-setup",
+          "Explore",
+          "Plan"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.71",
+        "cwd": "<REDACTED_CWD>",
+        "fast_mode_state": "off",
+        "mcp_servers": [
+          {
+            "name": "calculator",
+            "status": "connected"
+          }
+        ],
+        "model": "claude-haiku-4-5-20251001",
+        "output_style": "default",
+        "permissionMode": "bypassPermissions",
+        "plugins": [],
+        "session_id": "31fc0827-d751-45a8-9cf0-607d37bf3c52",
+        "skills": [
+          "keybindings-help",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "claude-api"
+        ],
+        "slash_commands": [
+          "keybindings-help",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "claude-api",
+          "compact",
+          "context",
+          "cost",
+          "heapdump",
+          "init",
+          "pr-comments",
+          "release-notes",
+          "review",
+          "security-review",
+          "insights"
+        ],
+        "subtype": "init",
+        "tools": [
+          "Task",
+          "TaskOutput",
+          "Bash",
+          "Glob",
+          "Grep",
+          "ExitPlanMode",
+          "Read",
+          "Edit",
+          "Write",
+          "NotebookEdit",
+          "WebFetch",
+          "TodoWrite",
+          "WebSearch",
+          "TaskStop",
+          "AskUserQuestion",
+          "Skill",
+          "EnterPlanMode",
+          "EnterWorktree",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "ToolSearch",
+          "mcp__calculator__calculator"
+        ],
+        "type": "system",
+        "uuid": "27638b62-28a0-4931-aa94-9d2952895a86"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "The user is asking me to:\n1. Calculate 15 multiplied by 7\n2. Then subtract 5 from that result\n\nI can use the calculator tool to do this. Let me first multiply 15 by 7, then subtract 5 from the result.\n\nFirst calculation: 15 * 7 = 105\nThen: 105 - 5 = 100\n\nI should make these calls. I can do the first calculation, then use the result to do the second calculation. Since the second calculation depends on the first, I need to do them sequentially.\n\nLet me start with the multiplication:",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_016hxa8wxeBgtn8cqvHSnFXW",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 0
+            },
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 18034,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 7,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "31fc0827-d751-45a8-9cf0-607d37bf3c52",
+        "type": "assistant",
+        "uuid": "1b85fe5f-4760-4d00-ac69-64cf8ee4ceea"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "caller": {
+                "type": "direct"
+              },
+              "id": "toolu_01AQ383TKiAF2ekgb444vpZC",
+              "input": {
+                "a": 15,
+                "b": 7,
+                "operation": "multiply"
+              },
+              "name": "mcp__calculator__calculator",
+              "type": "tool_use"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_016hxa8wxeBgtn8cqvHSnFXW",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 0
+            },
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 18034,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 7,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "31fc0827-d751-45a8-9cf0-607d37bf3c52",
+        "type": "assistant",
+        "uuid": "910539d3-b9d3-499f-99c7-8befc4886ef9"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "id": 2,
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+              "_meta": {
+                "claudecode/toolUseId": "toolu_01AQ383TKiAF2ekgb444vpZC",
+                "progressToken": 2
+              },
+              "arguments": {
+                "a": 15,
+                "b": 7,
+                "operation": "multiply"
+              },
+              "name": "calculator"
+            }
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "1b19d53c-0e0f-48b7-ac54-f6cc85a8436e",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "1b19d53c-0e0f-48b7-ac54-f6cc85a8436e",
+            "response": {
+              "mcp_response": {
+                "id": 2,
+                "jsonrpc": "2.0",
+                "result": {
+                  "content": [
+                    {
+                      "text": "The result of multiply(15, 7) is 105",
+                      "type": "text"
+                    }
+                  ]
+                }
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "The result of multiply(15, 7) is 105",
+                  "type": "text"
+                }
+              ],
+              "tool_use_id": "toolu_01AQ383TKiAF2ekgb444vpZC",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "31fc0827-d751-45a8-9cf0-607d37bf3c52",
+        "tool_use_result": [
+          {
+            "text": "The result of multiply(15, 7) is 105",
+            "type": "text"
+          }
+        ],
+        "type": "user",
+        "uuid": "e0c17e5a-8cdf-487f-aac2-7fe27fe2ffc1"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "Great! 15 \u00d7 7 = 105. Now I need to subtract 5 from this result.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01KoQgg7NpZwQPHrh7Q3Hb1a",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 266
+            },
+            "cache_creation_input_tokens": 266,
+            "cache_read_input_tokens": 18034,
+            "inference_geo": "not_available",
+            "input_tokens": 8,
+            "output_tokens": 1,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "31fc0827-d751-45a8-9cf0-607d37bf3c52",
+        "type": "assistant",
+        "uuid": "4d2700c4-ecad-4160-b121-6daff58f2632"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "caller": {
+                "type": "direct"
+              },
+              "id": "toolu_01KnPS5RFM71zxSp4THdpyMk",
+              "input": {
+                "a": 105,
+                "b": 5,
+                "operation": "subtract"
+              },
+              "name": "mcp__calculator__calculator",
+              "type": "tool_use"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01KoQgg7NpZwQPHrh7Q3Hb1a",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 266
+            },
+            "cache_creation_input_tokens": 266,
+            "cache_read_input_tokens": 18034,
+            "inference_geo": "not_available",
+            "input_tokens": 8,
+            "output_tokens": 1,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "31fc0827-d751-45a8-9cf0-607d37bf3c52",
+        "type": "assistant",
+        "uuid": "7eefb65f-c5ac-4c5d-a7af-032512a0f763"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "id": 3,
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+              "_meta": {
+                "claudecode/toolUseId": "toolu_01KnPS5RFM71zxSp4THdpyMk",
+                "progressToken": 3
+              },
+              "arguments": {
+                "a": 105,
+                "b": 5,
+                "operation": "subtract"
+              },
+              "name": "calculator"
+            }
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "fca4ca14-b214-4b37-a9b0-0b87d5c3c062",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "fca4ca14-b214-4b37-a9b0-0b87d5c3c062",
+            "response": {
+              "mcp_response": {
+                "id": 3,
+                "jsonrpc": "2.0",
+                "result": {
+                  "content": [
+                    {
+                      "text": "The result of subtract(105, 5) is 100",
+                      "type": "text"
+                    }
+                  ]
+                }
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "The result of subtract(105, 5) is 100",
+                  "type": "text"
+                }
+              ],
+              "tool_use_id": "toolu_01KnPS5RFM71zxSp4THdpyMk",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "31fc0827-d751-45a8-9cf0-607d37bf3c52",
+        "tool_use_result": [
+          {
+            "text": "The result of subtract(105, 5) is 100",
+            "type": "text"
+          }
+        ],
+        "type": "user",
+        "uuid": "e2fdd3b7-c529-4f6a-a95a-922ad2e37ac9"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "Perfect! I have the answer:\n- 15 \u00d7 7 = 105\n- 105 - 5 = 100",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_016CfLs6TyhvantAcTiLQ2L9",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 155
+            },
+            "cache_creation_input_tokens": 155,
+            "cache_read_input_tokens": 18300,
+            "inference_geo": "not_available",
+            "input_tokens": 8,
+            "output_tokens": 3,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "31fc0827-d751-45a8-9cf0-607d37bf3c52",
+        "type": "assistant",
+        "uuid": "81e201f1-c54d-43c3-9c43-7d28cddab1c5"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "The answer is **100**.\n\nHere's the breakdown:\n1. 15 \u00d7 7 = 105\n2. 105 - 5 = 100",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_016CfLs6TyhvantAcTiLQ2L9",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 155
+            },
+            "cache_creation_input_tokens": 155,
+            "cache_read_input_tokens": 18300,
+            "inference_geo": "not_available",
+            "input_tokens": 8,
+            "output_tokens": 3,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "31fc0827-d751-45a8-9cf0-607d37bf3c52",
+        "type": "assistant",
+        "uuid": "153ec255-c5c0-42d5-b374-44a666dfffde"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "duration_api_ms": 5537,
+        "duration_ms": 5664,
+        "fast_mode_state": "off",
+        "is_error": false,
+        "modelUsage": {
+          "claude-haiku-4-5-20251001": {
+            "cacheCreationInputTokens": 421,
+            "cacheReadInputTokens": 54368,
+            "contextWindow": 200000,
+            "costUSD": 0.00817905,
+            "inputTokens": 26,
+            "maxOutputTokens": 32000,
+            "outputTokens": 438,
+            "webSearchRequests": 0
+          }
+        },
+        "num_turns": 3,
+        "permission_denials": [],
+        "result": "The answer is **100**.\n\nHere's the breakdown:\n1. 15 \u00d7 7 = 105\n2. 105 - 5 = 100",
+        "session_id": "31fc0827-d751-45a8-9cf0-607d37bf3c52",
+        "stop_reason": "end_turn",
+        "subtype": "success",
+        "total_cost_usd": 0.00817905,
+        "type": "result",
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 421
+          },
+          "cache_creation_input_tokens": 421,
+          "cache_read_input_tokens": 54368,
+          "inference_geo": "",
+          "input_tokens": 26,
+          "iterations": [],
+          "output_tokens": 438,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0
+          },
+          "service_tier": "standard",
+          "speed": "standard"
+        },
+        "uuid": "b60de4b9-ad9c-4cf9-b2eb-093b88d6b1be"
+      }
+    }
+  ],
+  "sdk_version": "0.1.48"
+}

--- a/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_query_async_iterable_asyncgen_multi__sdk_0_1_10.json
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_query_async_iterable_asyncgen_multi__sdk_0_1_10.json
@@ -1,0 +1,271 @@
+{
+  "cassette_name": "test_query_async_iterable_asyncgen_multi",
+  "events": [
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "request": {
+            "hooks": null,
+            "subtype": "initialize"
+          },
+          "request_id": "req_1_d0759297",
+          "type": "control_request"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "response": {
+          "request_id": "req_1_d0759297",
+          "response": {
+            "account": {
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "tokenSource": "none"
+            },
+            "available_output_styles": [
+              "default",
+              "Explanatory",
+              "Learning"
+            ],
+            "commands": [
+              {
+                "argumentHint": "<optional custom summarization instructions>",
+                "description": "Clear conversation history but keep a summary in context. Optional: /compact [instructions for summarization]",
+                "name": "compact"
+              },
+              {
+                "argumentHint": "",
+                "description": "Visualize current context usage as a colored grid",
+                "name": "context"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show the total cost and duration of the current session",
+                "name": "cost"
+              },
+              {
+                "argumentHint": "",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "name": "init"
+              },
+              {
+                "argumentHint": "",
+                "description": "Get comments from a GitHub pull request",
+                "name": "pr-comments"
+              },
+              {
+                "argumentHint": "",
+                "description": "View release notes",
+                "name": "release-notes"
+              },
+              {
+                "argumentHint": "",
+                "description": "List current todo items",
+                "name": "todos"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review a pull request",
+                "name": "review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "name": "security-review"
+              }
+            ],
+            "models": [
+              {
+                "description": "Use the default model (currently Sonnet 4.5) \u00b7 $3/$15 per Mtok",
+                "displayName": "Default (recommended)",
+                "value": "default"
+              },
+              {
+                "description": "Opus 4.5 \u00b7 Most capable for complex work \u00b7 $5/$25 per Mtok",
+                "displayName": "Opus",
+                "value": "opus"
+              },
+              {
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+                "displayName": "Haiku",
+                "value": "haiku"
+              },
+              {
+                "description": "Custom model",
+                "displayName": "claude-haiku-4-5-20251001",
+                "value": "claude-haiku-4-5-20251001"
+              }
+            ],
+            "output_style": "default"
+          },
+          "subtype": "success"
+        },
+        "type": "control_response"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "Part 1",
+            "role": "user"
+          },
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "Part 2",
+            "role": "user"
+          },
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "agents": [
+          "general-purpose",
+          "statusline-setup",
+          "Explore",
+          "Plan"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.0.53",
+        "cwd": "<REDACTED_CWD>",
+        "mcp_servers": [],
+        "model": "claude-haiku-4-5-20251001",
+        "output_style": "default",
+        "permissionMode": "bypassPermissions",
+        "plugins": [],
+        "session_id": "15d3a62c-617c-490f-bb06-8800b6ff455f",
+        "skills": [],
+        "slash_commands": [
+          "compact",
+          "context",
+          "cost",
+          "init",
+          "pr-comments",
+          "release-notes",
+          "todos",
+          "review",
+          "security-review"
+        ],
+        "subtype": "init",
+        "tools": [
+          "Task",
+          "Bash",
+          "Glob",
+          "Grep",
+          "ExitPlanMode",
+          "Read",
+          "Edit",
+          "Write",
+          "NotebookEdit",
+          "WebFetch",
+          "TodoWrite",
+          "WebSearch",
+          "BashOutput",
+          "KillShell",
+          "Skill",
+          "SlashCommand",
+          "EnterPlanMode"
+        ],
+        "type": "system",
+        "uuid": "a1f98ad4-0f89-4b5f-bb8a-0e7e6af87e58"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "I'm ready to help! However, I notice you've just written \"Part 1\" without specifying what you'd like me to do.\n\nCould you please provide more details about what you need help with? For example:\n\n- Do you want me to work on a specific coding task?\n- Are you looking to explore or modify a codebase?\n- Do you need help with debugging, refactoring, or implementing a feature?\n- Is there a file you'd like me to read or analyze?\n\nOnce you provide more context, I'll be able to assist you effectively!",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_018cxp1mXFHFEWwj5rCwQ7Bp",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 323
+            },
+            "cache_creation_input_tokens": 323,
+            "cache_read_input_tokens": 13554,
+            "inference_geo": "not_available",
+            "input_tokens": 3,
+            "output_tokens": 2,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "15d3a62c-617c-490f-bb06-8800b6ff455f",
+        "type": "assistant",
+        "uuid": "fe2633eb-32d5-4e23-a007-d583c38fe2a7"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "duration_api_ms": 4424,
+        "duration_ms": 2545,
+        "is_error": false,
+        "modelUsage": {
+          "claude-haiku-4-5-20251001": {
+            "cacheCreationInputTokens": 323,
+            "cacheReadInputTokens": 13554,
+            "contextWindow": 200000,
+            "costUSD": 0.00409115,
+            "inputTokens": 967,
+            "outputTokens": 273,
+            "webSearchRequests": 0
+          }
+        },
+        "num_turns": 1,
+        "permission_denials": [],
+        "result": "I'm ready to help! However, I notice you've just written \"Part 1\" without specifying what you'd like me to do.\n\nCould you please provide more details about what you need help with? For example:\n\n- Do you want me to work on a specific coding task?\n- Are you looking to explore or modify a codebase?\n- Do you need help with debugging, refactoring, or implementing a feature?\n- Is there a file you'd like me to read or analyze?\n\nOnce you provide more context, I'll be able to assist you effectively!",
+        "session_id": "15d3a62c-617c-490f-bb06-8800b6ff455f",
+        "subtype": "success",
+        "total_cost_usd": 0.00409115,
+        "type": "result",
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 323
+          },
+          "cache_creation_input_tokens": 323,
+          "cache_read_input_tokens": 13554,
+          "input_tokens": 3,
+          "output_tokens": 127,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0
+          },
+          "service_tier": "standard"
+        },
+        "uuid": "dc00ce8e-ea1a-4d9b-bfeb-b0066666ef2a"
+      }
+    }
+  ],
+  "sdk_version": "0.1.10"
+}

--- a/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_query_async_iterable_asyncgen_multi__sdk_0_1_48.json
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_query_async_iterable_asyncgen_multi__sdk_0_1_48.json
@@ -1,0 +1,434 @@
+{
+  "cassette_name": "test_query_async_iterable_asyncgen_multi",
+  "events": [
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "request": {
+            "hooks": null,
+            "subtype": "initialize"
+          },
+          "request_id": "req_1_f2ff09b8",
+          "type": "control_request"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "response": {
+          "request_id": "req_1_f2ff09b8",
+          "response": {
+            "account": {
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "tokenSource": "none"
+            },
+            "agents": [
+              {
+                "description": "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you.",
+                "name": "general-purpose"
+              },
+              {
+                "description": "Use this agent to configure the user's Claude Code status line setting.",
+                "model": "sonnet",
+                "name": "statusline-setup"
+              },
+              {
+                "description": "Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. \"src/components/**/*.tsx\"), search code for keywords (eg. \"API endpoints\"), or answer questions about the codebase (eg. \"how do API endpoints work?\"). When calling this agent, specify the desired thoroughness level: \"quick\" for basic searches, \"medium\" for moderate exploration, or \"very thorough\" for comprehensive analysis across multiple locations and naming conventions.",
+                "model": "haiku",
+                "name": "Explore"
+              },
+              {
+                "description": "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.",
+                "name": "Plan"
+              }
+            ],
+            "available_output_styles": [
+              "default",
+              "Explanatory",
+              "Learning"
+            ],
+            "commands": [
+              {
+                "argumentHint": "",
+                "description": "Use when the user wants to customize keyboard shortcuts, rebind keys, add chord bindings, or modify ~/.claude/keybindings.json. Examples: \"rebind ctrl+s\", \"add a chord shortcut\", \"change the submit key\", \"customize keybindings\". (bundled)",
+                "name": "keybindings-help"
+              },
+              {
+                "argumentHint": "[issue description]",
+                "description": "Enable debug logging for this session and help diagnose issues (bundled)",
+                "name": "debug"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review changed code for reuse, quality, and efficiency, then fix any issues found. (bundled)",
+                "name": "simplify"
+              },
+              {
+                "argumentHint": "<instruction>",
+                "description": "Research and plan a large-scale change, then execute it in parallel across 5\u201330 isolated worktree agents that each open a PR. (bundled)",
+                "name": "batch"
+              },
+              {
+                "argumentHint": "[interval] <prompt>",
+                "description": "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo, defaults to 10m) (bundled)",
+                "name": "loop"
+              },
+              {
+                "argumentHint": "",
+                "description": "Build apps with the Claude API or Anthropic SDK.\nTRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK.\nDO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks. (bundled)",
+                "name": "claude-api"
+              },
+              {
+                "argumentHint": "<optional custom summarization instructions>",
+                "description": "Clear conversation history but keep a summary in context. Optional: /compact [instructions for summarization]",
+                "name": "compact"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show current context usage",
+                "name": "context"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show the total cost and duration of the current session",
+                "name": "cost"
+              },
+              {
+                "argumentHint": "",
+                "description": "Dump the JS heap to ~/Desktop",
+                "name": "heapdump"
+              },
+              {
+                "argumentHint": "",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "name": "init"
+              },
+              {
+                "argumentHint": "",
+                "description": "Get comments from a GitHub pull request",
+                "name": "pr-comments"
+              },
+              {
+                "argumentHint": "",
+                "description": "View release notes",
+                "name": "release-notes"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review a pull request",
+                "name": "review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "name": "security-review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Generate a report analyzing your Claude Code sessions",
+                "name": "insights"
+              }
+            ],
+            "models": [
+              {
+                "description": "Use the default model (currently Sonnet 4.6) \u00b7 $3/$15 per Mtok",
+                "displayName": "Default (recommended)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "value": "default"
+              },
+              {
+                "description": "Sonnet 4.6 for long sessions \u00b7 $6/$22.50 per Mtok",
+                "displayName": "Sonnet (1M context)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "value": "sonnet[1m]"
+              },
+              {
+                "description": "Opus 4.6 \u00b7 Most capable for complex work \u00b7 $5/$25 per Mtok",
+                "displayName": "Opus",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "supportsFastMode": true,
+                "value": "opus"
+              },
+              {
+                "description": "Opus 4.6 for long sessions \u00b7 $10/$37.50 per Mtok",
+                "displayName": "Opus (1M context)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "supportsFastMode": true,
+                "value": "opus[1m]"
+              },
+              {
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+                "displayName": "Haiku",
+                "value": "haiku"
+              },
+              {
+                "description": "claude-haiku-4-5-20251001",
+                "displayName": "Haiku 4.5",
+                "value": "claude-haiku-4-5-20251001"
+              }
+            ],
+            "output_style": "default",
+            "pid": 171
+          },
+          "subtype": "success"
+        },
+        "type": "control_response"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "Part 1",
+            "role": "user"
+          },
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "Part 2",
+            "role": "user"
+          },
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "agents": [
+          "general-purpose",
+          "statusline-setup",
+          "Explore",
+          "Plan"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.71",
+        "cwd": "<REDACTED_CWD>",
+        "fast_mode_state": "off",
+        "mcp_servers": [],
+        "model": "claude-haiku-4-5-20251001",
+        "output_style": "default",
+        "permissionMode": "bypassPermissions",
+        "plugins": [],
+        "session_id": "982f3129-7544-418e-94cc-021a5c532975",
+        "skills": [
+          "keybindings-help",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "claude-api"
+        ],
+        "slash_commands": [
+          "keybindings-help",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "claude-api",
+          "compact",
+          "context",
+          "cost",
+          "heapdump",
+          "init",
+          "pr-comments",
+          "release-notes",
+          "review",
+          "security-review",
+          "insights"
+        ],
+        "subtype": "init",
+        "tools": [
+          "Task",
+          "TaskOutput",
+          "Bash",
+          "Glob",
+          "Grep",
+          "ExitPlanMode",
+          "Read",
+          "Edit",
+          "Write",
+          "NotebookEdit",
+          "WebFetch",
+          "TodoWrite",
+          "WebSearch",
+          "TaskStop",
+          "AskUserQuestion",
+          "Skill",
+          "EnterPlanMode",
+          "EnterWorktree",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "ToolSearch"
+        ],
+        "type": "system",
+        "uuid": "e414daeb-6b16-4ac6-91f6-b5be6b18765a"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "The user has written \"Part 1\" which is quite vague. They haven't actually asked me to do anything specific. I should ask them what they'd like me to help with, as there's no clear task or request here.\n\nLet me wait for clarification on what \"Part 1\" refers to - it could be referring to:\n- A multi-part task they want to break down\n- A section of code or documentation\n- Something else entirely\n\nI should ask them to clarify what they need help with.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01VvB5o1ThNmrvZt4Uhzjvt2",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 874
+            },
+            "cache_creation_input_tokens": 874,
+            "cache_read_input_tokens": 17022,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 3,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "982f3129-7544-418e-94cc-021a5c532975",
+        "type": "assistant",
+        "uuid": "b45c44d7-0192-48cf-89c0-9512a6e0bfda"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "I see you've written \"Part 1\" - I'm ready to help! However, I need more information about what you'd like me to do. \n\nCould you please clarify:\n- What project or task are you working on?\n- What would you like me to help with for Part 1?\n- Do you have code you'd like me to review, create, debug, or modify?\n- Are there specific requirements or goals you're aiming for?\n\nOnce you provide more details, I'll be able to assist you effectively!",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01VvB5o1ThNmrvZt4Uhzjvt2",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 874
+            },
+            "cache_creation_input_tokens": 874,
+            "cache_read_input_tokens": 17022,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 3,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "982f3129-7544-418e-94cc-021a5c532975",
+        "type": "assistant",
+        "uuid": "49adc10c-3e47-4c4e-8e91-cf6521f9f8eb"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "duration_api_ms": 2798,
+        "duration_ms": 2981,
+        "fast_mode_state": "off",
+        "is_error": false,
+        "modelUsage": {
+          "claude-haiku-4-5-20251001": {
+            "cacheCreationInputTokens": 874,
+            "cacheReadInputTokens": 17022,
+            "contextWindow": 200000,
+            "costUSD": 0.0039947,
+            "inputTokens": 10,
+            "maxOutputTokens": 32000,
+            "outputTokens": 238,
+            "webSearchRequests": 0
+          }
+        },
+        "num_turns": 1,
+        "permission_denials": [],
+        "result": "I see you've written \"Part 1\" - I'm ready to help! However, I need more information about what you'd like me to do. \n\nCould you please clarify:\n- What project or task are you working on?\n- What would you like me to help with for Part 1?\n- Do you have code you'd like me to review, create, debug, or modify?\n- Are there specific requirements or goals you're aiming for?\n\nOnce you provide more details, I'll be able to assist you effectively!",
+        "session_id": "982f3129-7544-418e-94cc-021a5c532975",
+        "stop_reason": "end_turn",
+        "subtype": "success",
+        "total_cost_usd": 0.0039947,
+        "type": "result",
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 874
+          },
+          "cache_creation_input_tokens": 874,
+          "cache_read_input_tokens": 17022,
+          "inference_geo": "",
+          "input_tokens": 10,
+          "iterations": [],
+          "output_tokens": 238,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0
+          },
+          "service_tier": "standard",
+          "speed": "standard"
+        },
+        "uuid": "f8dc535d-643a-4d36-97e0-3adad711a9ad"
+      }
+    }
+  ],
+  "sdk_version": "0.1.48"
+}

--- a/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_query_async_iterable_asyncgen_single__sdk_0_1_10.json
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_query_async_iterable_asyncgen_single__sdk_0_1_10.json
@@ -1,0 +1,257 @@
+{
+  "cassette_name": "test_query_async_iterable_asyncgen_single",
+  "events": [
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "request": {
+            "hooks": null,
+            "subtype": "initialize"
+          },
+          "request_id": "req_1_457f90f4",
+          "type": "control_request"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "response": {
+          "request_id": "req_1_457f90f4",
+          "response": {
+            "account": {
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "tokenSource": "none"
+            },
+            "available_output_styles": [
+              "default",
+              "Explanatory",
+              "Learning"
+            ],
+            "commands": [
+              {
+                "argumentHint": "<optional custom summarization instructions>",
+                "description": "Clear conversation history but keep a summary in context. Optional: /compact [instructions for summarization]",
+                "name": "compact"
+              },
+              {
+                "argumentHint": "",
+                "description": "Visualize current context usage as a colored grid",
+                "name": "context"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show the total cost and duration of the current session",
+                "name": "cost"
+              },
+              {
+                "argumentHint": "",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "name": "init"
+              },
+              {
+                "argumentHint": "",
+                "description": "Get comments from a GitHub pull request",
+                "name": "pr-comments"
+              },
+              {
+                "argumentHint": "",
+                "description": "View release notes",
+                "name": "release-notes"
+              },
+              {
+                "argumentHint": "",
+                "description": "List current todo items",
+                "name": "todos"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review a pull request",
+                "name": "review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "name": "security-review"
+              }
+            ],
+            "models": [
+              {
+                "description": "Use the default model (currently Sonnet 4.5) \u00b7 $3/$15 per Mtok",
+                "displayName": "Default (recommended)",
+                "value": "default"
+              },
+              {
+                "description": "Opus 4.5 \u00b7 Most capable for complex work \u00b7 $5/$25 per Mtok",
+                "displayName": "Opus",
+                "value": "opus"
+              },
+              {
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+                "displayName": "Haiku",
+                "value": "haiku"
+              },
+              {
+                "description": "Custom model",
+                "displayName": "claude-haiku-4-5-20251001",
+                "value": "claude-haiku-4-5-20251001"
+              }
+            ],
+            "output_style": "default"
+          },
+          "subtype": "success"
+        },
+        "type": "control_response"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "What is 2 + 2?",
+            "role": "user"
+          },
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "agents": [
+          "general-purpose",
+          "statusline-setup",
+          "Explore",
+          "Plan"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.0.53",
+        "cwd": "<REDACTED_CWD>",
+        "mcp_servers": [],
+        "model": "claude-haiku-4-5-20251001",
+        "output_style": "default",
+        "permissionMode": "bypassPermissions",
+        "plugins": [],
+        "session_id": "3b225142-68d3-4288-a51d-3ae170d30d38",
+        "skills": [],
+        "slash_commands": [
+          "compact",
+          "context",
+          "cost",
+          "init",
+          "pr-comments",
+          "release-notes",
+          "todos",
+          "review",
+          "security-review"
+        ],
+        "subtype": "init",
+        "tools": [
+          "Task",
+          "Bash",
+          "Glob",
+          "Grep",
+          "ExitPlanMode",
+          "Read",
+          "Edit",
+          "Write",
+          "NotebookEdit",
+          "WebFetch",
+          "TodoWrite",
+          "WebSearch",
+          "BashOutput",
+          "KillShell",
+          "Skill",
+          "SlashCommand",
+          "EnterPlanMode"
+        ],
+        "type": "system",
+        "uuid": "a9253a2e-aab7-4374-84a2-3580fe791d30"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "2 + 2 = 4\n\nThis is basic arithmetic: when you add 2 and 2 together, you get 4.",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01S14VLS9fHC1hRMRULwVXdv",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 13883
+            },
+            "cache_creation_input_tokens": 13883,
+            "cache_read_input_tokens": 0,
+            "inference_geo": "not_available",
+            "input_tokens": 3,
+            "output_tokens": 1,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "3b225142-68d3-4288-a51d-3ae170d30d38",
+        "type": "assistant",
+        "uuid": "6ac00cbc-1fee-4be2-834c-54a67b5da8a2"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "duration_api_ms": 3781,
+        "duration_ms": 1950,
+        "is_error": false,
+        "modelUsage": {
+          "claude-haiku-4-5-20251001": {
+            "cacheCreationInputTokens": 13883,
+            "cacheReadInputTokens": 0,
+            "contextWindow": 200000,
+            "costUSD": 0.019255750000000002,
+            "inputTokens": 967,
+            "outputTokens": 187,
+            "webSearchRequests": 0
+          }
+        },
+        "num_turns": 1,
+        "permission_denials": [],
+        "result": "2 + 2 = 4\n\nThis is basic arithmetic: when you add 2 and 2 together, you get 4.",
+        "session_id": "3b225142-68d3-4288-a51d-3ae170d30d38",
+        "subtype": "success",
+        "total_cost_usd": 0.019255750000000002,
+        "type": "result",
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 13883
+          },
+          "cache_creation_input_tokens": 13883,
+          "cache_read_input_tokens": 0,
+          "input_tokens": 3,
+          "output_tokens": 36,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0
+          },
+          "service_tier": "standard"
+        },
+        "uuid": "99178824-6110-4d25-a4ab-5653e3701230"
+      }
+    }
+  ],
+  "sdk_version": "0.1.10"
+}

--- a/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_query_async_iterable_asyncgen_single__sdk_0_1_48.json
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_query_async_iterable_asyncgen_single__sdk_0_1_48.json
@@ -1,0 +1,420 @@
+{
+  "cassette_name": "test_query_async_iterable_asyncgen_single",
+  "events": [
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "request": {
+            "hooks": null,
+            "subtype": "initialize"
+          },
+          "request_id": "req_1_89b41c03",
+          "type": "control_request"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "response": {
+          "request_id": "req_1_89b41c03",
+          "response": {
+            "account": {
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "tokenSource": "none"
+            },
+            "agents": [
+              {
+                "description": "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you.",
+                "name": "general-purpose"
+              },
+              {
+                "description": "Use this agent to configure the user's Claude Code status line setting.",
+                "model": "sonnet",
+                "name": "statusline-setup"
+              },
+              {
+                "description": "Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. \"src/components/**/*.tsx\"), search code for keywords (eg. \"API endpoints\"), or answer questions about the codebase (eg. \"how do API endpoints work?\"). When calling this agent, specify the desired thoroughness level: \"quick\" for basic searches, \"medium\" for moderate exploration, or \"very thorough\" for comprehensive analysis across multiple locations and naming conventions.",
+                "model": "haiku",
+                "name": "Explore"
+              },
+              {
+                "description": "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.",
+                "name": "Plan"
+              }
+            ],
+            "available_output_styles": [
+              "default",
+              "Explanatory",
+              "Learning"
+            ],
+            "commands": [
+              {
+                "argumentHint": "",
+                "description": "Use when the user wants to customize keyboard shortcuts, rebind keys, add chord bindings, or modify ~/.claude/keybindings.json. Examples: \"rebind ctrl+s\", \"add a chord shortcut\", \"change the submit key\", \"customize keybindings\". (bundled)",
+                "name": "keybindings-help"
+              },
+              {
+                "argumentHint": "[issue description]",
+                "description": "Enable debug logging for this session and help diagnose issues (bundled)",
+                "name": "debug"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review changed code for reuse, quality, and efficiency, then fix any issues found. (bundled)",
+                "name": "simplify"
+              },
+              {
+                "argumentHint": "<instruction>",
+                "description": "Research and plan a large-scale change, then execute it in parallel across 5\u201330 isolated worktree agents that each open a PR. (bundled)",
+                "name": "batch"
+              },
+              {
+                "argumentHint": "[interval] <prompt>",
+                "description": "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo, defaults to 10m) (bundled)",
+                "name": "loop"
+              },
+              {
+                "argumentHint": "",
+                "description": "Build apps with the Claude API or Anthropic SDK.\nTRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK.\nDO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks. (bundled)",
+                "name": "claude-api"
+              },
+              {
+                "argumentHint": "<optional custom summarization instructions>",
+                "description": "Clear conversation history but keep a summary in context. Optional: /compact [instructions for summarization]",
+                "name": "compact"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show current context usage",
+                "name": "context"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show the total cost and duration of the current session",
+                "name": "cost"
+              },
+              {
+                "argumentHint": "",
+                "description": "Dump the JS heap to ~/Desktop",
+                "name": "heapdump"
+              },
+              {
+                "argumentHint": "",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "name": "init"
+              },
+              {
+                "argumentHint": "",
+                "description": "Get comments from a GitHub pull request",
+                "name": "pr-comments"
+              },
+              {
+                "argumentHint": "",
+                "description": "View release notes",
+                "name": "release-notes"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review a pull request",
+                "name": "review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "name": "security-review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Generate a report analyzing your Claude Code sessions",
+                "name": "insights"
+              }
+            ],
+            "models": [
+              {
+                "description": "Use the default model (currently Sonnet 4.6) \u00b7 $3/$15 per Mtok",
+                "displayName": "Default (recommended)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "value": "default"
+              },
+              {
+                "description": "Sonnet 4.6 for long sessions \u00b7 $6/$22.50 per Mtok",
+                "displayName": "Sonnet (1M context)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "value": "sonnet[1m]"
+              },
+              {
+                "description": "Opus 4.6 \u00b7 Most capable for complex work \u00b7 $5/$25 per Mtok",
+                "displayName": "Opus",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "supportsFastMode": true,
+                "value": "opus"
+              },
+              {
+                "description": "Opus 4.6 for long sessions \u00b7 $10/$37.50 per Mtok",
+                "displayName": "Opus (1M context)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "supportsFastMode": true,
+                "value": "opus[1m]"
+              },
+              {
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+                "displayName": "Haiku",
+                "value": "haiku"
+              },
+              {
+                "description": "claude-haiku-4-5-20251001",
+                "displayName": "Haiku 4.5",
+                "value": "claude-haiku-4-5-20251001"
+              }
+            ],
+            "output_style": "default",
+            "pid": 99989
+          },
+          "subtype": "success"
+        },
+        "type": "control_response"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "What is 2 + 2?",
+            "role": "user"
+          },
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "agents": [
+          "general-purpose",
+          "statusline-setup",
+          "Explore",
+          "Plan"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.71",
+        "cwd": "<REDACTED_CWD>",
+        "fast_mode_state": "off",
+        "mcp_servers": [],
+        "model": "claude-haiku-4-5-20251001",
+        "output_style": "default",
+        "permissionMode": "bypassPermissions",
+        "plugins": [],
+        "session_id": "e4923f50-caa1-4bfa-9307-3ada79c71dfb",
+        "skills": [
+          "keybindings-help",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "claude-api"
+        ],
+        "slash_commands": [
+          "keybindings-help",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "claude-api",
+          "compact",
+          "context",
+          "cost",
+          "heapdump",
+          "init",
+          "pr-comments",
+          "release-notes",
+          "review",
+          "security-review",
+          "insights"
+        ],
+        "subtype": "init",
+        "tools": [
+          "Task",
+          "TaskOutput",
+          "Bash",
+          "Glob",
+          "Grep",
+          "ExitPlanMode",
+          "Read",
+          "Edit",
+          "Write",
+          "NotebookEdit",
+          "WebFetch",
+          "TodoWrite",
+          "WebSearch",
+          "TaskStop",
+          "AskUserQuestion",
+          "Skill",
+          "EnterPlanMode",
+          "EnterWorktree",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "ToolSearch"
+        ],
+        "type": "system",
+        "uuid": "428028b4-37fa-47d7-91e7-ccf95d0d0305"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "The user is asking a simple arithmetic question: \"What is 2 + 2?\"\n\nThis is straightforward mathematics. 2 + 2 = 4.\n\nThere's no need to use any tools for this - it's a basic calculation that I can answer directly.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01V1cusnrvq36te6JJ8ctNRx",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 4179
+            },
+            "cache_creation_input_tokens": 4179,
+            "cache_read_input_tokens": 13723,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "e4923f50-caa1-4bfa-9307-3ada79c71dfb",
+        "type": "assistant",
+        "uuid": "8046841f-0e0c-4b60-bfe9-e51ed87a804d"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "2 + 2 = 4",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01V1cusnrvq36te6JJ8ctNRx",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 4179
+            },
+            "cache_creation_input_tokens": 4179,
+            "cache_read_input_tokens": 13723,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "e4923f50-caa1-4bfa-9307-3ada79c71dfb",
+        "type": "assistant",
+        "uuid": "8aad0a19-297d-4a59-bcbf-3e5c46174df9"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "duration_api_ms": 1866,
+        "duration_ms": 2003,
+        "fast_mode_state": "off",
+        "is_error": false,
+        "modelUsage": {
+          "claude-haiku-4-5-20251001": {
+            "cacheCreationInputTokens": 4179,
+            "cacheReadInputTokens": 13723,
+            "contextWindow": 200000,
+            "costUSD": 0.0070060500000000015,
+            "inputTokens": 10,
+            "maxOutputTokens": 32000,
+            "outputTokens": 80,
+            "webSearchRequests": 0
+          }
+        },
+        "num_turns": 1,
+        "permission_denials": [],
+        "result": "2 + 2 = 4",
+        "session_id": "e4923f50-caa1-4bfa-9307-3ada79c71dfb",
+        "stop_reason": "end_turn",
+        "subtype": "success",
+        "total_cost_usd": 0.0070060500000000015,
+        "type": "result",
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 4179
+          },
+          "cache_creation_input_tokens": 4179,
+          "cache_read_input_tokens": 13723,
+          "inference_geo": "",
+          "input_tokens": 10,
+          "iterations": [],
+          "output_tokens": 80,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0
+          },
+          "service_tier": "standard",
+          "speed": "standard"
+        },
+        "uuid": "53aa55c0-0ec7-41cc-ba62-8a6e0672a4fb"
+      }
+    }
+  ],
+  "sdk_version": "0.1.48"
+}

--- a/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_query_async_iterable_custom_async_iterable__sdk_0_1_10.json
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_query_async_iterable_custom_async_iterable__sdk_0_1_10.json
@@ -1,0 +1,271 @@
+{
+  "cassette_name": "test_query_async_iterable_custom_async_iterable",
+  "events": [
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "request": {
+            "hooks": null,
+            "subtype": "initialize"
+          },
+          "request_id": "req_1_235d5d62",
+          "type": "control_request"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "response": {
+          "request_id": "req_1_235d5d62",
+          "response": {
+            "account": {
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "tokenSource": "none"
+            },
+            "available_output_styles": [
+              "default",
+              "Explanatory",
+              "Learning"
+            ],
+            "commands": [
+              {
+                "argumentHint": "<optional custom summarization instructions>",
+                "description": "Clear conversation history but keep a summary in context. Optional: /compact [instructions for summarization]",
+                "name": "compact"
+              },
+              {
+                "argumentHint": "",
+                "description": "Visualize current context usage as a colored grid",
+                "name": "context"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show the total cost and duration of the current session",
+                "name": "cost"
+              },
+              {
+                "argumentHint": "",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "name": "init"
+              },
+              {
+                "argumentHint": "",
+                "description": "Get comments from a GitHub pull request",
+                "name": "pr-comments"
+              },
+              {
+                "argumentHint": "",
+                "description": "View release notes",
+                "name": "release-notes"
+              },
+              {
+                "argumentHint": "",
+                "description": "List current todo items",
+                "name": "todos"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review a pull request",
+                "name": "review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "name": "security-review"
+              }
+            ],
+            "models": [
+              {
+                "description": "Use the default model (currently Sonnet 4.5) \u00b7 $3/$15 per Mtok",
+                "displayName": "Default (recommended)",
+                "value": "default"
+              },
+              {
+                "description": "Opus 4.5 \u00b7 Most capable for complex work \u00b7 $5/$25 per Mtok",
+                "displayName": "Opus",
+                "value": "opus"
+              },
+              {
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+                "displayName": "Haiku",
+                "value": "haiku"
+              },
+              {
+                "description": "Custom model",
+                "displayName": "claude-haiku-4-5-20251001",
+                "value": "claude-haiku-4-5-20251001"
+              }
+            ],
+            "output_style": "default"
+          },
+          "subtype": "success"
+        },
+        "type": "control_response"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "Custom 1",
+            "role": "user"
+          },
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "Custom 2",
+            "role": "user"
+          },
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "agents": [
+          "general-purpose",
+          "statusline-setup",
+          "Explore",
+          "Plan"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.0.53",
+        "cwd": "<REDACTED_CWD>",
+        "mcp_servers": [],
+        "model": "claude-haiku-4-5-20251001",
+        "output_style": "default",
+        "permissionMode": "bypassPermissions",
+        "plugins": [],
+        "session_id": "36b62d67-cdd0-48d9-ad08-1ea9fa9a8e24",
+        "skills": [],
+        "slash_commands": [
+          "compact",
+          "context",
+          "cost",
+          "init",
+          "pr-comments",
+          "release-notes",
+          "todos",
+          "review",
+          "security-review"
+        ],
+        "subtype": "init",
+        "tools": [
+          "Task",
+          "Bash",
+          "Glob",
+          "Grep",
+          "ExitPlanMode",
+          "Read",
+          "Edit",
+          "Write",
+          "NotebookEdit",
+          "WebFetch",
+          "TodoWrite",
+          "WebSearch",
+          "BashOutput",
+          "KillShell",
+          "Skill",
+          "SlashCommand",
+          "EnterPlanMode"
+        ],
+        "type": "system",
+        "uuid": "d9078887-f8b5-4aff-9cdc-f78d7ff2cade"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "I'll help you with a custom task! However, I need more information about what you'd like me to do. Could you please provide:\n\n1. **What is the task?** (e.g., code changes, file operations, research, debugging, etc.)\n2. **What codebase or files are involved?** (if applicable)\n3. **Any specific requirements or constraints?**\n\nOnce you give me more details, I'll be able to assist you effectively!",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01UBBAVvUYXYu5P3heQ99Ew5",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 323
+            },
+            "cache_creation_input_tokens": 323,
+            "cache_read_input_tokens": 13554,
+            "inference_geo": "not_available",
+            "input_tokens": 3,
+            "output_tokens": 5,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "36b62d67-cdd0-48d9-ad08-1ea9fa9a8e24",
+        "type": "assistant",
+        "uuid": "57af45bb-7949-4fab-87c0-a739043f20cb"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "duration_api_ms": 3843,
+        "duration_ms": 2109,
+        "is_error": false,
+        "modelUsage": {
+          "claude-haiku-4-5-20251001": {
+            "cacheCreationInputTokens": 323,
+            "cacheReadInputTokens": 13554,
+            "contextWindow": 200000,
+            "costUSD": 0.00376115,
+            "inputTokens": 967,
+            "outputTokens": 207,
+            "webSearchRequests": 0
+          }
+        },
+        "num_turns": 1,
+        "permission_denials": [],
+        "result": "I'll help you with a custom task! However, I need more information about what you'd like me to do. Could you please provide:\n\n1. **What is the task?** (e.g., code changes, file operations, research, debugging, etc.)\n2. **What codebase or files are involved?** (if applicable)\n3. **Any specific requirements or constraints?**\n\nOnce you give me more details, I'll be able to assist you effectively!",
+        "session_id": "36b62d67-cdd0-48d9-ad08-1ea9fa9a8e24",
+        "subtype": "success",
+        "total_cost_usd": 0.00376115,
+        "type": "result",
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 323
+          },
+          "cache_creation_input_tokens": 323,
+          "cache_read_input_tokens": 13554,
+          "input_tokens": 3,
+          "output_tokens": 105,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0
+          },
+          "service_tier": "standard"
+        },
+        "uuid": "67334230-d67e-448d-ae3f-806001c95a22"
+      }
+    }
+  ],
+  "sdk_version": "0.1.10"
+}

--- a/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_query_async_iterable_custom_async_iterable__sdk_0_1_48.json
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/cassettes/test_query_async_iterable_custom_async_iterable__sdk_0_1_48.json
@@ -1,0 +1,434 @@
+{
+  "cassette_name": "test_query_async_iterable_custom_async_iterable",
+  "events": [
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "request": {
+            "hooks": null,
+            "subtype": "initialize"
+          },
+          "request_id": "req_1_d304ec28",
+          "type": "control_request"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "response": {
+          "request_id": "req_1_d304ec28",
+          "response": {
+            "account": {
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "tokenSource": "none"
+            },
+            "agents": [
+              {
+                "description": "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you.",
+                "name": "general-purpose"
+              },
+              {
+                "description": "Use this agent to configure the user's Claude Code status line setting.",
+                "model": "sonnet",
+                "name": "statusline-setup"
+              },
+              {
+                "description": "Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. \"src/components/**/*.tsx\"), search code for keywords (eg. \"API endpoints\"), or answer questions about the codebase (eg. \"how do API endpoints work?\"). When calling this agent, specify the desired thoroughness level: \"quick\" for basic searches, \"medium\" for moderate exploration, or \"very thorough\" for comprehensive analysis across multiple locations and naming conventions.",
+                "model": "haiku",
+                "name": "Explore"
+              },
+              {
+                "description": "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.",
+                "name": "Plan"
+              }
+            ],
+            "available_output_styles": [
+              "default",
+              "Explanatory",
+              "Learning"
+            ],
+            "commands": [
+              {
+                "argumentHint": "",
+                "description": "Use when the user wants to customize keyboard shortcuts, rebind keys, add chord bindings, or modify ~/.claude/keybindings.json. Examples: \"rebind ctrl+s\", \"add a chord shortcut\", \"change the submit key\", \"customize keybindings\". (bundled)",
+                "name": "keybindings-help"
+              },
+              {
+                "argumentHint": "[issue description]",
+                "description": "Enable debug logging for this session and help diagnose issues (bundled)",
+                "name": "debug"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review changed code for reuse, quality, and efficiency, then fix any issues found. (bundled)",
+                "name": "simplify"
+              },
+              {
+                "argumentHint": "<instruction>",
+                "description": "Research and plan a large-scale change, then execute it in parallel across 5\u201330 isolated worktree agents that each open a PR. (bundled)",
+                "name": "batch"
+              },
+              {
+                "argumentHint": "[interval] <prompt>",
+                "description": "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo, defaults to 10m) (bundled)",
+                "name": "loop"
+              },
+              {
+                "argumentHint": "",
+                "description": "Build apps with the Claude API or Anthropic SDK.\nTRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK.\nDO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks. (bundled)",
+                "name": "claude-api"
+              },
+              {
+                "argumentHint": "<optional custom summarization instructions>",
+                "description": "Clear conversation history but keep a summary in context. Optional: /compact [instructions for summarization]",
+                "name": "compact"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show current context usage",
+                "name": "context"
+              },
+              {
+                "argumentHint": "",
+                "description": "Show the total cost and duration of the current session",
+                "name": "cost"
+              },
+              {
+                "argumentHint": "",
+                "description": "Dump the JS heap to ~/Desktop",
+                "name": "heapdump"
+              },
+              {
+                "argumentHint": "",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "name": "init"
+              },
+              {
+                "argumentHint": "",
+                "description": "Get comments from a GitHub pull request",
+                "name": "pr-comments"
+              },
+              {
+                "argumentHint": "",
+                "description": "View release notes",
+                "name": "release-notes"
+              },
+              {
+                "argumentHint": "",
+                "description": "Review a pull request",
+                "name": "review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "name": "security-review"
+              },
+              {
+                "argumentHint": "",
+                "description": "Generate a report analyzing your Claude Code sessions",
+                "name": "insights"
+              }
+            ],
+            "models": [
+              {
+                "description": "Use the default model (currently Sonnet 4.6) \u00b7 $3/$15 per Mtok",
+                "displayName": "Default (recommended)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "value": "default"
+              },
+              {
+                "description": "Sonnet 4.6 for long sessions \u00b7 $6/$22.50 per Mtok",
+                "displayName": "Sonnet (1M context)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "value": "sonnet[1m]"
+              },
+              {
+                "description": "Opus 4.6 \u00b7 Most capable for complex work \u00b7 $5/$25 per Mtok",
+                "displayName": "Opus",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "supportsFastMode": true,
+                "value": "opus"
+              },
+              {
+                "description": "Opus 4.6 for long sessions \u00b7 $10/$37.50 per Mtok",
+                "displayName": "Opus (1M context)",
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsEffort": true,
+                "supportsFastMode": true,
+                "value": "opus[1m]"
+              },
+              {
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok",
+                "displayName": "Haiku",
+                "value": "haiku"
+              },
+              {
+                "description": "claude-haiku-4-5-20251001",
+                "displayName": "Haiku 4.5",
+                "value": "claude-haiku-4-5-20251001"
+              }
+            ],
+            "output_style": "default",
+            "pid": 372
+          },
+          "subtype": "success"
+        },
+        "type": "control_response"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "Custom 1",
+            "role": "user"
+          },
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "Custom 2",
+            "role": "user"
+          },
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "agents": [
+          "general-purpose",
+          "statusline-setup",
+          "Explore",
+          "Plan"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.71",
+        "cwd": "<REDACTED_CWD>",
+        "fast_mode_state": "off",
+        "mcp_servers": [],
+        "model": "claude-haiku-4-5-20251001",
+        "output_style": "default",
+        "permissionMode": "bypassPermissions",
+        "plugins": [],
+        "session_id": "3169895f-b0a2-4c2e-9e08-d96bd7ab1eaa",
+        "skills": [
+          "keybindings-help",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "claude-api"
+        ],
+        "slash_commands": [
+          "keybindings-help",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "claude-api",
+          "compact",
+          "context",
+          "cost",
+          "heapdump",
+          "init",
+          "pr-comments",
+          "release-notes",
+          "review",
+          "security-review",
+          "insights"
+        ],
+        "subtype": "init",
+        "tools": [
+          "Task",
+          "TaskOutput",
+          "Bash",
+          "Glob",
+          "Grep",
+          "ExitPlanMode",
+          "Read",
+          "Edit",
+          "Write",
+          "NotebookEdit",
+          "WebFetch",
+          "TodoWrite",
+          "WebSearch",
+          "TaskStop",
+          "AskUserQuestion",
+          "Skill",
+          "EnterPlanMode",
+          "EnterWorktree",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "ToolSearch"
+        ],
+        "type": "system",
+        "uuid": "9f87e72b-47cb-4141-9811-f0cccb091fbb"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "The user has just sent \"Custom 1\" which appears to be a test message or placeholder. I should ask them what they need help with or what task they'd like me to assist with.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01DQNYLBHXw96x6razoxPAvS",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 874
+            },
+            "cache_creation_input_tokens": 874,
+            "cache_read_input_tokens": 17022,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 4,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "3169895f-b0a2-4c2e-9e08-d96bd7ab1eaa",
+        "type": "assistant",
+        "uuid": "56cc6996-0b17-46c6-85c7-9578b900e51d"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "Hello! I'm Claude, an AI assistant. I see you've sent \"Custom 1\" - I'm not sure what you need help with. \n\nHow can I assist you? Here are some things I can help with:\n\n- **Code implementation**: Write, modify, or debug code\n- **Project exploration**: Search and understand your codebase\n- **Git operations**: Manage commits, branches, and pull requests\n- **Testing and debugging**: Run tests and troubleshoot issues\n- **Planning**: Design implementation strategies for complex features\n- **API and SDK work**: Help with Claude API or other integrations\n\nFeel free to share what you'd like to work on, and I'll be happy to help!",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01DQNYLBHXw96x6razoxPAvS",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 874
+            },
+            "cache_creation_input_tokens": 874,
+            "cache_read_input_tokens": 17022,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 4,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "3169895f-b0a2-4c2e-9e08-d96bd7ab1eaa",
+        "type": "assistant",
+        "uuid": "ae52b382-9ed6-43ea-94a3-76b46809ea9e"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "duration_api_ms": 2940,
+        "duration_ms": 3096,
+        "fast_mode_state": "off",
+        "is_error": false,
+        "modelUsage": {
+          "claude-haiku-4-5-20251001": {
+            "cacheCreationInputTokens": 874,
+            "cacheReadInputTokens": 17022,
+            "contextWindow": 200000,
+            "costUSD": 0.0038147,
+            "inputTokens": 10,
+            "maxOutputTokens": 32000,
+            "outputTokens": 202,
+            "webSearchRequests": 0
+          }
+        },
+        "num_turns": 1,
+        "permission_denials": [],
+        "result": "Hello! I'm Claude, an AI assistant. I see you've sent \"Custom 1\" - I'm not sure what you need help with. \n\nHow can I assist you? Here are some things I can help with:\n\n- **Code implementation**: Write, modify, or debug code\n- **Project exploration**: Search and understand your codebase\n- **Git operations**: Manage commits, branches, and pull requests\n- **Testing and debugging**: Run tests and troubleshoot issues\n- **Planning**: Design implementation strategies for complex features\n- **API and SDK work**: Help with Claude API or other integrations\n\nFeel free to share what you'd like to work on, and I'll be happy to help!",
+        "session_id": "3169895f-b0a2-4c2e-9e08-d96bd7ab1eaa",
+        "stop_reason": "end_turn",
+        "subtype": "success",
+        "total_cost_usd": 0.0038147,
+        "type": "result",
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 874
+          },
+          "cache_creation_input_tokens": 874,
+          "cache_read_input_tokens": 17022,
+          "inference_geo": "",
+          "input_tokens": 10,
+          "iterations": [],
+          "output_tokens": 202,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0
+          },
+          "service_tier": "standard",
+          "speed": "standard"
+        },
+        "uuid": "2c44d6fb-428c-4dfe-b339-589e1df5dd80"
+      }
+    }
+  ],
+  "sdk_version": "0.1.48"
+}

--- a/py/src/braintrust/wrappers/claude_agent_sdk/test_wrapper.py
+++ b/py/src/braintrust/wrappers/claude_agent_sdk/test_wrapper.py
@@ -26,6 +26,7 @@ from braintrust import logger
 from braintrust.span_types import SpanTypeAttribute
 from braintrust.test_helpers import init_test_logger
 from braintrust.wrappers.claude_agent_sdk import setup_claude_agent_sdk
+from braintrust.wrappers.claude_agent_sdk._test_transport import make_cassette_transport
 from braintrust.wrappers.claude_agent_sdk._wrapper import (
     _create_client_wrapper_class,
     _create_tool_wrapper_class,
@@ -65,78 +66,85 @@ async def test_calculator_with_multiple_operations(memory_logger):
     claude_agent_sdk.ClaudeSDKClient = _create_client_wrapper_class(original_client)
     claude_agent_sdk.SdkMcpTool = _create_tool_wrapper_class(original_tool_class)
 
-    # Create calculator tool
-    async def calculator_handler(args):
-        operation = args["operation"]
-        a = args["a"]
-        b = args["b"]
+    try:
+        # Create calculator tool
+        async def calculator_handler(args):
+            operation = args["operation"]
+            a = args["a"]
+            b = args["b"]
 
-        if operation == "multiply":
-            result = a * b
-        elif operation == "subtract":
-            result = a - b
-        elif operation == "add":
-            result = a + b
-        elif operation == "divide":
-            if b == 0:
+            if operation == "multiply":
+                result = a * b
+            elif operation == "subtract":
+                result = a - b
+            elif operation == "add":
+                result = a + b
+            elif operation == "divide":
+                if b == 0:
+                    return {
+                        "content": [{"type": "text", "text": "Error: Division by zero"}],
+                        "isError": True,
+                    }
+                result = a / b
+            else:
                 return {
-                    "content": [{"type": "text", "text": "Error: Division by zero"}],
+                    "content": [{"type": "text", "text": f"Unknown operation: {operation}"}],
                     "isError": True,
                 }
-            result = a / b
-        else:
+
             return {
-                "content": [{"type": "text", "text": f"Unknown operation: {operation}"}],
-                "isError": True,
+                "content": [{"type": "text", "text": f"The result of {operation}({a}, {b}) is {result}"}],
             }
 
-        return {
-            "content": [{"type": "text", "text": f"The result of {operation}({a}, {b}) is {result}"}],
-        }
-
-    calculator_tool = claude_agent_sdk.SdkMcpTool(
-        name="calculator",
-        description="Performs basic arithmetic operations",
-        input_schema={
-            "type": "object",
-            "properties": {
-                "operation": {
-                    "type": "string",
-                    "enum": ["add", "subtract", "multiply", "divide"],
-                    "description": "The arithmetic operation to perform",
+        calculator_tool = claude_agent_sdk.SdkMcpTool(
+            name="calculator",
+            description="Performs basic arithmetic operations",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "operation": {
+                        "type": "string",
+                        "enum": ["add", "subtract", "multiply", "divide"],
+                        "description": "The arithmetic operation to perform",
+                    },
+                    "a": {"type": "number", "description": "First number"},
+                    "b": {"type": "number", "description": "Second number"},
                 },
-                "a": {"type": "number", "description": "First number"},
-                "b": {"type": "number", "description": "Second number"},
+                "required": ["operation", "a", "b"],
             },
-            "required": ["operation", "a", "b"],
-        },
-        handler=calculator_handler,
-    )
+            handler=calculator_handler,
+        )
 
-    # Run the query using ClaudeSDKClient (required for tracing)
-    options = claude_agent_sdk.ClaudeAgentOptions(
-        model=TEST_MODEL,
-        mcp_servers={
-            "calculator": claude_agent_sdk.create_sdk_mcp_server(
-                name="calculator",
-                version="1.0.0",
-                tools=[calculator_tool],
-            )
-        },
-    )
+        options = claude_agent_sdk.ClaudeAgentOptions(
+            model=TEST_MODEL,
+            permission_mode="bypassPermissions",
+            mcp_servers={
+                "calculator": claude_agent_sdk.create_sdk_mcp_server(
+                    name="calculator",
+                    version="1.0.0",
+                    tools=[calculator_tool],
+                )
+            },
+        )
+        transport = make_cassette_transport(
+            cassette_name="test_calculator_with_multiple_operations",
+            prompt="",
+            options=options,
+        )
 
-    result_message = None
-    async with claude_agent_sdk.ClaudeSDKClient(options=options) as client:
-        await client.query("What is 15 multiplied by 7? Then subtract 5 from the result.")
-        async for message in client.receive_response():
-            # Check for ResultMessage by class name
-            if type(message).__name__ == "ResultMessage":
-                result_message = message
+        result_message = None
+        async with claude_agent_sdk.ClaudeSDKClient(options=options, transport=transport) as client:
+            await client.query("What is 15 multiplied by 7? Then subtract 5 from the result.")
+            async for message in client.receive_response():
+                if type(message).__name__ == "ResultMessage":
+                    result_message = message
 
-    # Get logged spans
+    finally:
+        claude_agent_sdk.ClaudeSDKClient = original_client
+        claude_agent_sdk.SdkMcpTool = original_tool_class
+
     spans = memory_logger.pop()
 
-    # Verify root task span
     task_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.TASK]
     assert len(task_spans) == 1, f"Should have exactly one task span, got {len(task_spans)}"
 
@@ -145,41 +153,33 @@ async def test_calculator_with_multiple_operations(memory_logger):
     assert "15 multiplied by 7" in task_span["input"]
     assert task_span["output"] is not None
 
-    # Verify we received result message with metadata
     assert result_message is not None, "Should have received result message"
     if hasattr(result_message, "num_turns"):
         assert task_span.get("metadata", {}).get("num_turns") is not None
     if hasattr(result_message, "session_id"):
         assert task_span.get("metadata", {}).get("session_id") is not None
 
-    # Verify LLM spans (multiple anthropic.messages.create calls)
     llm_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.LLM]
     assert len(llm_spans) >= 1, f"Should have at least one LLM span, got {len(llm_spans)}"
 
-    # Check that at least one LLM span has token metrics
     llm_spans_with_metrics = [s for s in llm_spans if "prompt_tokens" in s.get("metrics", {})]
     assert len(llm_spans_with_metrics) >= 1, "At least one LLM span should have token metrics"
 
     for llm_span in llm_spans:
         assert llm_span["span_attributes"]["name"] == "anthropic.messages.create"
-        # Output should be an array of messages
         assert isinstance(llm_span["output"], list)
         assert len(llm_span["output"]) > 0
 
-    # Verify the last LLM span has complete metrics
     last_llm_span = llm_spans[-1]
     assert last_llm_span["metrics"]["prompt_tokens"] > 0
     assert last_llm_span["metrics"]["completion_tokens"] > 0
 
-    # Verify tool spans (calculator may or may not be called depending on model behavior)
     tool_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.TOOL]
-
     for tool_span in tool_spans:
         assert tool_span["span_attributes"]["name"] == "calculator"
         assert tool_span["input"] is not None
         assert tool_span["output"] is not None
 
-    # Verify span hierarchy (all children should reference the root task span)
     root_span_id = task_span["span_id"]
     for span in spans:
         if span["span_id"] != root_span_id:
@@ -227,59 +227,65 @@ class CustomAsyncIterator:
 @pytest.mark.skipif(not CLAUDE_SDK_AVAILABLE, reason="Claude Agent SDK not installed")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "input_factory,expected_contents",
+    "cassette_name,input_factory,expected_contents",
     [
         pytest.param(
+            "test_query_async_iterable_asyncgen_single",
             lambda: (msg async for msg in _single_message_generator()),
             ["What is 2 + 2?"],
             id="asyncgen_single",
         ),
         pytest.param(
+            "test_query_async_iterable_asyncgen_multi",
             lambda: (msg async for msg in _multi_message_generator()),
             ["Part 1", "Part 2"],
             id="asyncgen_multi",
         ),
         pytest.param(
+            "test_query_async_iterable_custom_async_iterable",
             lambda: CustomAsyncIterable([_make_message("Custom 1"), _make_message("Custom 2")]),
             ["Custom 1", "Custom 2"],
             id="custom_async_iterable",
         ),
     ],
 )
-async def test_query_async_iterable(memory_logger, input_factory, expected_contents):
-    """Test that async iterable inputs are captured as structured lists.
-
-    Verifies that passing AsyncIterable[dict] to query() results in the span
-    input showing the structured message list, not a flattened string or repr.
-    """
+async def test_query_async_iterable(memory_logger, cassette_name, input_factory, expected_contents):
+    """Test that async iterable inputs are captured as structured lists."""
     assert not memory_logger.pop()
 
     original_client = claude_agent_sdk.ClaudeSDKClient
     claude_agent_sdk.ClaudeSDKClient = _create_client_wrapper_class(original_client)
 
     try:
-        options = claude_agent_sdk.ClaudeAgentOptions(model=TEST_MODEL)
+        options = claude_agent_sdk.ClaudeAgentOptions(
+            model=TEST_MODEL,
+            permission_mode="bypassPermissions",
+        )
+        transport = make_cassette_transport(
+            cassette_name=cassette_name,
+            prompt="",
+            options=options,
+        )
 
-        async with claude_agent_sdk.ClaudeSDKClient(options=options) as client:
+        async with claude_agent_sdk.ClaudeSDKClient(options=options, transport=transport) as client:
             await client.query(input_factory())
             async for message in client.receive_response():
                 if type(message).__name__ == "ResultMessage":
                     break
 
-        spans = memory_logger.pop()
-
-        task_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.TASK]
-        assert len(task_spans) >= 1, f"Should have at least one task span, got {len(task_spans)}"
-
-        task_span = next(
-            (s for s in task_spans if s["span_attributes"]["name"] == "Claude Agent"),
-            task_spans[0],
-        )
-
-        _assert_structured_input(task_span, expected_contents)
-
     finally:
         claude_agent_sdk.ClaudeSDKClient = original_client
+
+    spans = memory_logger.pop()
+
+    task_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.TASK]
+    assert len(task_spans) >= 1, f"Should have at least one task span, got {len(task_spans)}"
+
+    task_span = next(
+        (s for s in task_spans if s["span_attributes"]["name"] == "Claude Agent"),
+        task_spans[0],
+    )
+    _assert_structured_input(task_span, expected_contents)
 
 
 async def _single_message_generator():
@@ -371,8 +377,6 @@ async def test_setup_claude_agent_sdk_repro_import_before_setup(memory_logger, m
     consumer_module.ClaudeAgentOptions = fake_sdk.ClaudeAgentOptions
     monkeypatch.setitem(sys.modules, consumer_module_name, consumer_module)
 
-    # Mirror the reported import pattern:
-    # from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
     assert setup_claude_agent_sdk(project=PROJECT_NAME, api_key=logger.TEST_API_KEY)
     assert consumer_module.ClaudeSDKClient is not _FakeClaudeSDKClient
 

--- a/py/src/braintrust/wrappers/test_utils.py
+++ b/py/src/braintrust/wrappers/test_utils.py
@@ -43,6 +43,9 @@ def verify_autoinstrument_script(script_name: str, timeout: int = 30) -> subproc
     # Pass cassettes dir to subprocess since it may use installed package
     env = os.environ.copy()
     env["BRAINTRUST_CASSETTES_DIR"] = str(_SOURCE_DIR / "cassettes")
+    env["BRAINTRUST_CLAUDE_AGENT_SDK_CASSETTES_DIR"] = str(
+        _SOURCE_DIR / "claude_agent_sdk" / "cassettes"
+    )
     result = subprocess.run(
         [sys.executable, str(script_path)],
         capture_output=True,
@@ -69,10 +72,14 @@ def assert_metrics_are_valid(metrics, start=None, end=None):
 
 
 @contextmanager
-def autoinstrument_test_context(cassette_name: str):
+def autoinstrument_test_context(cassette_name: str, *, use_vcr: bool = True):
     """Context manager for auto_instrument tests.
 
-    Sets up VCR and memory_logger, yields memory_logger for direct use.
+    Sets up the shared memory_logger context and, by default, VCR.
+
+    Use ``use_vcr=False`` for tests that replay provider traffic through a
+    non-VCR mechanism, such as the Claude Agent SDK subprocess cassette
+    transport.
 
     Usage:
         with autoinstrument_test_context("test_auto_openai") as memory_logger:
@@ -85,6 +92,10 @@ def autoinstrument_test_context(cassette_name: str):
 
     with logger._internal_with_memory_background_logger() as memory_logger:
         memory_logger.pop()  # Clear any prior spans
+
+        if not use_vcr:
+            yield memory_logger
+            return
 
         my_vcr = vcr.VCR(**get_vcr_config())
         with my_vcr.use_cassette(str(cassette_path)):


### PR DESCRIPTION
Claude Agent SDK tests were not running in CI because they did not work with VCR.

Me and codex wrote a small VCR equivalent for just the claude agent sdk tests. Check out `CONTRIBUTING.md` for how it works. This allows us to re-enable the claude agent sdk tests in CI, unblocking our work in https://github.com/braintrustdata/braintrust-sdk-python/pull/65 and https://github.com/braintrustdata/braintrust-sdk-python/pull/66