### PR TITLE
Fix python sandbox parameters

### DIFF
--- a/py/src/braintrust/cli/push.py
+++ b/py/src/braintrust/cli/push.py
@@ -22,7 +22,7 @@ from braintrust.framework import _evals, _scorer_name, _set_lazy_load
 from .. import api_conn, login, org_id, proxy_conn
 from ..framework2 import ProjectIdCache, global_
 from ..generated_types import IfExists
-from ..parameters import parameters_to_json_schema
+from ..parameters import serialize_remote_eval_parameters_container
 from ..util import add_azure_blob_headers
 
 
@@ -289,7 +289,7 @@ def _collect_evaluator_defs(
         scores = [{"name": _scorer_name(scorer, i)} for i, scorer in enumerate(evaluator.scores)]
         evaluator_definition: dict[str, Any] = {"scores": scores}
         if evaluator.parameters is not None:
-            evaluator_definition["parameters"] = parameters_to_json_schema(evaluator.parameters)
+            evaluator_definition["parameters"] = serialize_remote_eval_parameters_container(evaluator.parameters)
 
         functions.append(
             {

--- a/py/src/braintrust/cli/test_push_evaluator.py
+++ b/py/src/braintrust/cli/test_push_evaluator.py
@@ -92,8 +92,11 @@ class TestCollectEvaluatorDefs:
         _collect_evaluator_defs(mock_project_ids, functions, "bundle-1", "replace", "eval.py", evaluators)
 
         eval_def = functions[0]["function_data"]["data"]["location"]["evaluator_definition"]
-        assert "parameters" in eval_def
         assert "scores" in eval_def
+        parameters = eval_def["parameters"]
+        assert parameters["type"] == "braintrust.staticParameters"
+        assert parameters["source"] is None
+        assert parameters["schema"]["prompt"]["type"] == "prompt"
 
     def test_slug_from_source_file(self, mock_project_ids):
         evaluators = {"Test Eval": _make_evaluator("test-project", ["accuracy"])}


### PR DESCRIPTION
Sandbox parameters were getting serialized incorrectly which was breaking the playground UI. this fixes the issue so python sandboxes with parameters now load in the playground UI correctly. 