### PR TITLE
fix(devserver): add x-bt-use-gateway to CORS allowed headers

### DIFF
--- a/py/src/braintrust/devserver/cors.py
+++ b/py/src/braintrust/devserver/cors.py
@@ -23,6 +23,7 @@ ALLOWED_HEADERS = [
     "x-bt-project-id",
     "x-bt-stream-fmt",
     "x-bt-use-cache",
+    "x-bt-use-gateway",
     "x-stainless-os",
     "x-stainless-lang",
     "x-stainless-package-version",

--- a/py/src/braintrust/devserver/test_server_integration.py
+++ b/py/src/braintrust/devserver/test_server_integration.py
@@ -87,6 +87,28 @@ def test_devserver_health_check(client):
     assert response.text == "Hello, world!"
 
 
+def test_cors_preflight_allows_gateway_header(client):
+    """Test that CORS preflight accepts x-bt-use-gateway header.
+
+    The Braintrust Playground sends this header when gateway routing is
+    enabled.  If it is missing from the devserver's allowed-headers list
+    the browser blocks the actual request with a CORS error.
+    """
+    response = client.options(
+        "/eval",
+        headers={
+            "origin": "https://www.braintrust.dev",
+            "access-control-request-method": "POST",
+            "access-control-request-headers": "x-bt-use-gateway",
+        },
+    )
+    assert response.status_code == 200
+    allowed = response.headers.get("access-control-allow-headers", "")
+    assert "x-bt-use-gateway" in allowed, (
+        f"x-bt-use-gateway not found in access-control-allow-headers: {allowed}"
+    )
+
+
 @pytest.mark.vcr
 def test_devserver_list_evaluators(client, api_key, org_name):
     """Test listing evaluators endpoint."""


### PR DESCRIPTION
## Summary

- Add `x-bt-use-gateway` to `ALLOWED_HEADERS` in the Python devserver CORS config, matching what `api-ts/src/cors.ts` already allows
- Add a test that verifies CORS preflight accepts this header

## Context

The Braintrust Playground sends `x-bt-use-gateway: true` when gateway routing is enabled. The main data plane (`api-ts`) added this header to its CORS allowlist in Feb (commit `ee5f4f65e0`), but the Python SDK devserver was never updated to match.

This causes browsers to block preflight `OPTIONS` requests to any remote eval server built on `braintrust.devserver`, with an error like:

```
Request header field x-bt-use-gateway is not allowed by Access-Control-Allow-Headers
```

Multiple demo projects (`pydantic-supervisor`, `langgraph-supervisor`, `google-adk-supervisor`) independently worked around this by monkey-patching `bt_cors.ALLOWED_HEADERS` at startup. This fix addresses it at the source.

## Test plan

- [x] New test `test_cors_preflight_allows_gateway_header` sends an OPTIONS request with `x-bt-use-gateway` and asserts it appears in the response's `access-control-allow-headers`
- [x] All existing devserver integration tests continue to pass