### PR TITLE
chore: add .claude/skills symlink to .agents/skills

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
Mirrors the existing CLAUDE.md -> AGENTS.md pattern so Claude Code discovers the repo's skill definitions automatically.