### PR TITLE
fix(cli): reject whitespace in python bundle filenames

### DIFF
--- a/py/src/braintrust/cli/push.py
+++ b/py/src/braintrust/cli/push.py
@@ -140,6 +140,26 @@ def _run_install(install_args: list[str], packages_dir: str):
     )
 
 
+def _archive_source_path(source: str, archive_root: str) -> str:
+    return os.path.normpath(os.path.relpath(os.path.abspath(source), os.path.abspath(archive_root)))
+
+
+def _validate_python_archive_path(archive_path: str) -> None:
+    for component in archive_path.split(os.sep):
+        if any(ch.isspace() for ch in component):
+            raise ValueError(
+                "python bundle source path "
+                f"'{archive_path}' contains whitespace in path component '{component}'; "
+                "rename the file or directory before running `braintrust push`"
+            )
+
+
+def _validate_python_bundle_source_paths(sources: list[str], archive_root: str | None = None) -> None:
+    archive_root = archive_root or os.getcwd()
+    for source in sources:
+        _validate_python_archive_path(_archive_source_path(source, archive_root))
+
+
 def _upload_bundle(entry_module_name: str, sources: list[str], requirements: str | None) -> str:
     _check_uv()
 
@@ -369,6 +389,7 @@ def run(args):
     needs_bundle = len(global_.functions) > 0 or len(evaluators) > 0
     bundle_id = None
     if needs_bundle:
+        _validate_python_bundle_source_paths(sources)
         bundle_id = _upload_bundle(module_name, sources, args.requirements)
 
     if len(global_.functions) > 0:

--- a/py/src/braintrust/cli/push.py
+++ b/py/src/braintrust/cli/push.py
@@ -140,10 +140,6 @@ def _run_install(install_args: list[str], packages_dir: str):
     )
 
 
-def _archive_source_path(source: str, archive_root: str) -> str:
-    return os.path.normpath(os.path.relpath(os.path.abspath(source), os.path.abspath(archive_root)))
-
-
 def _validate_python_archive_path(archive_path: str) -> None:
     for component in archive_path.split(os.sep):
         if any(ch.isspace() for ch in component):
@@ -155,9 +151,10 @@ def _validate_python_archive_path(archive_path: str) -> None:
 
 
 def _validate_python_bundle_source_paths(sources: list[str], archive_root: str | None = None) -> None:
-    archive_root = archive_root or os.getcwd()
+    abs_root = os.path.abspath(archive_root or os.getcwd())
     for source in sources:
-        _validate_python_archive_path(_archive_source_path(source, archive_root))
+        archive_path = os.path.normpath(os.path.relpath(os.path.abspath(source), abs_root))
+        _validate_python_archive_path(archive_path)
 
 
 def _upload_bundle(entry_module_name: str, sources: list[str], requirements: str | None) -> str:

--- a/py/src/braintrust/cli/test_push.py
+++ b/py/src/braintrust/cli/test_push.py
@@ -118,3 +118,20 @@ class TestValidatePythonBundleSourcePaths:
     @pytest.mark.skipif(sys.platform == "win32", reason="leading-space filenames are not portable on Windows")
     def test_rejects_leading_whitespace_in_filename(self, tmp_path):
         self._assert_whitespace_in_filename_rejected(tmp_path, " tool.py")
+
+    def test_rejects_whitespace_in_directory_name(self, tmp_path):
+        subdir = tmp_path / "my tools"
+        subdir.mkdir()
+        source = subdir / "tool.py"
+        source.write_text("VALUE = 1\n")
+
+        with pytest.raises(ValueError, match="contains whitespace in path component"):
+            _validate_python_bundle_source_paths([str(source)], str(tmp_path))
+
+    def test_rejects_tab_in_filename(self, tmp_path):
+        self._assert_whitespace_in_filename_rejected(tmp_path, "my\ttool.py")
+
+    def test_accepts_valid_path(self, tmp_path):
+        source = tmp_path / "my_tool.py"
+        source.write_text("VALUE = 1\n")
+        _validate_python_bundle_source_paths([str(source)], str(tmp_path))

--- a/py/src/braintrust/cli/test_push.py
+++ b/py/src/braintrust/cli/test_push.py
@@ -128,6 +128,7 @@ class TestValidatePythonBundleSourcePaths:
         with pytest.raises(ValueError, match="contains whitespace in path component"):
             _validate_python_bundle_source_paths([str(source)], str(tmp_path))
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="tab characters in filenames are not allowed on Windows")
     def test_rejects_tab_in_filename(self, tmp_path):
         self._assert_whitespace_in_filename_rejected(tmp_path, "my\ttool.py")
 

--- a/py/src/braintrust/cli/test_push.py
+++ b/py/src/braintrust/cli/test_push.py
@@ -1,5 +1,7 @@
 """Tests for push command serialization."""
 
+import sys
+
 import pytest
 
 
@@ -9,7 +11,7 @@ from ..framework2 import (
     global_,
     projects,
 )
-from .push import _collect_function_function_defs
+from .push import _collect_function_function_defs, _validate_python_bundle_source_paths
 
 
 class ToolInput(pydantic.BaseModel):
@@ -100,3 +102,19 @@ class TestPushTags:
 
         assert len(functions) == 1
         assert "tags" not in functions[0]
+
+
+class TestValidatePythonBundleSourcePaths:
+    def _assert_whitespace_in_filename_rejected(self, tmp_path, filename: str):
+        source = tmp_path / filename
+        source.write_text("VALUE = 1\n")
+
+        with pytest.raises(ValueError, match="contains whitespace in path component"):
+            _validate_python_bundle_source_paths([str(source)], str(tmp_path))
+
+    def test_rejects_whitespace_in_filename(self, tmp_path):
+        self._assert_whitespace_in_filename_rejected(tmp_path, "my tool.py")
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="leading-space filenames are not portable on Windows")
+    def test_rejects_leading_whitespace_in_filename(self, tmp_path):
+        self._assert_whitespace_in_filename_rejected(tmp_path, " tool.py")


### PR DESCRIPTION
Fail fast in `braintrust push` when a bundled Python source path contains whitespace in any path component. These paths can be bundled successfully but are not safe to import via the generated bundle entrypoint, so rejecting them up front avoids a later runtime failure.

Add regression coverage for filenames with embedded whitespace and leading whitespace, with the leading-space case skipped on Windows where those filenames are not portable.

ref https://linear.app/braintrustdata/issue/BT-4686/whitespace-in-file-names-for-functions-cause-errors
See bt cli PR: https://github.com/braintrustdata/bt/pull/99