### PR TITLE
fix(framework): preserve defaults for unmatched callback params

### DIFF
--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -505,8 +505,13 @@ def _call_user_fn_args(fn, kwargs):
 
         if name in kwargs:
             final_kwargs[name] = kwargs.pop(name)
-        else:
-            next_arg = list(kwargs.keys())[0]
+        elif param.default is not inspect.Parameter.empty:
+            final_kwargs[name] = param.default
+        elif kwargs:
+            # Legacy positional fallback: assigns the next remaining kwarg to this
+            # param even though names don't match.  Remove in next major version and
+            # require param names to match Braintrust-provided kwarg names.
+            next_arg = next(iter(kwargs))
             final_kwargs[name] = kwargs.pop(next_arg)
 
     if accepts_kwargs:

--- a/py/src/braintrust/test_framework.py
+++ b/py/src/braintrust/test_framework.py
@@ -13,6 +13,7 @@ from .framework import (
     EvalResultWithSummary,
     Evaluator,
     Filter,
+    _call_user_fn_args,
     evaluate_filter,
     parse_filters,
     run_evaluator,
@@ -630,6 +631,55 @@ async def test_run_evaluator_empty_dataset_warns(capsys):
     captured = capsys.readouterr()
     assert "Warning" in captured.err
     assert "empty" in captured.err.lower()
+
+
+class TestCallUserFnArgs:
+    """Regression tests for https://github.com/braintrustdata/braintrust-sdk-python/issues/240."""
+
+    def test_preserves_default_for_unmatched_keyword_only_param(self):
+        default_config = object()
+
+        def scorer(input, output, expected, *, config=default_config, **kwargs):
+            return config, kwargs
+
+        positional_args, final_kwargs = _call_user_fn_args(
+            scorer,
+            {
+                "input": "question",
+                "output": "answer",
+                "expected": "answer",
+                "metadata": {"case": 1},
+                "trace": object(),
+            },
+        )
+
+        assert positional_args == []
+        assert final_kwargs["input"] == "question"
+        assert final_kwargs["output"] == "answer"
+        assert final_kwargs["expected"] == "answer"
+        assert final_kwargs["config"] is default_config
+        assert final_kwargs["metadata"] == {"case": 1}
+        assert "trace" in final_kwargs
+
+    def test_keeps_required_unmatched_params_backward_compatible(self):
+        def scorer(input_value, output, expected):
+            return input_value, output, expected
+
+        positional_args, final_kwargs = _call_user_fn_args(
+            scorer,
+            {
+                "input": "question",
+                "output": "answer",
+                "expected": "answer",
+            },
+        )
+
+        assert positional_args == []
+        assert final_kwargs == {
+            "input_value": "question",
+            "output": "answer",
+            "expected": "answer",
+        }
 
 
 class TestEvaluateFilter:


### PR DESCRIPTION
Keep declared defaults when callback parameters do not match Braintrust- provided kwargs, which fixes scorer signatures that use keyword-only configuration or dependency injection parameters.

Add regression coverage for the current binding behavior, including the legacy fallback for required unmatched params, and leave a note to clean up that fallback in a future major version.

fixes https://github.com/braintrustdata/braintrust-sdk-python/issues/230