### PR TITLE
fix(anthropic): capture thinking config in span metadata

### DIFF
--- a/py/src/braintrust/wrappers/anthropic.py
+++ b/py/src/braintrust/wrappers/anthropic.py
@@ -37,6 +37,7 @@ METADATA_PARAMS = (
     "tool_choice",
     "tools",
     "stream",
+    "thinking",
 )
 
 


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk-python/issues/107