### PR TITLE
feat: Support OpenAI `with_raw_response`

### DIFF
--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -349,19 +349,66 @@ class ChatCompletionWrapper:
         }
 
 
+class _TracedStream(NamedWrapper):
+    """Traced sync stream. Iterates via the traced generator while delegating
+    SDK-specific attributes (e.g. .close(), .response) to the original stream."""
+
+    def __init__(self, original_stream: Any, traced_generator: Any) -> None:
+        self._traced_generator = traced_generator
+        super().__init__(original_stream)
+
+    def __iter__(self) -> Any:
+        return self._traced_generator
+
+    def __next__(self) -> Any:
+        return next(self._traced_generator)
+
+
+class _AsyncTracedStream(NamedWrapper):
+    """Traced async stream. Iterates via the traced generator while delegating
+    SDK-specific attributes (e.g. .close(), .response) to the original stream."""
+
+    def __init__(self, original_stream: Any, traced_generator: Any) -> None:
+        self._traced_generator = traced_generator
+        super().__init__(original_stream)
+
+    def __aiter__(self) -> Any:
+        return self._traced_generator
+
+    async def __anext__(self) -> Any:
+        return await self._traced_generator.__anext__()
+
+
+class _RawResponseWithTracedStream(NamedWrapper):
+    """Proxy for LegacyAPIResponse that replaces parse() with a traced stream,
+    so that with_raw_response + stream=True preserves both headers and tracing."""
+
+    def __init__(self, raw_response: Any, traced_stream: Any) -> None:
+        self._traced_stream = traced_stream
+        super().__init__(raw_response)
+
+    def parse(self, *args: Any, **kwargs: Any) -> Any:
+        return self._traced_stream
+
+
 class ResponseWrapper:
-    def __init__(self, create_fn: Callable[..., Any] | None, acreate_fn: Callable[..., Any] | None, name: str = "openai.responses.create"):
+    def __init__(
+        self,
+        create_fn: Callable[..., Any] | None,
+        acreate_fn: Callable[..., Any] | None,
+        name: str = "openai.responses.create",
+        return_raw: bool = False,
+    ):
         self.create_fn = create_fn
         self.acreate_fn = acreate_fn
         self.name = name
+        self.return_raw = return_raw
 
     def create(self, *args: Any, **kwargs: Any) -> Any:
         params = self._parse_params(kwargs)
         stream = kwargs.get("stream", False)
 
-        span = start_span(
-            **merge_dicts(dict(name=self.name, span_attributes={"type": SpanTypeAttribute.LLM}), params)
-        )
+        span = start_span(**merge_dicts(dict(name=self.name, span_attributes={"type": SpanTypeAttribute.LLM}), params))
         should_end = True
 
         try:
@@ -373,6 +420,7 @@ class ResponseWrapper:
             else:
                 raw_response = create_response
             if stream:
+
                 def gen():
                     try:
                         first = True
@@ -393,6 +441,8 @@ class ResponseWrapper:
                         span.end()
 
                 should_end = False
+                if self.return_raw and hasattr(create_response, "parse"):
+                    return _RawResponseWithTracedStream(create_response, _TracedStream(raw_response, gen()))
                 return gen()
             else:
                 log_response = _try_to_dict(raw_response)
@@ -401,7 +451,7 @@ class ResponseWrapper:
                     event_data["metrics"] = {}
                 event_data["metrics"]["time_to_first_token"] = time.time() - start
                 span.log(**event_data)
-                return raw_response
+                return create_response if (self.return_raw and hasattr(create_response, "parse")) else raw_response
         finally:
             if should_end:
                 span.end()
@@ -410,9 +460,7 @@ class ResponseWrapper:
         params = self._parse_params(kwargs)
         stream = kwargs.get("stream", False)
 
-        span = start_span(
-            **merge_dicts(dict(name=self.name, span_attributes={"type": SpanTypeAttribute.LLM}), params)
-        )
+        span = start_span(**merge_dicts(dict(name=self.name, span_attributes={"type": SpanTypeAttribute.LLM}), params))
         should_end = True
 
         try:
@@ -424,6 +472,7 @@ class ResponseWrapper:
             else:
                 raw_response = create_response
             if stream:
+
                 async def gen():
                     try:
                         first = True
@@ -445,6 +494,8 @@ class ResponseWrapper:
 
                 should_end = False
                 streamer = gen()
+                if self.return_raw and hasattr(create_response, "parse"):
+                    return _RawResponseWithTracedStream(create_response, _AsyncTracedStream(raw_response, streamer))
                 return AsyncResponseWrapper(streamer)
             else:
                 log_response = _try_to_dict(raw_response)
@@ -453,7 +504,7 @@ class ResponseWrapper:
                     event_data["metrics"] = {}
                 event_data["metrics"]["time_to_first_token"] = time.time() - start
                 span.log(**event_data)
-                return raw_response
+                return create_response if (self.return_raw and hasattr(create_response, "parse")) else raw_response
         finally:
             if should_end:
                 span.end()
@@ -506,7 +557,12 @@ class ResponseWrapper:
 
         for result in all_results:
             usage = getattr(result, "usage", None)
-            if not usage and hasattr(result, "type") and result.type == "response.completed" and hasattr(result, "response"):
+            if (
+                not usage
+                and hasattr(result, "type")
+                and result.type == "response.completed"
+                and hasattr(result, "response")
+            ):
                 # Handle summaries from completed response if present
                 if hasattr(result.response, "output") and result.response.output:
                     for output_item in result.response.output:
@@ -787,29 +843,43 @@ class ChatV1Wrapper(NamedWrapper):
 
 
 class ResponsesV1Wrapper(NamedWrapper):
-    def __init__(self, responses: Any):
+    def __init__(self, responses: Any, return_raw: bool = False) -> None:
         self.__responses = responses
+        self.__return_raw = return_raw
+        if not return_raw:
+            self.with_raw_response = ResponsesV1Wrapper(responses, return_raw=True)
         super().__init__(responses)
 
     def create(self, *args: Any, **kwargs: Any) -> Any:
-        return ResponseWrapper(self.__responses.with_raw_response.create, None).create(*args, **kwargs)
+        return ResponseWrapper(self.__responses.with_raw_response.create, None, return_raw=self.__return_raw).create(
+            *args, **kwargs
+        )
 
     def parse(self, *args: Any, **kwargs: Any) -> Any:
-        return ResponseWrapper(self.__responses.with_raw_response.parse, None, "openai.responses.parse").create(*args, **kwargs)
+        return ResponseWrapper(
+            self.__responses.with_raw_response.parse, None, "openai.responses.parse", return_raw=self.__return_raw
+        ).create(*args, **kwargs)
 
 
 class AsyncResponsesV1Wrapper(NamedWrapper):
-    def __init__(self, responses: Any):
+    def __init__(self, responses: Any, return_raw: bool = False) -> None:
         self.__responses = responses
+        self.__return_raw = return_raw
+        if not return_raw:
+            self.with_raw_response = AsyncResponsesV1Wrapper(responses, return_raw=True)
         super().__init__(responses)
 
     async def create(self, *args: Any, **kwargs: Any) -> Any:
-        response = await ResponseWrapper(None, self.__responses.with_raw_response.create).acreate(*args, **kwargs)
-        return AsyncResponseWrapper(response)
+        response = await ResponseWrapper(
+            None, self.__responses.with_raw_response.create, return_raw=self.__return_raw
+        ).acreate(*args, **kwargs)
+        return response if self.__return_raw else AsyncResponseWrapper(response)
 
     async def parse(self, *args: Any, **kwargs: Any) -> Any:
-        response = await ResponseWrapper(None, self.__responses.with_raw_response.parse, "openai.responses.parse").acreate(*args, **kwargs)
-        return AsyncResponseWrapper(response)
+        response = await ResponseWrapper(
+            None, self.__responses.with_raw_response.parse, "openai.responses.parse", return_raw=self.__return_raw
+        ).acreate(*args, **kwargs)
+        return response if self.__return_raw else AsyncResponseWrapper(response)
 
 
 class BetaCompletionsV1Wrapper(NamedWrapper):
@@ -878,7 +948,7 @@ class OpenAIV1Wrapper(NamedWrapper):
 
 def wrap_openai(openai: Any):
     """
-    Wrap the openai module (pre v1) or OpenAI instance (post v1) to add tracing.
+    Wrap the openai module (pre v1) or OpenAI instance (v1.* or v2.*) to add tracing.
     If Braintrust is not configured, nothing will be traced. If this is not an
     `OpenAI` object, this function is a no-op.
 
@@ -936,7 +1006,6 @@ def _parse_metrics_from_usage(usage: Any) -> dict[str, Any]:
             metrics[name] = value
 
     return metrics
-
 
 
 def prettify_params(params: dict[str, Any]) -> dict[str, Any]:

--- a/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_async.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_async.yaml
@@ -1,0 +1,234 @@
+interactions:
+- request:
+    body: '{"input":"What''s 12 + 12?","instructions":"Just the number please","model":"gpt-4o-mini"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - AsyncOpenAI/Python 2.26.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.26.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: "{\n  \"id\": \"resp_0bed43dd6abfb0010069b210d1942c81939cea0c2b48002ec9\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1773277393,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1773277395,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        \"Just the number please\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\":
+        null,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n  \"output\": [\n    {\n
+        \     \"id\": \"msg_0bed43dd6abfb0010069b210d361b48193ad7726e93b6e63ca\",\n
+        \     \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\":
+        [\n        {\n          \"type\": \"output_text\",\n          \"annotations\":
+        [],\n          \"logprobs\": [],\n          \"text\": \"24\"\n        }\n
+        \     ],\n      \"role\": \"assistant\"\n    }\n  ],\n  \"parallel_tool_calls\":
+        true,\n  \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\":
+        null,\n  \"prompt_cache_retention\": null,\n  \"reasoning\": {\n    \"effort\":
+        null,\n    \"summary\": null\n  },\n  \"safety_identifier\": null,\n  \"service_tier\":
+        \"default\",\n  \"store\": true,\n  \"temperature\": 1.0,\n  \"text\": {\n
+        \   \"format\": {\n      \"type\": \"text\"\n    },\n    \"verbosity\": \"medium\"\n
+        \ },\n  \"tool_choice\": \"auto\",\n  \"tools\": [],\n  \"top_logprobs\":
+        0,\n  \"top_p\": 1.0,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n    \"input_tokens\":
+        22,\n    \"input_tokens_details\": {\n      \"cached_tokens\": 0\n    },\n
+        \   \"output_tokens\": 2,\n    \"output_tokens_details\": {\n      \"reasoning_tokens\":
+        0\n    },\n    \"total_tokens\": 24\n  },\n  \"user\": null,\n  \"metadata\":
+        {}\n}"
+    headers:
+      CF-RAY:
+      - 9daee0bbcaf6f457-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 12 Mar 2026 01:03:15 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1549'
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '1985'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=WJkugkIS2sHaPu1rZZUoSbR5izMErirYE267VsJfNTg-1773277393.2459075-1.0.1.1-UDB03YAIBFMwtjGwfYoWCckkejXrPflHqOpnmS23jYVyME9Ff4Bev1PpO.8ayvuMX5sXOhu9o14lkCFvfj25LzRcz.pOv4qS0XQ5lZ6ECGvOa8BYj1ZwkdsYnepwAzVw;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 12 Mar 2026
+        01:33:15 GMT
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999960'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_0ac0677cd98649fa83607e201cae7e7f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"input":"What''s 12 + 12?","instructions":"Just the number please","model":"gpt-4o-mini"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - AsyncOpenAI/Python 2.26.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.26.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: "{\n  \"id\": \"resp_0078a4664c3969b00069b210d5d4908195b9590feeeead62ed\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1773277397,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1773277398,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        \"Just the number please\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\":
+        null,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n  \"output\": [\n    {\n
+        \     \"id\": \"msg_0078a4664c3969b00069b210d6265c81959e7d64886c3b1c81\",\n
+        \     \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\":
+        [\n        {\n          \"type\": \"output_text\",\n          \"annotations\":
+        [],\n          \"logprobs\": [],\n          \"text\": \"24\"\n        }\n
+        \     ],\n      \"role\": \"assistant\"\n    }\n  ],\n  \"parallel_tool_calls\":
+        true,\n  \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\":
+        null,\n  \"prompt_cache_retention\": null,\n  \"reasoning\": {\n    \"effort\":
+        null,\n    \"summary\": null\n  },\n  \"safety_identifier\": null,\n  \"service_tier\":
+        \"default\",\n  \"store\": true,\n  \"temperature\": 1.0,\n  \"text\": {\n
+        \   \"format\": {\n      \"type\": \"text\"\n    },\n    \"verbosity\": \"medium\"\n
+        \ },\n  \"tool_choice\": \"auto\",\n  \"tools\": [],\n  \"top_logprobs\":
+        0,\n  \"top_p\": 1.0,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n    \"input_tokens\":
+        22,\n    \"input_tokens_details\": {\n      \"cached_tokens\": 0\n    },\n
+        \   \"output_tokens\": 2,\n    \"output_tokens_details\": {\n      \"reasoning_tokens\":
+        0\n    },\n    \"total_tokens\": 24\n  },\n  \"user\": null,\n  \"metadata\":
+        {}\n}"
+    headers:
+      CF-RAY:
+      - 9daee0d8292a2157-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 12 Mar 2026 01:03:18 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1549'
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '498'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=k_sgjbvvmiJHygr_.PReGTInXW9G83Da5hQW.UN2jhk-1773277397.7889063-1.0.1.1-Lv5zH71GNroBF6SRyP2Ns4LCh3d2mM5H1aB0IgiQuidlL.ru8OBk6YeLAquNSlF1z1Kw_AaI1ny7sSUNwK1LImP6mx1STOa32XJp9JS7YxbHIut8pWVcMmc5xps_utlo;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 12 Mar 2026
+        01:33:18 GMT
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999960'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_5fde3d3964ab4e80befdb1744f24e98e
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_create.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_create.yaml
@@ -1,0 +1,234 @@
+interactions:
+- request:
+    body: '{"input":"What''s 12 + 12?","instructions":"Just the number please","model":"gpt-4o-mini"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - OpenAI/Python 2.26.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.26.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: "{\n  \"id\": \"resp_004cb4445a947a0a0069b210c4b45c81948349117fb131c0f0\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1773277380,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1773277381,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        \"Just the number please\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\":
+        null,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n  \"output\": [\n    {\n
+        \     \"id\": \"msg_004cb4445a947a0a0069b210c56fd481948668fe49cf467851\",\n
+        \     \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\":
+        [\n        {\n          \"type\": \"output_text\",\n          \"annotations\":
+        [],\n          \"logprobs\": [],\n          \"text\": \"24\"\n        }\n
+        \     ],\n      \"role\": \"assistant\"\n    }\n  ],\n  \"parallel_tool_calls\":
+        true,\n  \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\":
+        null,\n  \"prompt_cache_retention\": null,\n  \"reasoning\": {\n    \"effort\":
+        null,\n    \"summary\": null\n  },\n  \"safety_identifier\": null,\n  \"service_tier\":
+        \"default\",\n  \"store\": true,\n  \"temperature\": 1.0,\n  \"text\": {\n
+        \   \"format\": {\n      \"type\": \"text\"\n    },\n    \"verbosity\": \"medium\"\n
+        \ },\n  \"tool_choice\": \"auto\",\n  \"tools\": [],\n  \"top_logprobs\":
+        0,\n  \"top_p\": 1.0,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n    \"input_tokens\":
+        22,\n    \"input_tokens_details\": {\n      \"cached_tokens\": 0\n    },\n
+        \   \"output_tokens\": 2,\n    \"output_tokens_details\": {\n      \"reasoning_tokens\":
+        0\n    },\n    \"total_tokens\": 24\n  },\n  \"user\": null,\n  \"metadata\":
+        {}\n}"
+    headers:
+      CF-RAY:
+      - 9daee06b18486dd5-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 12 Mar 2026 01:03:01 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1549'
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '938'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=MAs_EUHWaS5XzVo4tT4h9GWVw_o2nydxVCi_1MQ5J6c-1773277380.3344576-1.0.1.1-cBKltiFOHaQRalCpRpE1UARqaF4G.YbYvPvkkbIJiOelqIltIIuasKUZ19FWKRHSa2LReB5h8w6yafxYThtqVAeksnxrZjfcHqvLUZXeMUpq6hxcu5_U3V9YtK6xC20y;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 12 Mar 2026
+        01:33:01 GMT
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999960'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_abdd40991d4d42dcbbcbc2159b1f9b50
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"input":"What''s 12 + 12?","instructions":"Just the number please","model":"gpt-4o-mini"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - OpenAI/Python 2.26.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.26.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: "{\n  \"id\": \"resp_0196fb9362faa1f50069b210c85798819888af84d351cde5ab\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1773277384,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1773277385,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        \"Just the number please\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\":
+        null,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n  \"output\": [\n    {\n
+        \     \"id\": \"msg_0196fb9362faa1f50069b210c951fc8198a75669bd08c90186\",\n
+        \     \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\":
+        [\n        {\n          \"type\": \"output_text\",\n          \"annotations\":
+        [],\n          \"logprobs\": [],\n          \"text\": \"24\"\n        }\n
+        \     ],\n      \"role\": \"assistant\"\n    }\n  ],\n  \"parallel_tool_calls\":
+        true,\n  \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\":
+        null,\n  \"prompt_cache_retention\": null,\n  \"reasoning\": {\n    \"effort\":
+        null,\n    \"summary\": null\n  },\n  \"safety_identifier\": null,\n  \"service_tier\":
+        \"default\",\n  \"store\": true,\n  \"temperature\": 1.0,\n  \"text\": {\n
+        \   \"format\": {\n      \"type\": \"text\"\n    },\n    \"verbosity\": \"medium\"\n
+        \ },\n  \"tool_choice\": \"auto\",\n  \"tools\": [],\n  \"top_logprobs\":
+        0,\n  \"top_p\": 1.0,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n    \"input_tokens\":
+        22,\n    \"input_tokens_details\": {\n      \"cached_tokens\": 0\n    },\n
+        \   \"output_tokens\": 2,\n    \"output_tokens_details\": {\n      \"reasoning_tokens\":
+        0\n    },\n    \"total_tokens\": 24\n  },\n  \"user\": null,\n  \"metadata\":
+        {}\n}"
+    headers:
+      CF-RAY:
+      - 9daee08109885fe3-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 12 Mar 2026 01:03:05 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1549'
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '1103'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=aq9HIvhG9EBOMxq5YsI5WHcCeKwwjdUPKk3RwFMEpLs-1773277383.8459609-1.0.1.1-DuzJ6UyL1wH3QgUFaX8DwnkffIH9c8i59d3MGtMJinlK9AFCUA1OwNJUnzN53C1uv25wboODeb9T.b6EoWbRX_3R8C7.h5mOv0DCTlt.eHRWDfP152RqWVuzuRb9cXyN;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 12 Mar 2026
+        01:33:05 GMT
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999960'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_81244ffa796a456b87dc8e0da0895c19
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_create_stream.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_create_stream.yaml
@@ -1,0 +1,330 @@
+interactions:
+- request:
+    body: '{"input":"What''s 12 + 12?","model":"gpt-4o-mini","stream":true}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '63'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - OpenAI/Python 2.26.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.26.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","response":{"id":"resp_0c3ae345f7b01acd0069b2f65f6c8081949bb96b7a44ae2df8","object":"response","created_at":1773336159,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","response":{"id":"resp_0c3ae345f7b01acd0069b2f65f6c8081949bb96b7a44ae2df8","object":"response","created_at":1773336159,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","item":{"id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"12","item_id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","logprobs":[],"obfuscation":"7aZW9abnw1Y30Z","output_index":0,"sequence_number":4}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" +","item_id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","logprobs":[],"obfuscation":"e3yNU3SRKNqAUu","output_index":0,"sequence_number":5}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","logprobs":[],"obfuscation":"HUMMao3zrcNpsAf","output_index":0,"sequence_number":6}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"12","item_id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","logprobs":[],"obfuscation":"Fh0jSjNs7kSS3e","output_index":0,"sequence_number":7}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" equals","item_id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","logprobs":[],"obfuscation":"MEpoScxLq","output_index":0,"sequence_number":8}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","logprobs":[],"obfuscation":"GevBGvBE8GMedb3","output_index":0,"sequence_number":9}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"24","item_id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","logprobs":[],"obfuscation":"xcBtVzzWBiTwDE","output_index":0,"sequence_number":10}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","logprobs":[],"obfuscation":"d51YFKcnO5hbxW3","output_index":0,"sequence_number":11}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","logprobs":[],"output_index":0,"sequence_number":12,"text":"12
+        + 12 equals 24."}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"12
+        + 12 equals 24."},"sequence_number":13}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","item":{"id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"12
+        + 12 equals 24."}],"role":"assistant"},"output_index":0,"sequence_number":14}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","response":{"id":"resp_0c3ae345f7b01acd0069b2f65f6c8081949bb96b7a44ae2df8","object":"response","created_at":1773336159,"status":"completed","background":false,"completed_at":1773336160,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_0c3ae345f7b01acd0069b2f6600570819491f0b8215556c989","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"12
+        + 12 equals 24."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":14,"input_tokens_details":{"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":23},"user":null,"metadata":{}},"sequence_number":15}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9db47b721b384833-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Thu, 12 Mar 2026 17:22:39 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '67'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=Al9ntd9.Qbi1m8s0yeKZh1.LsQ6K7wVfqY9x.dMEXj0-1773336159.051377-1.0.1.1-Y4k2khMwR1cosN.66_8eScroz8b9usEjO8bLO5km7Po4f39jaFZg_bHslFptuNzV3Xyvc5zJ3XLtAhw5Pd3wCdSZ47MtMUCzW0W6pvuzfrePN.h2v2vnmUs_KNjgyP8C;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 12 Mar 2026
+        17:52:39 GMT
+      x-request-id:
+      - req_ebac62941e4b4dc094436aaa629f50a7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"input":"What''s 12 + 12?","model":"gpt-4o-mini","stream":true}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '63'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - OpenAI/Python 2.26.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.26.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","response":{"id":"resp_0a40f73a58d34b0a0069b2f660759c81909d55d9e3578e1752","object":"response","created_at":1773336160,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","response":{"id":"resp_0a40f73a58d34b0a0069b2f660759c81909d55d9e3578e1752","object":"response","created_at":1773336160,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","item":{"id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"12","item_id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","logprobs":[],"obfuscation":"E75S0K9BXfywSM","output_index":0,"sequence_number":4}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" +","item_id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","logprobs":[],"obfuscation":"ElmLb8jrTedQYm","output_index":0,"sequence_number":5}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","logprobs":[],"obfuscation":"VBFrVPNyRZ7wArC","output_index":0,"sequence_number":6}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"12","item_id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","logprobs":[],"obfuscation":"VFpY8roo0wuwS5","output_index":0,"sequence_number":7}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" equals","item_id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","logprobs":[],"obfuscation":"TvAzQMn27","output_index":0,"sequence_number":8}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","logprobs":[],"obfuscation":"tY2thbMMHjJxOPK","output_index":0,"sequence_number":9}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"24","item_id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","logprobs":[],"obfuscation":"psa3FOfWJuRwzj","output_index":0,"sequence_number":10}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","logprobs":[],"obfuscation":"6Kz9RzB2OWBitTw","output_index":0,"sequence_number":11}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","logprobs":[],"output_index":0,"sequence_number":12,"text":"12
+        + 12 equals 24."}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"12
+        + 12 equals 24."},"sequence_number":13}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","item":{"id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"12
+        + 12 equals 24."}],"role":"assistant"},"output_index":0,"sequence_number":14}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","response":{"id":"resp_0a40f73a58d34b0a0069b2f660759c81909d55d9e3578e1752","object":"response","created_at":1773336160,"status":"completed","background":false,"completed_at":1773336160,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_0a40f73a58d34b0a0069b2f660d368819081d0ec1f87fc98ac","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"12
+        + 12 equals 24."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":14,"input_tokens_details":{"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":23},"user":null,"metadata":{}},"sequence_number":15}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9db47b7a98cdddff-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Thu, 12 Mar 2026 17:22:40 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '73'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=RYOqiA7_Mk4v43pNYdV9vLiC6RBKeJLfyAC2Fpa0LpA-1773336160.419359-1.0.1.1-XspDOXp5ZyNSenpfxnwUD9L5ReneUURCBPDH2E65MYv4IfRsKX9.pIQKPUCiGRxHUaLu4wQMOM8m27Pc2aH._UbxCXyQajbc2ufI5qkCGOgPh9n8gOcDPIscAusytUPk;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 12 Mar 2026
+        17:52:40 GMT
+      x-request-id:
+      - req_9cc89e4fa3b148d2b5f1b2a1fe767a51
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_create_stream_async.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_create_stream_async.yaml
@@ -1,0 +1,330 @@
+interactions:
+- request:
+    body: '{"input":"What''s 12 + 12?","model":"gpt-4o-mini","stream":true}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '63'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - AsyncOpenAI/Python 2.26.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.26.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","response":{"id":"resp_090ed39e879ee9370069b2fcd615088197a22fd1d40096a427","object":"response","created_at":1773337814,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","response":{"id":"resp_090ed39e879ee9370069b2fcd615088197a22fd1d40096a427","object":"response","created_at":1773337814,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","item":{"id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"12","item_id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","logprobs":[],"obfuscation":"lmLeZPrC5KpH95","output_index":0,"sequence_number":4}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" +","item_id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","logprobs":[],"obfuscation":"mlONf6sbJ0lgLK","output_index":0,"sequence_number":5}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","logprobs":[],"obfuscation":"JYlbUbusCpbja2C","output_index":0,"sequence_number":6}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"12","item_id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","logprobs":[],"obfuscation":"0omNUqlDWyz1Xh","output_index":0,"sequence_number":7}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" equals","item_id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","logprobs":[],"obfuscation":"fiFYDN0Yc","output_index":0,"sequence_number":8}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","logprobs":[],"obfuscation":"2hkYatqyVyZK8a3","output_index":0,"sequence_number":9}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"24","item_id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","logprobs":[],"obfuscation":"C1jwPBapGudnBl","output_index":0,"sequence_number":10}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","logprobs":[],"obfuscation":"cuV8KuUpM5ZDMpc","output_index":0,"sequence_number":11}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","logprobs":[],"output_index":0,"sequence_number":12,"text":"12
+        + 12 equals 24."}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"12
+        + 12 equals 24."},"sequence_number":13}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","item":{"id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"12
+        + 12 equals 24."}],"role":"assistant"},"output_index":0,"sequence_number":14}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","response":{"id":"resp_090ed39e879ee9370069b2fcd615088197a22fd1d40096a427","object":"response","created_at":1773337814,"status":"completed","background":false,"completed_at":1773337815,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_090ed39e879ee9370069b2fcd6da608197be8e443512903fba","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"12
+        + 12 equals 24."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":14,"input_tokens_details":{"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":23},"user":null,"metadata":{}},"sequence_number":15}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9db4a3d7dd71cef1-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Thu, 12 Mar 2026 17:50:14 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '50'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=CCJpEpH_vMN1Eq4f9d06ZRc.5c0_Rl8Ow7CFJOO2hf8-1773337813.7360198-1.0.1.1-K2SffBOWS0lIVNLBnyCMoyKZz5ZVSfOyeidF8mYW3Bk7n30hzJBij_yLZI46XnN7eKWGTdJPiPGyYQbWCuIiqp_rL.glumIWer8wA0.jEjGpAfBg5iAZb49lUBS0PYyR;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 12 Mar 2026
+        18:20:14 GMT
+      x-request-id:
+      - req_7bc4bbcecdb044e58ed7880f902e6575
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"input":"What''s 12 + 12?","model":"gpt-4o-mini","stream":true}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '63'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - AsyncOpenAI/Python 2.26.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.26.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","response":{"id":"resp_0a7628a631f7f65a0069b2fcd7a0d881978cb45138f353d127","object":"response","created_at":1773337815,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","response":{"id":"resp_0a7628a631f7f65a0069b2fcd7a0d881978cb45138f353d127","object":"response","created_at":1773337815,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","item":{"id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"12","item_id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","logprobs":[],"obfuscation":"3ISMash7bh9RkJ","output_index":0,"sequence_number":4}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" +","item_id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","logprobs":[],"obfuscation":"4Rvq1eztXDDc3m","output_index":0,"sequence_number":5}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","logprobs":[],"obfuscation":"0l2DlYQ6zA8Tqml","output_index":0,"sequence_number":6}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"12","item_id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","logprobs":[],"obfuscation":"3Ikb59XOvcPjAk","output_index":0,"sequence_number":7}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" equals","item_id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","logprobs":[],"obfuscation":"QT3Pz0Jmf","output_index":0,"sequence_number":8}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","logprobs":[],"obfuscation":"mTi9j1rgMkeMTHS","output_index":0,"sequence_number":9}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"24","item_id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","logprobs":[],"obfuscation":"E6wsGMmckSLnIP","output_index":0,"sequence_number":10}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","logprobs":[],"obfuscation":"YbPrE6695wPntWr","output_index":0,"sequence_number":11}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","logprobs":[],"output_index":0,"sequence_number":12,"text":"12
+        + 12 equals 24."}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"12
+        + 12 equals 24."},"sequence_number":13}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","item":{"id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"12
+        + 12 equals 24."}],"role":"assistant"},"output_index":0,"sequence_number":14}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","response":{"id":"resp_0a7628a631f7f65a0069b2fcd7a0d881978cb45138f353d127","object":"response","created_at":1773337815,"status":"completed","background":false,"completed_at":1773337816,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_0a7628a631f7f65a0069b2fcd8578081978bb9f5804324fa2a","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"12
+        + 12 equals 24."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":14,"input_tokens_details":{"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":23},"user":null,"metadata":{}},"sequence_number":15}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9db4a3e17c4f1949-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Thu, 12 Mar 2026 17:50:15 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '52'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=czZKK9fU1x23wgdZ0mZTJbvitID8avnTdkvV39DUC2Y-1773337815.2749774-1.0.1.1-TVbeeClbCzGvGA2zwh_VbTS0cIloCY00GXhXmRENIhoB126nhV2btKmQgl_s7UrWPt1jOytVuRAMwnvti5yDb5JqLUb5G4Xl5Q.fnkf2rsdCdwb.90QWYTK07ie.UDD1;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 12 Mar 2026
+        18:20:15 GMT
+      x-request-id:
+      - req_8576123e1adc4e23aed1b068d921d82c
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_parse.yaml
+++ b/py/src/braintrust/wrappers/cassettes/test_openai_responses_with_raw_response_parse.yaml
@@ -1,0 +1,246 @@
+interactions:
+- request:
+    body: '{"input":"What''s 12 + 12?","model":"gpt-4o-mini","text":{"format":{"type":"json_schema","strict":true,"name":"NumberAnswer","schema":{"properties":{"value":{"title":"Value","type":"integer"},"reasoning":{"title":"Reasoning","type":"string"}},"required":["value","reasoning"],"title":"NumberAnswer","type":"object","additionalProperties":false}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '346'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - OpenAI/Python 2.26.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.26.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: "{\n  \"id\": \"resp_0151f6d0efba1ece0069b210ccda34819aa67613ea39bc147f\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1773277388,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1773277389,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        null,\n  \"max_output_tokens\": null,\n  \"max_tool_calls\": null,\n  \"model\":
+        \"gpt-4o-mini-2024-07-18\",\n  \"output\": [\n    {\n      \"id\": \"msg_0151f6d0efba1ece0069b210cd969c819a8c83daafcc25e0cf\",\n
+        \     \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\":
+        [\n        {\n          \"type\": \"output_text\",\n          \"annotations\":
+        [],\n          \"logprobs\": [],\n          \"text\": \"{\\\"value\\\":24,\\\"reasoning\\\":\\\"Adding
+        12 and 12 together gives 24.\\\"}\"\n        }\n      ],\n      \"role\":
+        \"assistant\"\n    }\n  ],\n  \"parallel_tool_calls\": true,\n  \"presence_penalty\":
+        0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\": null,\n  \"prompt_cache_retention\":
+        null,\n  \"reasoning\": {\n    \"effort\": null,\n    \"summary\": null\n
+        \ },\n  \"safety_identifier\": null,\n  \"service_tier\": \"default\",\n  \"store\":
+        true,\n  \"temperature\": 1.0,\n  \"text\": {\n    \"format\": {\n      \"type\":
+        \"json_schema\",\n      \"description\": null,\n      \"name\": \"NumberAnswer\",\n
+        \     \"schema\": {\n        \"properties\": {\n          \"value\": {\n            \"title\":
+        \"Value\",\n            \"type\": \"integer\"\n          },\n          \"reasoning\":
+        {\n            \"title\": \"Reasoning\",\n            \"type\": \"string\"\n
+        \         }\n        },\n        \"required\": [\n          \"value\",\n          \"reasoning\"\n
+        \       ],\n        \"title\": \"NumberAnswer\",\n        \"type\": \"object\",\n
+        \       \"additionalProperties\": false\n      },\n      \"strict\": true\n
+        \   },\n    \"verbosity\": \"medium\"\n  },\n  \"tool_choice\": \"auto\",\n
+        \ \"tools\": [],\n  \"top_logprobs\": 0,\n  \"top_p\": 1.0,\n  \"truncation\":
+        \"disabled\",\n  \"usage\": {\n    \"input_tokens\": 59,\n    \"input_tokens_details\":
+        {\n      \"cached_tokens\": 0\n    },\n    \"output_tokens\": 21,\n    \"output_tokens_details\":
+        {\n      \"reasoning_tokens\": 0\n    },\n    \"total_tokens\": 80\n  },\n
+        \ \"user\": null,\n  \"metadata\": {}\n}"
+    headers:
+      CF-RAY:
+      - 9daee09e78ce78eb-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 12 Mar 2026 01:03:10 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '2109'
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '1233'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=OYwZhCEObJaBQoGETh7N0iwuDojPhYhQHpp8_3Isfvc-1773277388.5575202-1.0.1.1-UxMNGJICox_cTodiuNh1lA1KHMR2dmyZ0EMrkNa.1pOpyfnbZ9alWEWZCFYpJUXvYtEwtNsq83VyIQjPyx.uKw0RV8CoU3LfjUeq1kFMuleZtm327G0fbv.UvdEPFQ7j;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 12 Mar 2026
+        01:33:10 GMT
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999922'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_7f37b46a02c64786a9d42d12777ffcf4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"input":"What''s 12 + 12?","model":"gpt-4o-mini","text":{"format":{"type":"json_schema","strict":true,"name":"NumberAnswer","schema":{"properties":{"value":{"title":"Value","type":"integer"},"reasoning":{"title":"Reasoning","type":"string"}},"required":["value","reasoning"],"title":"NumberAnswer","type":"object","additionalProperties":false}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '346'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - OpenAI/Python 2.26.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.26.0
+      X-Stainless-Raw-Response:
+      - 'true'
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: "{\n  \"id\": \"resp_0851778f1ce88e420069b210cf8d4c819aaefb002fba9fa4cb\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1773277391,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1773277392,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        null,\n  \"max_output_tokens\": null,\n  \"max_tool_calls\": null,\n  \"model\":
+        \"gpt-4o-mini-2024-07-18\",\n  \"output\": [\n    {\n      \"id\": \"msg_0851778f1ce88e420069b210d09a54819a87fb4fbd3abf1b64\",\n
+        \     \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\":
+        [\n        {\n          \"type\": \"output_text\",\n          \"annotations\":
+        [],\n          \"logprobs\": [],\n          \"text\": \"{\\\"value\\\":24,\\\"reasoning\\\":\\\"Adding
+        12 and 12 together results in 24.\\\"}\"\n        }\n      ],\n      \"role\":
+        \"assistant\"\n    }\n  ],\n  \"parallel_tool_calls\": true,\n  \"presence_penalty\":
+        0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\": null,\n  \"prompt_cache_retention\":
+        null,\n  \"reasoning\": {\n    \"effort\": null,\n    \"summary\": null\n
+        \ },\n  \"safety_identifier\": null,\n  \"service_tier\": \"default\",\n  \"store\":
+        true,\n  \"temperature\": 1.0,\n  \"text\": {\n    \"format\": {\n      \"type\":
+        \"json_schema\",\n      \"description\": null,\n      \"name\": \"NumberAnswer\",\n
+        \     \"schema\": {\n        \"properties\": {\n          \"value\": {\n            \"title\":
+        \"Value\",\n            \"type\": \"integer\"\n          },\n          \"reasoning\":
+        {\n            \"title\": \"Reasoning\",\n            \"type\": \"string\"\n
+        \         }\n        },\n        \"required\": [\n          \"value\",\n          \"reasoning\"\n
+        \       ],\n        \"title\": \"NumberAnswer\",\n        \"type\": \"object\",\n
+        \       \"additionalProperties\": false\n      },\n      \"strict\": true\n
+        \   },\n    \"verbosity\": \"medium\"\n  },\n  \"tool_choice\": \"auto\",\n
+        \ \"tools\": [],\n  \"top_logprobs\": 0,\n  \"top_p\": 1.0,\n  \"truncation\":
+        \"disabled\",\n  \"usage\": {\n    \"input_tokens\": 59,\n    \"input_tokens_details\":
+        {\n      \"cached_tokens\": 0\n    },\n    \"output_tokens\": 22,\n    \"output_tokens_details\":
+        {\n      \"reasoning_tokens\": 0\n    },\n    \"total_tokens\": 81\n  },\n
+        \ \"user\": null,\n  \"metadata\": {}\n}"
+    headers:
+      CF-RAY:
+      - 9daee0ad8a1f1576-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 12 Mar 2026 01:03:13 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '2114'
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '1598'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=.MV7tMc3yN.sx_welIv7zFgKUNDGi.7P4uEM4brdcf4-1773277390.9660673-1.0.1.1-.CuB1pX4fk5NJMJ_DrnKBh5bIm0LwHMwuhRhtkmkyv3k.8gppiZxFYusmftSU.dQ6TOsc9RAiTLdCnwbQUb6hhS.7KnrdLKGHgtCVfYZ.gWwjNiv_8Tjf1HeYMU7Gbwq;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 12 Mar 2026
+        01:33:13 GMT
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999922'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_575b502ef7604fd3a3653f50a9fc8ccb
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/wrappers/test_openai.py
+++ b/py/src/braintrust/wrappers/test_openai.py
@@ -378,6 +378,7 @@ def test_openai_responses_sparse_indices(memory_logger):
     # No spans should be generated from this unit test
     assert not memory_logger.pop()
 
+
 @pytest.mark.vcr
 def test_openai_embeddings(memory_logger):
     assert not memory_logger.pop()
@@ -1211,6 +1212,241 @@ def test_openai_responses_not_given_filtering(memory_logger):
 
 
 @pytest.mark.vcr
+def test_openai_responses_with_raw_response_create(memory_logger):
+    """Test that with_raw_response.create returns HTTP response headers AND generates a tracing span."""
+    assert not memory_logger.pop()
+
+    # Unwrapped client: with_raw_response should work but produce no spans.
+    unwrapped_client = openai.OpenAI()
+    raw = unwrapped_client.responses.with_raw_response.create(
+        model=TEST_MODEL,
+        input=TEST_PROMPT,
+        instructions="Just the number please",
+    )
+    assert raw.headers  # HTTP response headers are accessible
+    response = raw.parse()
+    assert response.output
+    content = response.output[0].content[0].text
+    assert "24" in content or "twenty-four" in content.lower()
+    assert not memory_logger.pop()
+
+    # Wrapped client: with_raw_response should ALSO generate a span.
+    client = wrap_openai(openai.OpenAI())
+    start = time.time()
+    raw = client.responses.with_raw_response.create(
+        model=TEST_MODEL,
+        input=TEST_PROMPT,
+        instructions="Just the number please",
+    )
+    end = time.time()
+
+    # The raw HTTP response (with headers) must be returned to the caller.
+    assert raw.headers
+    response = raw.parse()
+    assert response.output
+    content = response.output[0].content[0].text
+    assert "24" in content or "twenty-four" in content.lower()
+
+    # A span must have been recorded with correct metrics and metadata.
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    metrics = span["metrics"]
+    assert_metrics_are_valid(metrics, start, end)
+    assert TEST_MODEL in span["metadata"]["model"]
+    assert span["metadata"]["provider"] == "openai"
+    assert TEST_PROMPT in str(span["input"])
+    assert len(span["output"]) > 0
+    span_content = span["output"][0]["content"][0]["text"]
+    assert "24" in span_content or "twenty-four" in span_content.lower()
+
+
+@pytest.mark.vcr
+def test_openai_responses_with_raw_response_create_stream(memory_logger):
+    """Test that with_raw_response.create with stream=True returns headers AND generates a tracing span."""
+    assert not memory_logger.pop()
+
+    # Unwrapped client: headers accessible, stream iterable via parse(), no spans.
+    unwrapped_client = openai.OpenAI()
+    raw = unwrapped_client.responses.with_raw_response.create(
+        model=TEST_MODEL,
+        input=TEST_PROMPT,
+        stream=True,
+    )
+    assert raw.headers
+    chunks = []
+    for chunk in raw.parse():
+        if chunk.type == "response.output_text.delta":
+            chunks.append(chunk.delta)
+    assert "24" in "".join(chunks) or "twenty-four" in "".join(chunks).lower()
+    assert not memory_logger.pop()
+
+    # Wrapped client: headers still accessible, parse() yields traced stream, span generated.
+    client = wrap_openai(openai.OpenAI())
+    start = time.time()
+    raw = client.responses.with_raw_response.create(
+        model=TEST_MODEL,
+        input=TEST_PROMPT,
+        stream=True,
+    )
+    assert raw.headers
+    stream = raw.parse()
+    assert stream.response  # SDK-specific attribute preserved
+    chunks = []
+    for chunk in stream:
+        if chunk.type == "response.output_text.delta":
+            chunks.append(chunk.delta)
+    end = time.time()
+    assert "24" in "".join(chunks) or "twenty-four" in "".join(chunks).lower()
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    metrics = span["metrics"]
+    assert_metrics_are_valid(metrics, start, end)
+    assert span["metadata"]["stream"] == True
+    assert TEST_MODEL in span["metadata"]["model"]
+    assert TEST_PROMPT in str(span["input"])
+    assert "24" in str(span["output"]) or "twenty-four" in str(span["output"]).lower()
+
+
+@pytest.mark.vcr
+def test_openai_responses_with_raw_response_parse(memory_logger):
+    """Test that with_raw_response.parse returns HTTP response headers AND generates a tracing span."""
+    assert not memory_logger.pop()
+
+    class NumberAnswer(BaseModel):
+        value: int
+        reasoning: str
+
+    unwrapped_client = openai.OpenAI()
+    raw_parse = unwrapped_client.responses.with_raw_response.parse(
+        model=TEST_MODEL, input=TEST_PROMPT, text_format=NumberAnswer
+    )
+    assert raw_parse.headers
+    parse_response = raw_parse.parse()
+    assert parse_response.output_parsed
+    assert parse_response.output_parsed.value == 24
+    assert not memory_logger.pop()
+
+    client = wrap_openai(openai.OpenAI())
+    start = time.time()
+    raw_parse = client.responses.with_raw_response.parse(model=TEST_MODEL, input=TEST_PROMPT, text_format=NumberAnswer)
+    end = time.time()
+
+    assert raw_parse.headers
+    parse_response = raw_parse.parse()
+    assert parse_response.output_parsed
+    assert parse_response.output_parsed.value == 24
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    metrics = span["metrics"]
+    assert_metrics_are_valid(metrics, start, end)
+    assert TEST_MODEL in span["metadata"]["model"]
+    assert span["metadata"]["provider"] == "openai"
+    assert TEST_PROMPT in str(span["input"])
+    assert span["output"][0]["content"][0]["parsed"]["value"] == 24
+
+
+@pytest.mark.asyncio
+@pytest.mark.vcr
+async def test_openai_responses_with_raw_response_async(memory_logger):
+    """Async version of test_openai_responses_with_raw_response."""
+    assert not memory_logger.pop()
+
+    unwrapped_client = AsyncOpenAI()
+    raw = await unwrapped_client.responses.with_raw_response.create(
+        model=TEST_MODEL,
+        input=TEST_PROMPT,
+        instructions="Just the number please",
+    )
+    assert raw.headers
+    response = raw.parse()
+    assert response.output
+    content = response.output[0].content[0].text
+    assert "24" in content or "twenty-four" in content.lower()
+    assert not memory_logger.pop()
+
+    client = wrap_openai(AsyncOpenAI())
+    start = time.time()
+    raw = await client.responses.with_raw_response.create(
+        model=TEST_MODEL,
+        input=TEST_PROMPT,
+        instructions="Just the number please",
+    )
+    end = time.time()
+
+    assert raw.headers
+    response = raw.parse()
+    assert response.output
+    content = response.output[0].content[0].text
+    assert "24" in content or "twenty-four" in content.lower()
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    metrics = span["metrics"]
+    assert_metrics_are_valid(metrics, start, end)
+    assert TEST_MODEL in span["metadata"]["model"]
+    assert TEST_PROMPT in str(span["input"])
+    assert len(span["output"]) > 0
+    span_content = span["output"][0]["content"][0]["text"]
+    assert "24" in span_content or "twenty-four" in span_content.lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.vcr
+async def test_openai_responses_with_raw_response_create_stream_async(memory_logger):
+    """Async version of test_openai_responses_with_raw_response_create_stream."""
+    assert not memory_logger.pop()
+
+    # Unwrapped client: headers accessible, stream iterable via parse(), no spans.
+    unwrapped_client = AsyncOpenAI()
+    raw = await unwrapped_client.responses.with_raw_response.create(
+        model=TEST_MODEL,
+        input=TEST_PROMPT,
+        stream=True,
+    )
+    assert raw.headers
+    chunks = []
+    async for chunk in raw.parse():
+        if chunk.type == "response.output_text.delta":
+            chunks.append(chunk.delta)
+    assert "24" in "".join(chunks) or "twenty-four" in "".join(chunks).lower()
+    assert not memory_logger.pop()
+
+    # Wrapped client: headers still accessible, parse() yields traced stream, span generated.
+    client = wrap_openai(AsyncOpenAI())
+    start = time.time()
+    raw = await client.responses.with_raw_response.create(
+        model=TEST_MODEL,
+        input=TEST_PROMPT,
+        stream=True,
+    )
+    assert raw.headers
+    stream = raw.parse()
+    assert stream.response  # SDK-specific attribute preserved
+    chunks = []
+    async for chunk in stream:
+        if chunk.type == "response.output_text.delta":
+            chunks.append(chunk.delta)
+    end = time.time()
+    assert "24" in "".join(chunks) or "twenty-four" in "".join(chunks).lower()
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    metrics = span["metrics"]
+    assert_metrics_are_valid(metrics, start, end)
+    assert span["metadata"]["stream"] == True
+    assert TEST_MODEL in span["metadata"]["model"]
+    assert TEST_PROMPT in str(span["input"])
+    assert "24" in str(span["output"]) or "twenty-four" in str(span["output"]).lower()
+
+
+@pytest.mark.vcr
 def test_openai_parallel_tool_calls(memory_logger):
     """Test parallel tool calls with both streaming and non-streaming modes."""
     assert not memory_logger.pop()
@@ -1934,6 +2170,7 @@ class TestAutoInstrumentOpenAI:
     def test_auto_instrument_openai(self):
         """Test auto_instrument patches OpenAI, creates spans, and uninstrument works."""
         verify_autoinstrument_script("test_auto_openai.py")
+
 
 class TestZAICompatibleOpenAI:
     """Tests for validating some ZAI compatibility with OpenAI wrapper."""


### PR DESCRIPTION
fix #36
openai.Client().responses.with_raw_response now has tracing.

PR seems to be very large but most of it is due to the VCR (and a bit of formatting).

3 new classes in oai.py to support raw responses, and slightly adapting other functions to recognize raw responses and use the correct classes.

When returning a raw response and streaming it, _TracedStream and _AsyncTracedStream are used to wrap a traced generator while preserving the OpenAI methods of the original OpenAI stream object, otherwise a python generator gen() would be returned.
Can be removed if deemed not necessary.