### PR TITLE
google_genai and pydantic init_logger no longer unconditionally called during auto_instrument

### DIFF
--- a/py/src/braintrust/integrations/adk/__init__.py
+++ b/py/src/braintrust/integrations/adk/__init__.py
@@ -3,7 +3,7 @@
 import logging
 import warnings
 
-from braintrust.logger import NOOP_SPAN, current_span, init_logger
+from braintrust.logger import NOOP_SPAN, current_logger, current_span, init_logger
 
 from .integration import ADKIntegration
 from .patchers import (
@@ -56,7 +56,7 @@ def setup_adk(
         warnings.warn("SpanProcessor parameter is deprecated and will be ignored", DeprecationWarning, stacklevel=2)
 
     span = current_span()
-    if span == NOOP_SPAN:
+    if span == NOOP_SPAN and current_logger() is None:
         init_logger(project=project_name, api_key=api_key, project_id=project_id)
 
     return ADKIntegration.setup()

--- a/py/src/braintrust/integrations/agno/__init__.py
+++ b/py/src/braintrust/integrations/agno/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from braintrust.logger import NOOP_SPAN, current_span, init_logger
+from braintrust.logger import NOOP_SPAN, current_logger, current_span, init_logger
 
 from .integration import AgnoIntegration
 from .patchers import (
@@ -44,7 +44,7 @@ def setup_agno(
         True if setup was successful, False otherwise
     """
     span = current_span()
-    if span == NOOP_SPAN:
+    if span == NOOP_SPAN and current_logger() is None:
         init_logger(project=project_name, api_key=api_key, project_id=project_id)
 
     return AgnoIntegration.setup()

--- a/py/src/braintrust/integrations/claude_agent_sdk/__init__.py
+++ b/py/src/braintrust/integrations/claude_agent_sdk/__init__.py
@@ -16,7 +16,7 @@ Usage (imports can be before or after setup):
 
 import logging
 
-from braintrust.logger import NOOP_SPAN, current_span, init_logger
+from braintrust.logger import NOOP_SPAN, current_logger, current_span, init_logger
 
 from .integration import ClaudeAgentSDKIntegration
 
@@ -58,7 +58,7 @@ def setup_claude_agent_sdk(
         ```
     """
     span = current_span()
-    if span == NOOP_SPAN:
+    if span == NOOP_SPAN and current_logger() is None:
         init_logger(project=project, api_key=api_key, project_id=project_id)
 
     return ClaudeAgentSDKIntegration.setup()

--- a/py/src/braintrust/integrations/google_genai/__init__.py
+++ b/py/src/braintrust/integrations/google_genai/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from braintrust.logger import NOOP_SPAN, current_span, init_logger
+from braintrust.logger import NOOP_SPAN, current_logger, current_span, init_logger
 
 from .integration import GoogleGenAIIntegration
 
@@ -33,7 +33,7 @@ def setup_genai(
         True if setup was successful, False if google-genai is not installed.
     """
     span = current_span()
-    if span == NOOP_SPAN:
+    if span == NOOP_SPAN and current_logger() is None:
         init_logger(project=project_name, api_key=api_key, project_id=project_id)
 
     return GoogleGenAIIntegration.setup()

--- a/py/src/braintrust/wrappers/pydantic_ai.py
+++ b/py/src/braintrust/wrappers/pydantic_ai.py
@@ -7,7 +7,7 @@ from contextlib import AbstractAsyncContextManager
 from typing import Any
 
 from braintrust.bt_json import bt_safe_deep_copy
-from braintrust.logger import NOOP_SPAN, Attachment, current_span, init_logger, start_span
+from braintrust.logger import NOOP_SPAN, Attachment, current_logger, current_span, init_logger, start_span
 from braintrust.span_types import SpanTypeAttribute
 from wrapt import wrap_function_wrapper
 
@@ -34,7 +34,7 @@ def setup_pydantic_ai(
         bool: True if setup was successful, False otherwise.
     """
     span = current_span()
-    if span == NOOP_SPAN:
+    if span == NOOP_SPAN and current_logger() is None:
         init_logger(project=project_name, api_key=api_key, project_id=project_id)
 
     try:


### PR DESCRIPTION
Fix https://github.com/braintrustdata/braintrust-sdk-python/issues/168

```diff
-    if span == NOOP_SPAN:
+    if span == NOOP_SPAN and current_logger() is None:
```
5 times (plus the import).

init_logger was called when there was no active span without checking for a logger.