### PR TITLE
chore: Fix broken lint in devserver tests

### DIFF
--- a/py/src/braintrust/devserver/test_server_integration.py
+++ b/py/src/braintrust/devserver/test_server_integration.py
@@ -104,9 +104,7 @@ def test_cors_preflight_allows_gateway_header(client):
     )
     assert response.status_code == 200
     allowed = response.headers.get("access-control-allow-headers", "")
-    assert "x-bt-use-gateway" in allowed, (
-        f"x-bt-use-gateway not found in access-control-allow-headers: {allowed}"
-    )
+    assert "x-bt-use-gateway" in allowed, f"x-bt-use-gateway not found in access-control-allow-headers: {allowed}"
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
https://github.com/braintrustdata/braintrust-sdk-python/pull/119 left lints being broken. This fixes that.