### PR TITLE
fix: Make agno rely on provider attribute

### DIFF
--- a/py/src/braintrust/wrappers/agno/model.py
+++ b/py/src/braintrust/wrappers/agno/model.py
@@ -310,6 +310,9 @@ def wrap_model(Model: Any) -> Any:
 
 
 def _get_model_name(instance: Any) -> str:
+    provider = getattr(instance, "provider", None)
+    if provider:
+        return str(provider)
     if hasattr(instance, "get_provider") and callable(instance.get_provider):
         return str(instance.get_provider())
     return getattr(instance.__class__, "__name__", "Model")

--- a/py/src/braintrust/wrappers/agno/test_agno.py
+++ b/py/src/braintrust/wrappers/agno/test_agno.py
@@ -11,6 +11,7 @@ from braintrust import logger
 from braintrust.logger import start_span
 from braintrust.test_helpers import init_test_logger
 from braintrust.wrappers.agno import agent as agno_agent_module
+from braintrust.wrappers.agno import model as agno_model_module
 from braintrust.wrappers.agno import run_helpers as agno_run_helpers_module
 from braintrust.wrappers.agno import setup_agno
 from braintrust.wrappers.agno import team as agno_team_module
@@ -110,6 +111,16 @@ def test_agno_simple_agent_execution(memory_logger):
     assert llm_span["metrics"]["prompt_tokens"] == 38
     assert llm_span["metrics"]["completion_tokens"] == 4
     assert llm_span["metrics"]["tokens"] == 42
+
+
+def test_get_model_name_prefers_stable_provider_attribute():
+    class FakeModel:
+        provider = "OpenAI"
+
+        def get_provider(self):
+            return "OpenAI Chat"
+
+    assert agno_model_module._get_model_name(FakeModel()) == "OpenAI"
 
 
 class TestAutoInstrumentAgno:


### PR DESCRIPTION
Generated completely with codex:

The breakage was in `test_agno(latest)` from the GitHub Actions run on March 17, 2026. Agno’s current latest release changed `OpenAIChat.get_provider()` from `"OpenAI"` to `"OpenAI Chat"`, which made our wrapper rename the LLM span from `OpenAI.response` to `OpenAI Chat.response` and broke the hard-coded assertion.

I fixed it by making the Agno wrapper prefer the stable `provider` attribute for span naming in `model.py`, and I added a regression test in `test_agno.py` to lock that behavior in.

Verified locally with:
- `cd py && nox -s "test_agno(latest)"`
- `cd py && nox -s "test_agno(2.1.0)"`

Both passed.