### PR TITLE
include sandbox runtime in list request

### DIFF
--- a/py/src/braintrust/sandbox.py
+++ b/py/src/braintrust/sandbox.py
@@ -107,6 +107,7 @@ def register_sandbox(
                 "provider": sandbox.provider,
                 "snapshot_ref": sandbox.snapshot_ref,
             },
+            "runtime_context": runtime_context,
             "entrypoints": entrypoints,
             "project_id": project_id,
         },


### PR DESCRIPTION
In order to add support for python based sandboxes we need to pass the runtime into the list request. The change is backwards compatible and the value will be stripped on out of date data plane versions. 