### PR TITLE
feat(openai): trace images api calls

### DIFF
--- a/py/src/braintrust/integrations/adk/tracing.py
+++ b/py/src/braintrust/integrations/adk/tracing.py
@@ -9,7 +9,8 @@ from contextlib import aclosing
 from typing import Any, cast
 
 from braintrust.bt_json import bt_safe_deep_copy
-from braintrust.logger import Attachment, start_span
+from braintrust.integrations.utils import _attachment_from_bytes, _image_url_payload
+from braintrust.logger import start_span
 from braintrust.span_types import SpanTypeAttribute
 
 
@@ -59,12 +60,10 @@ def _serialize_part(part: Any) -> Any:
 
             # Convert bytes to Attachment
             if isinstance(data, bytes):
-                extension = mime_type.split("/")[1] if "/" in mime_type else "bin"
-                filename = f"file.{extension}"
-                attachment = Attachment(data=data, filename=filename, content_type=mime_type)
+                attachment = _attachment_from_bytes(data, mime_type)
 
                 # Return in image_url format - SDK will replace with AttachmentReference
-                return {"image_url": {"url": attachment}}
+                return _image_url_payload(attachment)
 
     # Handle Part objects with file_data (file references)
     if hasattr(part, "file_data") and part.file_data:

--- a/py/src/braintrust/integrations/anthropic/tracing.py
+++ b/py/src/braintrust/integrations/anthropic/tracing.py
@@ -1,11 +1,15 @@
-import base64
 import logging
 import time
 import warnings
 
 from braintrust.bt_json import bt_safe_deep_copy
 from braintrust.integrations.anthropic._utils import Wrapper, extract_anthropic_usage
-from braintrust.logger import Attachment, log_exc_info_to_span, start_span
+from braintrust.integrations.utils import (
+    _attachment_filename_for_mime_type,
+    _attachment_from_base64_data,
+    _image_url_payload,
+)
+from braintrust.logger import log_exc_info_to_span, start_span
 
 
 log = logging.getLogger(__name__)
@@ -410,10 +414,8 @@ def _start_batch_results_span(args, kwargs):
 
 
 def _attachment_filename_for_media_type(media_type: str, block_type: str) -> str:
-    extension = media_type.split("/", 1)[1] if "/" in media_type else "bin"
-    extension = extension.split("+", 1)[0]
     prefix = "image" if block_type == "image" else "document"
-    return f"{prefix}.{extension}"
+    return _attachment_filename_for_mime_type(media_type, prefix=prefix)
 
 
 def _convert_base64_source_to_attachment(block_type, source):
@@ -427,15 +429,10 @@ def _convert_base64_source_to_attachment(block_type, source):
     if not isinstance(media_type, str) or not isinstance(data, str):
         return None
 
-    try:
-        binary_data = base64.b64decode(data, validate=True)
-    except Exception:
-        return None
-
-    return Attachment(
-        data=binary_data,
+    return _attachment_from_base64_data(
+        data,
+        media_type,
         filename=_attachment_filename_for_media_type(media_type, block_type),
-        content_type=media_type,
     )
 
 
@@ -452,7 +449,7 @@ def _process_input_attachments(value):
             if attachment is not None:
                 processed = {k: _process_input_attachments(v) for k, v in value.items() if k != "source"}
                 processed["source"] = {k: _process_input_attachments(v) for k, v in source.items() if k != "data"}
-                processed["image_url"] = {"url": attachment}
+                processed.update(_image_url_payload(attachment))
                 return processed
 
         return {k: _process_input_attachments(v) for k, v in value.items()}

--- a/py/src/braintrust/integrations/google_genai/tracing.py
+++ b/py/src/braintrust/integrations/google_genai/tracing.py
@@ -1,7 +1,5 @@
 """Google GenAI-specific span creation, metadata extraction, stream handling, and output normalization."""
 
-import base64
-import binascii
 import contextvars
 import dataclasses
 import logging
@@ -12,6 +10,12 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from braintrust.bt_json import bt_safe_deep_copy
+from braintrust.integrations.utils import (
+    _attachment_filename_for_mime_type,
+    _attachment_from_base64_data,
+    _attachment_from_bytes,
+    _image_url_payload,
+)
 from braintrust.logger import Attachment, start_span
 from braintrust.span_types import SpanTypeAttribute
 from braintrust.util import clean_nones
@@ -114,16 +118,11 @@ def _serialize_content_item(item: Any) -> Any:
 
                 # Ensure data is bytes
                 if isinstance(data, bytes):
-                    # Determine file extension from mime type
-                    extension = mime_type.split("/")[1] if "/" in mime_type else "bin"
-                    filename = f"file.{extension}"
-
-                    # Create an Attachment object
-                    attachment = Attachment(data=data, filename=filename, content_type=mime_type)
+                    attachment = _attachment_from_bytes(data, mime_type)
 
                     # Return the attachment object in image_url format
                     # The SDK's _extract_attachments will replace it with its reference when logging
-                    return {"image_url": {"url": attachment}}
+                    return _image_url_payload(attachment)
 
         # Try to use built-in serialization if available
         if hasattr(item, "model_dump"):
@@ -154,21 +153,6 @@ def _serialize_tools(api_client: Any, input: Any | None) -> Any | None:
         return tools
     except Exception:
         return None
-
-
-def _attachment_from_base64_data(data: str, mime_type: str, *, label: str) -> Attachment | None:
-    raw_data = data
-    if raw_data.startswith("data:"):
-        _, _, encoded = raw_data.partition(",")
-        raw_data = encoded
-
-    try:
-        decoded = base64.b64decode(raw_data, validate=True)
-    except (ValueError, binascii.Error):
-        return None
-
-    extension = mime_type.split("/")[1] if "/" in mime_type else "bin"
-    return Attachment(data=decoded, filename=f"{label}.{extension}", content_type=mime_type)
 
 
 def _serialize_interaction_content_dict(value: dict[str, Any]) -> dict[str, Any]:
@@ -402,10 +386,12 @@ def _extract_generate_images_output(response: Any) -> dict[str, Any]:
         # Convert image bytes to an Attachment so the SDK uploads them to
         # object storage and the Braintrust UI can render the image.
         if isinstance(image_bytes, bytes) and mime_type:
-            extension = mime_type.split("/")[1] if "/" in mime_type else "bin"
-            filename = f"generated_image_{i}.{extension}"
-            attachment = Attachment(data=image_bytes, filename=filename, content_type=mime_type)
-            image_entry["image_url"] = {"url": attachment}
+            attachment = _attachment_from_bytes(
+                image_bytes,
+                mime_type,
+                filename=_attachment_filename_for_mime_type(mime_type, prefix=f"generated_image_{i}"),
+            )
+            image_entry.update(_image_url_payload(attachment))
 
         serialized_images.append(image_entry)
 

--- a/py/src/braintrust/integrations/openai/cassettes/test_openai_images_edit.yaml
+++ b/py/src/braintrust/integrations/openai/cassettes/test_openai_images_edit.yaml
@@ -1,0 +1,194 @@
+interactions:
+- request:
+    body: !!binary |
+      LS0xYWVjMzE5NmZmOTMxMWI1NzJjNjI3YmZlNmFiOTg0ZA0KQ29udGVudC1EaXNwb3NpdGlvbjog
+      Zm9ybS1kYXRhOyBuYW1lPSJwcm9tcHQiDQoNCkFkZCBhIGJsdWUgYm9yZGVyDQotLTFhZWMzMTk2
+      ZmY5MzExYjU3MmM2MjdiZmU2YWI5ODRkDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7
+      IG5hbWU9Im1vZGVsIg0KDQpkYWxsLWUtMg0KLS0xYWVjMzE5NmZmOTMxMWI1NzJjNjI3YmZlNmFi
+      OTg0ZA0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJyZXNwb25zZV9mb3Jt
+      YXQiDQoNCnVybA0KLS0xYWVjMzE5NmZmOTMxMWI1NzJjNjI3YmZlNmFiOTg0ZA0KQ29udGVudC1E
+      aXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJzaXplIg0KDQoyNTZ4MjU2DQotLTFhZWMzMTk2
+      ZmY5MzExYjU3MmM2MjdiZmU2YWI5ODRkDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7
+      IG5hbWU9ImltYWdlIjsgZmlsZW5hbWU9ImJyYWludHJ1c3QtdGVzdC1pbWFnZS5wbmciDQpDb250
+      ZW50LVR5cGU6IGltYWdlL3BuZw0KDQqJUE5HDQoaCgAAAA1JSERSAAAAQAAAAEAIBgAAAKppcd4A
+      AACUSURBVHic7dAxEQAwEMOw8Cf9haGhHrT7vNvuZ9MBWgN0gNYAHaA1QAdoDdABWgN0gNYAHaA1
+      QAdoDdABWgN0gNYAHaA1QAdoDdABWgN0gNYAHaA1QAdoDdABWgN0gNYAHaA1QAdoDdABWgN0gNYA
+      HaA1QAdoDdABWgN0gNYAHaA1QAdoDdABWgN0gNYAHaA1QAdoD0OI4dJt2PESAAAAAElFTkSuQmCC
+      DQotLTFhZWMzMTk2ZmY5MzExYjU3MmM2MjdiZmU2YWI5ODRkLS0NCg==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '781'
+      Content-Type:
+      - multipart/form-data; boundary=1aec3196ff9311b572c627bfe6ab984d
+      Host:
+      - api.openai.com
+      User-Agent:
+      - OpenAI/Python 2.24.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.24.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/images/edits
+  response:
+    body:
+      string: "{\n  \"created\": 1775759071,\n  \"data\": [\n    {\n      \"url\":
+        \"https://oaidalleapiprodscus.blob.core.windows.net/private/org-gY2CWXtioLkEfpHBJTrcdNID/user-jIouncdtCNqBNU7Q41fsSvZ2/img-sWsBgQsG5L08pmtO95p4nUGz.png?st=2026-04-09T17%3A24%3A31Z&se=2026-04-09T19%3A24%3A31Z&sp=r&sv=2026-02-06&sr=b&rscd=inline&rsct=image/png&skoid=8b33a531-2df9-46a3-bc02-d4b1430a422c&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2026-04-09T18%3A21%3A40Z&ske=2026-04-10T18%3A21%3A40Z&sks=b&skv=2026-02-06&sig=IWn2M3VRWKx8z8T9b95nfRa5EjAhZCemDwua6t23EbQ%3D\"\n
+        \   }\n  ]\n}"
+    headers:
+      CF-RAY:
+      - 9e9b8c57af1fa06e-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Apr 2026 18:24:31 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '544'
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '9957'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=awSasqBRHVxTDWJEEP6Qw.Xnqko8SJvLBvYIJ5jhC_A-1775759061.7060604-1.0.1.1-NR9TiN9VkB6eP1aqSC3oqHyb_wYQQnIHT18qD4FrGpG6IOP0xE56iRyQ.EI8ZSpFKitT8V1qfALR7m2lodLMoXKxbNtwd..QCsUA1.7NbCTBFr61c7xZAZkBq7cQZGkp;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 09 Apr 2026
+        18:54:31 GMT
+      x-request-id:
+      - req_23c05ec9d803459aa51a6bb3f029020a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: !!binary |
+      LS05Y2M1YWFiZWJlMmFkMTE4MzdlNGVmNjQ1MWEyMTcyOA0KQ29udGVudC1EaXNwb3NpdGlvbjog
+      Zm9ybS1kYXRhOyBuYW1lPSJwcm9tcHQiDQoNCkFkZCBhIGJsdWUgYm9yZGVyDQotLTljYzVhYWJl
+      YmUyYWQxMTgzN2U0ZWY2NDUxYTIxNzI4DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7
+      IG5hbWU9Im1vZGVsIg0KDQpkYWxsLWUtMg0KLS05Y2M1YWFiZWJlMmFkMTE4MzdlNGVmNjQ1MWEy
+      MTcyOA0KQ29udGVudC1EaXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJyZXNwb25zZV9mb3Jt
+      YXQiDQoNCnVybA0KLS05Y2M1YWFiZWJlMmFkMTE4MzdlNGVmNjQ1MWEyMTcyOA0KQ29udGVudC1E
+      aXNwb3NpdGlvbjogZm9ybS1kYXRhOyBuYW1lPSJzaXplIg0KDQoyNTZ4MjU2DQotLTljYzVhYWJl
+      YmUyYWQxMTgzN2U0ZWY2NDUxYTIxNzI4DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7
+      IG5hbWU9ImltYWdlIjsgZmlsZW5hbWU9ImJyYWludHJ1c3QtdGVzdC1pbWFnZS5wbmciDQpDb250
+      ZW50LVR5cGU6IGltYWdlL3BuZw0KDQqJUE5HDQoaCgAAAA1JSERSAAAAQAAAAEAIBgAAAKppcd4A
+      AACUSURBVHic7dAxEQAwEMOw8Cf9haGhHrT7vNvuZ9MBWgN0gNYAHaA1QAdoDdABWgN0gNYAHaA1
+      QAdoDdABWgN0gNYAHaA1QAdoDdABWgN0gNYAHaA1QAdoDdABWgN0gNYAHaA1QAdoDdABWgN0gNYA
+      HaA1QAdoDdABWgN0gNYAHaA1QAdoDdABWgN0gNYAHaA1QAdoD0OI4dJt2PESAAAAAElFTkSuQmCC
+      DQotLTljYzVhYWJlYmUyYWQxMTgzN2U0ZWY2NDUxYTIxNzI4LS0NCg==
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '781'
+      Content-Type:
+      - multipart/form-data; boundary=9cc5aabebe2ad11837e4ef6451a21728
+      Host:
+      - api.openai.com
+      User-Agent:
+      - OpenAI/Python 2.24.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.24.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/images/edits
+  response:
+    body:
+      string: "{\n  \"created\": 1775759080,\n  \"data\": [\n    {\n      \"url\":
+        \"https://oaidalleapiprodscus.blob.core.windows.net/private/org-gY2CWXtioLkEfpHBJTrcdNID/user-jIouncdtCNqBNU7Q41fsSvZ2/img-dg5LcnpEkqDsbL996mUGtuR7.png?st=2026-04-09T17%3A24%3A40Z&se=2026-04-09T19%3A24%3A40Z&sp=r&sv=2026-02-06&sr=b&rscd=inline&rsct=image/png&skoid=7daae675-7b42-4e2e-ab4c-8d8419a28d99&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2026-04-09T11%3A45%3A25Z&ske=2026-04-10T11%3A45%3A25Z&sks=b&skv=2026-02-06&sig=5xpj5xgDoSam7/osQpyjYWdD0WhqIvwfK6olzqGnNSw%3D\"\n
+        \   }\n  ]\n}"
+    headers:
+      CF-RAY:
+      - 9e9b8c96db4c8e83-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Apr 2026 18:24:40 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '544'
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '8841'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=71VJ5AXIV3KbEjxMwRTgzN6wXFuq_FJpfnaclJQEftA-1775759071.815464-1.0.1.1-KlPEAAV9pa1hiqAJSUM_1Hphmoc2bA67hnze_M9BLdP4BVlQNYOk7VfapD42MqF4SAAUD2srxAuNDxLnBCFHf1KO76acIfz5vC2uIwFn8Zsbn04ItH_OHQSg_bkamfxn;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 09 Apr 2026
+        18:54:40 GMT
+      x-request-id:
+      - req_4a84ca0d8b6641c0b92a54393a75f44b
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/openai/cassettes/test_openai_images_generate.yaml
+++ b/py/src/braintrust/integrations/openai/cassettes/test_openai_images_generate.yaml
@@ -1,0 +1,166 @@
+interactions:
+- request:
+    body: '{"prompt":"A tiny red square on a white background","model":"dall-e-2","response_format":"url","size":"256x256"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '112'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - OpenAI/Python 2.24.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.24.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/images/generations
+  response:
+    body:
+      string: "{\n  \"created\": 1775759052,\n  \"data\": [\n    {\n      \"url\":
+        \"https://oaidalleapiprodscus.blob.core.windows.net/private/org-gY2CWXtioLkEfpHBJTrcdNID/user-jIouncdtCNqBNU7Q41fsSvZ2/img-nKb4jxI2HanIlo2yvixTXYsA.png?st=2026-04-09T17%3A24%3A12Z&se=2026-04-09T19%3A24%3A12Z&sp=r&sv=2026-02-06&sr=b&rscd=inline&rsct=image/png&skoid=9346e9b9-5d29-4d37-a0a9-c6f95f09f79d&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2026-04-09T10%3A01%3A24Z&ske=2026-04-10T10%3A01%3A24Z&sks=b&skv=2026-02-06&sig=3GzrJPzvGLriuWCthhXfCinNsC6WN9mX58SN6Rzipus%3D\"\n
+        \   }\n  ]\n}"
+    headers:
+      CF-RAY:
+      - 9e9b8be8fcf8378a-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Apr 2026 18:24:12 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '544'
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '8715'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=d7Ui7BxgyDj1JVkVESIrsWHUtNFGVvSaPMyYAx6_Fcw-1775759043.9957075-1.0.1.1-en7eVUaa.H1GQ8YRb5mumdS4cJ4s_RMDulaFHhFDZGgFvrtr2CF6sabBruS36uGEcR6ZVeIkhCCudtb5lsywHslIXYzKjybNqoqQBP2KGLlo5hec_beaLgk1gf9oT_40;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 09 Apr 2026
+        18:54:12 GMT
+      x-request-id:
+      - req_8b3d3f3249b54fca96b51b4c7a151758
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"prompt":"A tiny red square on a white background","model":"dall-e-2","response_format":"url","size":"256x256"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '112'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - OpenAI/Python 2.24.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.24.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/images/generations
+  response:
+    body:
+      string: "{\n  \"created\": 1775759060,\n  \"data\": [\n    {\n      \"url\":
+        \"https://oaidalleapiprodscus.blob.core.windows.net/private/org-gY2CWXtioLkEfpHBJTrcdNID/user-jIouncdtCNqBNU7Q41fsSvZ2/img-YCihUrBJTgNWpS8J4VKy9JTh.png?st=2026-04-09T17%3A24%3A20Z&se=2026-04-09T19%3A24%3A20Z&sp=r&sv=2026-02-06&sr=b&rscd=inline&rsct=image/png&skoid=f1dafa11-a0c2-4092-91d4-10981fbda051&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2026-04-09T06%3A19%3A53Z&ske=2026-04-10T06%3A19%3A53Z&sks=b&skv=2026-02-06&sig=WoX26Mx17lxQkqv6/toVjCYcf/8wpPQkjyeuOLHvU1c%3D\"\n
+        \   }\n  ]\n}"
+    headers:
+      CF-RAY:
+      - 9e9b8c20abf94fcb-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Apr 2026 18:24:20 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '544'
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '7972'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=GmkqguJQWMzVdvMqYSBAQRx61nvUQDE5C70o.ouGGS8-1775759052.907019-1.0.1.1-C5XexWxBGhyz45zfIuaSjQAKAhG6Nh4VsVCk3WnySOQjTP9iaq9rZBRucHBJQIEmLHX2TtTMVZZ3Cq2_GmbkfWOZSSc63kuy0dnXoknPITCHx28j.A0_p9Ir6SFWotFu;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Thu, 09 Apr 2026
+        18:54:20 GMT
+      x-request-id:
+      - req_bdf4165c8486456e8b07ed966dd0c54f
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/openai/integration.py
+++ b/py/src/braintrust/integrations/openai/integration.py
@@ -8,6 +8,7 @@ from .patchers import (
     AudioTranslationsPatcher,
     ChatCompletionsPatcher,
     EmbeddingsPatcher,
+    ImagesPatcher,
     ModerationsPatcher,
     ResponsesPatcher,
 )
@@ -25,5 +26,6 @@ class OpenAIIntegration(BaseIntegration):
         AudioSpeechPatcher,
         AudioTranscriptionsPatcher,
         AudioTranslationsPatcher,
+        ImagesPatcher,
         ResponsesPatcher,
     )

--- a/py/src/braintrust/integrations/openai/patchers.py
+++ b/py/src/braintrust/integrations/openai/patchers.py
@@ -13,6 +13,9 @@ from .tracing import (
     _chat_completion_create_wrapper,
     _chat_completion_parse_wrapper,
     _embedding_create_wrapper,
+    _image_create_variation_wrapper,
+    _image_edit_wrapper,
+    _image_generate_wrapper,
     _moderation_create_wrapper,
     _responses_create_wrapper,
     _responses_parse_wrapper,
@@ -276,6 +279,60 @@ class _WrapAudioTranslations(CompositeFunctionWrapperPatcher):
 
 
 # ---------------------------------------------------------------------------
+# Images
+# ---------------------------------------------------------------------------
+
+_img_generate_sync, _img_generate_async, _wrap_img_generate = _make_method_patchers(
+    name_prefix="openai.images.generate",
+    target_module="openai.resources.images",
+    sync_class="Images",
+    async_class="AsyncImages",
+    method="generate",
+    wrapper=_image_generate_wrapper,
+    wrap_name="openai.wrap.images.generate",
+)
+
+_img_edit_sync, _img_edit_async, _wrap_img_edit = _make_method_patchers(
+    name_prefix="openai.images.edit",
+    target_module="openai.resources.images",
+    sync_class="Images",
+    async_class="AsyncImages",
+    method="edit",
+    wrapper=_image_edit_wrapper,
+    wrap_name="openai.wrap.images.edit",
+)
+
+_img_variation_sync, _img_variation_async, _wrap_img_variation = _make_method_patchers(
+    name_prefix="openai.images.create_variation",
+    target_module="openai.resources.images",
+    sync_class="Images",
+    async_class="AsyncImages",
+    method="create_variation",
+    wrapper=_image_create_variation_wrapper,
+    wrap_name="openai.wrap.images.create_variation",
+)
+
+
+class ImagesPatcher(CompositeFunctionWrapperPatcher):
+    """Patch ``openai.resources.images`` for tracing."""
+
+    name = "openai.images"
+    sub_patchers = (
+        _img_generate_sync,
+        _img_generate_async,
+        _img_edit_sync,
+        _img_edit_async,
+        _img_variation_sync,
+        _img_variation_async,
+    )
+
+
+class _WrapImages(CompositeFunctionWrapperPatcher):
+    name = "openai.wrap.images"
+    sub_patchers = (_wrap_img_generate, _wrap_img_edit, _wrap_img_variation)
+
+
+# ---------------------------------------------------------------------------
 # Responses
 # ---------------------------------------------------------------------------
 
@@ -365,6 +422,7 @@ _WRAP_TARGETS: tuple[tuple[str, type[CompositeFunctionWrapperPatcher]], ...] = (
     ("audio.speech", _WrapAudioSpeech),
     ("audio.transcriptions", _WrapAudioTranscriptions),
     ("audio.translations", _WrapAudioTranslations),
+    ("images", _WrapImages),
     ("responses", _WrapResponses),
     ("responses.with_raw_response", _WrapResponsesRaw),
     ("beta.chat.completions", _WrapChatCompletions),

--- a/py/src/braintrust/integrations/openai/test_openai.py
+++ b/py/src/braintrust/integrations/openai/test_openai.py
@@ -1,10 +1,14 @@
 import asyncio
+import binascii
 import os
+import struct
+import tempfile
 import time
+import zlib
 
 import openai
 import pytest
-from braintrust import logger, wrap_openai
+from braintrust import Attachment, logger, wrap_openai
 from braintrust.integrations.openai import OpenAIIntegration
 from braintrust.integrations.openai.tracing import RAW_RESPONSE_HEADER, ChatCompletionWrapper
 from braintrust.test_helpers import assert_dict_matches, init_test_logger
@@ -1718,6 +1722,100 @@ def _is_wrapped(client):
 TEST_AUDIO_FILE = os.path.join(os.path.dirname(__file__), "..", "..", "fixtures", "test_audio.wav")
 
 
+def _write_test_png(path: str, *, width: int = 64, height: int = 64) -> None:
+    """Write a simple opaque red RGBA PNG without external dependencies."""
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return struct.pack("!I", len(data)) + tag + data + struct.pack("!I", binascii.crc32(tag + data) & 0xFFFFFFFF)
+
+    row = b"\x00" + bytes([255, 0, 0, 255]) * width
+    raw_rows = row * height
+    header = struct.pack("!IIBBBBB", width, height, 8, 6, 0, 0, 0)
+    png = b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", header) + chunk(b"IDAT", zlib.compress(raw_rows)) + chunk(b"IEND", b"")
+
+    with open(path, "wb") as image_file:
+        image_file.write(png)
+
+
+@pytest.mark.vcr
+def test_openai_images_generate(memory_logger):
+    assert not memory_logger.pop()
+
+    prompt = "A tiny red square on a white background"
+    clients = [(openai.OpenAI(), False), (wrap_openai(openai.OpenAI()), True)]
+
+    for client, is_wrapped in clients:
+        response = client.images.generate(
+            model="dall-e-2",
+            prompt=prompt,
+            size="256x256",
+            response_format="url",
+        )
+
+        assert response
+        assert response.data
+        assert response.data[0].url
+
+        if not is_wrapped:
+            assert not memory_logger.pop()
+            continue
+
+        spans = memory_logger.pop()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span["metadata"]["model"] == "dall-e-2"
+        assert span["metadata"]["provider"] == "openai"
+        assert span["metadata"]["response_format"] == "url"
+        assert span["input"] == prompt
+        assert span["output"]["images_count"] == 1
+        assert span["output"]["images"][0]["image_url"]["url"].startswith("https://")
+        assert span["metrics"]["duration"] >= 0
+
+
+@pytest.mark.vcr
+def test_openai_images_edit(memory_logger):
+    assert not memory_logger.pop()
+
+    prompt = "Add a blue border"
+    with tempfile.TemporaryDirectory() as temp_dir:
+        image_path = os.path.join(temp_dir, "braintrust-test-image.png")
+        _write_test_png(image_path)
+
+        clients = [(openai.OpenAI(), False), (wrap_openai(openai.OpenAI()), True)]
+
+        for client, is_wrapped in clients:
+            with open(image_path, "rb") as image_file:
+                response = client.images.edit(
+                    model="dall-e-2",
+                    prompt=prompt,
+                    image=image_file,
+                    size="256x256",
+                    response_format="url",
+                )
+
+            assert response
+            assert response.data
+            assert response.data[0].url
+
+            if not is_wrapped:
+                assert not memory_logger.pop()
+                continue
+
+            spans = memory_logger.pop()
+            assert len(spans) == 1
+            span = spans[0]
+            assert span["metadata"]["model"] == "dall-e-2"
+            assert span["metadata"]["provider"] == "openai"
+            assert span["metadata"]["response_format"] == "url"
+            assert span["input"]["prompt"] == prompt
+            assert isinstance(span["input"]["image"], Attachment)
+            assert span["input"]["image"].reference["filename"] == "braintrust-test-image.png"
+            assert span["input"]["image"].reference["content_type"] == "image/png"
+            assert span["output"]["images_count"] == 1
+            assert span["output"]["images"][0]["image_url"]["url"].startswith("https://")
+            assert span["metrics"]["duration"] >= 0
+
+
 @pytest.mark.vcr
 def test_openai_audio_speech(memory_logger):
     assert not memory_logger.pop()
@@ -1997,6 +2095,35 @@ class TestAutoInstrumentOpenAI:
     def test_auto_instrument_openai(self):
         """Test auto_instrument patches OpenAI, creates spans, and uninstrument works."""
         verify_autoinstrument_script("test_auto_openai.py")
+
+
+def test_wrap_openai_wraps_images_methods():
+    """wrap_openai() should instrument every OpenAI images resource method."""
+    import inspect
+
+    from wrapt import FunctionWrapper
+
+    for client in (wrap_openai(openai.OpenAI()), wrap_openai(openai.AsyncOpenAI())):
+        for method_name in ("generate", "edit", "create_variation"):
+            method = inspect.getattr_static(client.images, method_name, None)
+            assert isinstance(method, FunctionWrapper), f"images.{method_name} was not wrapped"
+
+
+class TestOpenAIIntegrationSetupImages:
+    """Non-network tests for OpenAIIntegration.setup() images patchers."""
+
+    def test_setup_wraps_images_methods(self):
+        import inspect
+
+        from openai.resources.images import AsyncImages, Images
+        from wrapt import FunctionWrapper
+
+        OpenAIIntegration.setup()
+
+        for cls in (Images, AsyncImages):
+            for method_name in ("generate", "edit", "create_variation"):
+                method = inspect.getattr_static(cls, method_name, None)
+                assert isinstance(method, FunctionWrapper), f"{cls.__name__}.{method_name} was not patched"
 
 
 def test_wrap_openai_and_setup_use_same_wrappers():

--- a/py/src/braintrust/integrations/openai/tracing.py
+++ b/py/src/braintrust/integrations/openai/tracing.py
@@ -7,14 +7,19 @@ from collections.abc import Callable
 from typing import Any
 
 from braintrust.integrations.utils import (
+    _attachment_filename_for_mime_type,
+    _attachment_from_base64_data,
+    _attachment_from_file_input,
     _convert_data_url_to_attachment,
+    _image_url_payload,
     _parse_openai_usage_metrics,
     _prettify_response_params,
+    _timing_metrics,
     _try_to_dict,
 )
 from braintrust.logger import Span, start_span
 from braintrust.span_types import SpanTypeAttribute
-from braintrust.util import merge_dicts
+from braintrust.util import clean_nones, merge_dicts
 from wrapt import FunctionWrapper
 
 
@@ -246,11 +251,16 @@ def _moderation_create_wrapper(wrapped, instance, args, kwargs):
     return ModerationWrapper(create_fn, None).create(*args, **kwargs)
 
 
-def _make_base_wrapper_callback(wrapper_cls: type["BaseWrapper"]):
+def _make_base_wrapper_callback(
+    wrapper_cls: type["BaseWrapper"],
+    *,
+    method_name: str = "create",
+):
     """Create a wrapt callback that routes through with_raw_response for header capture."""
 
     def wrapper(wrapped, instance, args, kwargs):
-        create_fn = _get_raw_callable(instance, "create") or wrapped
+        stream = bool(kwargs.get("stream", False))
+        create_fn = wrapped if stream else (_get_raw_callable(instance, method_name) or wrapped)
         if _is_async_callable(wrapped):
 
             async def call():
@@ -868,6 +878,73 @@ class ResponseWrapper:
         }
 
 
+def _image_attachment_from_base64(
+    data: Any,
+    *,
+    output_format: Any,
+    index: int,
+) -> tuple[Any | None, int | None, str | None]:
+    if not isinstance(data, str):
+        return None, None, None
+
+    extension = output_format if isinstance(output_format, str) and output_format else "png"
+    mime_type = extension if "/" in extension else f"image/{extension}"
+    attachment = _attachment_from_base64_data(
+        data,
+        mime_type,
+        filename=_attachment_filename_for_mime_type(mime_type, prefix=f"generated_image_{index}"),
+    )
+    if attachment is None:
+        return None, None, None
+    return attachment, len(attachment.data), mime_type
+
+
+def _extract_images_output(response: dict[str, Any]) -> dict[str, Any]:
+    images = []
+    output_format = response.get("output_format")
+
+    for index, image in enumerate(response.get("data") or []):
+        image_dict = _try_to_dict(image)
+        if not isinstance(image_dict, dict):
+            continue
+
+        image_entry = clean_nones(
+            {
+                "revised_prompt": image_dict.get("revised_prompt"),
+            }
+        )
+
+        if isinstance(image_dict.get("url"), str):
+            image_entry.update(_image_url_payload(image_dict["url"]))
+
+        b64_json = image_dict.get("b64_json")
+        attachment, image_size_bytes, mime_type = _image_attachment_from_base64(
+            b64_json,
+            output_format=output_format,
+            index=index,
+        )
+        if attachment is not None:
+            image_entry.update(_image_url_payload(attachment))
+            image_entry["image_size_bytes"] = image_size_bytes
+            image_entry["mime_type"] = mime_type
+        elif isinstance(b64_json, str):
+            image_entry["b64_json_present"] = True
+
+        images.append(image_entry)
+
+    return clean_nones(
+        {
+            "created": response.get("created"),
+            "background": response.get("background"),
+            "output_format": output_format,
+            "quality": response.get("quality"),
+            "size": response.get("size"),
+            "images_count": len(images),
+            "images": images,
+        }
+    )
+
+
 class BaseWrapper(abc.ABC):
     def __init__(self, create_fn: Callable[..., Any] | None, acreate_fn: Callable[..., Any] | None, name: str):
         self._create_fn = create_fn
@@ -930,6 +1007,93 @@ class BaseWrapper(abc.ABC):
                 "metadata": {**params, "provider": "openai"},
             },
         )
+
+
+class _ImageBaseWrapper(BaseWrapper):
+    def _log_result(self, log_response: Any, start: float, span: Span) -> None:
+        end = time.time()
+        metrics = _timing_metrics(start, end)
+        if isinstance(log_response, dict):
+            metrics.update(_parse_metrics_from_usage(log_response.get("usage")))
+        output = _extract_images_output(log_response) if isinstance(log_response, dict) else log_response
+        span.log(metrics=metrics, output=output)
+
+    def create(self, *args: Any, **kwargs: Any) -> Any:
+        params = self._parse_params(kwargs)
+
+        with start_span(
+            **merge_dicts(dict(name=self._name, span_attributes={"type": SpanTypeAttribute.LLM}), params)
+        ) as span:
+            start = time.time()
+            create_response = self._create_fn(*args, **kwargs)
+            if hasattr(create_response, "parse"):
+                raw_response = create_response.parse()
+                log_headers(create_response, span)
+            else:
+                raw_response = create_response
+
+            self._log_result(_try_to_dict(raw_response), start, span)
+            return raw_response
+
+    async def acreate(self, *args: Any, **kwargs: Any) -> Any:
+        params = self._parse_params(kwargs)
+
+        with start_span(
+            **merge_dicts(dict(name=self._name, span_attributes={"type": SpanTypeAttribute.LLM}), params)
+        ) as span:
+            start = time.time()
+            create_response = await self._acreate_fn(*args, **kwargs)
+            if hasattr(create_response, "parse"):
+                raw_response = create_response.parse()
+                log_headers(create_response, span)
+            else:
+                raw_response = create_response
+
+            self._log_result(_try_to_dict(raw_response), start, span)
+            return raw_response
+
+    def process_output(self, response: Any, span: Span):
+        output = _extract_images_output(response) if isinstance(response, dict) else response
+        span.log(output=output)
+
+    @classmethod
+    def _parse_params(cls, params: dict[str, Any]) -> dict[str, Any]:
+        ret = params.pop("span_info", {})
+        params = prettify_params(params)
+        prompt = params.pop("prompt", None)
+        image = params.pop("image", None)
+        mask = params.pop("mask", None)
+
+        input_data = clean_nones(
+            {
+                "prompt": prompt,
+                "image": _attachment_from_file_input(image),
+                "mask": _attachment_from_file_input(mask),
+            }
+        )
+
+        return merge_dicts(
+            ret,
+            {
+                "input": prompt if (prompt is not None and len(input_data) == 1) else (input_data or None),
+                "metadata": {**params, "provider": "openai"},
+            },
+        )
+
+
+class ImageGenerateWrapper(_ImageBaseWrapper):
+    def __init__(self, create_fn: Callable[..., Any] | None, acreate_fn: Callable[..., Any] | None):
+        super().__init__(create_fn, acreate_fn, "Image Generation")
+
+
+class ImageEditWrapper(_ImageBaseWrapper):
+    def __init__(self, create_fn: Callable[..., Any] | None, acreate_fn: Callable[..., Any] | None):
+        super().__init__(create_fn, acreate_fn, "Image Edit")
+
+
+class ImageVariationWrapper(_ImageBaseWrapper):
+    def __init__(self, create_fn: Callable[..., Any] | None, acreate_fn: Callable[..., Any] | None):
+        super().__init__(create_fn, acreate_fn, "Image Variation")
 
 
 class EmbeddingWrapper(BaseWrapper):
@@ -1015,6 +1179,11 @@ class TranslationWrapper(_AudioFileWrapper):
 _audio_speech_create_wrapper = _make_base_wrapper_callback(SpeechWrapper)
 _audio_transcription_create_wrapper = _make_base_wrapper_callback(TranscriptionWrapper)
 _audio_translation_create_wrapper = _make_base_wrapper_callback(TranslationWrapper)
+
+
+_image_generate_wrapper = _make_base_wrapper_callback(ImageGenerateWrapper, method_name="generate")
+_image_edit_wrapper = _make_base_wrapper_callback(ImageEditWrapper, method_name="edit")
+_image_create_variation_wrapper = _make_base_wrapper_callback(ImageVariationWrapper, method_name="create_variation")
 
 
 # OpenAI's representation to Braintrust's representation

--- a/py/src/braintrust/integrations/pydantic_ai/tracing.py
+++ b/py/src/braintrust/integrations/pydantic_ai/tracing.py
@@ -7,7 +7,8 @@ from contextlib import AbstractAsyncContextManager
 from typing import Any
 
 from braintrust.bt_json import bt_safe_deep_copy
-from braintrust.logger import Attachment, start_span
+from braintrust.integrations.utils import _attachment_from_bytes
+from braintrust.logger import start_span
 from braintrust.span_types import SpanTypeAttribute
 from wrapt import wrap_function_wrapper
 
@@ -944,10 +945,7 @@ def _serialize_content_part(part: Any) -> Any:
             data = part.data
             media_type = part.media_type
 
-            extension = media_type.split("/")[1] if "/" in media_type else "bin"
-            filename = f"file.{extension}"
-
-            attachment = Attachment(data=data, filename=filename, content_type=media_type)
+            attachment = _attachment_from_bytes(data, media_type)
             return {"type": "binary", "attachment": attachment, "media_type": media_type}
 
     if hasattr(part, "content"):

--- a/py/src/braintrust/integrations/test_utils.py
+++ b/py/src/braintrust/integrations/test_utils.py
@@ -3,8 +3,13 @@ import unittest.mock
 import pytest
 from braintrust import Attachment
 from braintrust.integrations.utils import (
+    _attachment_filename_for_mime_type,
+    _attachment_from_base64_data,
+    _attachment_from_bytes,
+    _attachment_from_file_input,
     _camel_to_snake,
     _convert_data_url_to_attachment,
+    _image_url_payload,
     _is_supported_metric_value,
     _log_and_end_span,
     _log_error_and_end_span,
@@ -149,6 +154,36 @@ def test_prettify_response_params_filters_not_given_without_mutating_input():
     assert "optional" in original
 
 
+def test_attachment_filename_for_mime_type_handles_suffixes_and_prefixes():
+    assert _attachment_filename_for_mime_type("image/png", prefix="image") == "image.png"
+    assert _attachment_filename_for_mime_type("application/pdf", prefix="document") == "document.pdf"
+    assert _attachment_filename_for_mime_type("image/svg+xml", prefix="file") == "file.svg"
+
+
+def test_attachment_from_bytes_uses_default_filename():
+    attachment = _attachment_from_bytes(b"hello", "image/png")
+
+    assert isinstance(attachment, Attachment)
+    assert attachment.reference["content_type"] == "image/png"
+    assert attachment.reference["filename"] == "file.png"
+
+
+def test_attachment_from_base64_data_accepts_data_urls_and_custom_filenames():
+    attachment = _attachment_from_base64_data(
+        "data:image/png;base64,aGVsbG8=",
+        "image/png",
+        filename="generated_image_0.png",
+    )
+
+    assert isinstance(attachment, Attachment)
+    assert attachment.reference["content_type"] == "image/png"
+    assert attachment.reference["filename"] == "generated_image_0.png"
+
+
+def test_attachment_from_base64_data_returns_none_for_invalid_payloads():
+    assert _attachment_from_base64_data("aGVsbG8=!", "image/png") is None
+
+
 def test_convert_data_url_to_attachment_converts_valid_base64():
     data_url = "data:image/png;base64,aGVsbG8="
 
@@ -157,6 +192,56 @@ def test_convert_data_url_to_attachment_converts_valid_base64():
     assert isinstance(attachment, Attachment)
     assert attachment.reference["content_type"] == "image/png"
     assert attachment.reference["filename"] == "image.png"
+
+
+def test_image_url_payload_wraps_attachment_and_string_urls():
+    attachment = _attachment_from_bytes(b"hello", "image/png")
+
+    assert _image_url_payload(attachment) == {"image_url": {"url": attachment}}
+    assert _image_url_payload("https://example.com/image.png") == {
+        "image_url": {"url": "https://example.com/image.png"}
+    }
+
+
+def test_attachment_from_file_input_handles_common_input_shapes(tmp_path):
+    file_path = tmp_path / "example.png"
+    file_path.write_bytes(b"abc")
+
+    class FileLike:
+        def __init__(self):
+            self.name = str(file_path)
+            self._position = 0
+
+        def read(self):
+            self._position = 3
+            return b"abc"
+
+        def tell(self):
+            return 0
+
+        def seek(self, position):
+            self._position = position
+
+    path_attachment = _attachment_from_file_input(file_path)
+    bytes_attachment = _attachment_from_file_input(b"abc", filename="example.png")
+    tuple_attachment = _attachment_from_file_input((str(file_path), b"abc", "image/png"))
+    file_attachment = _attachment_from_file_input(FileLike())
+
+    for attachment in (path_attachment, bytes_attachment, tuple_attachment, file_attachment):
+        assert isinstance(attachment, Attachment)
+        assert attachment.reference["filename"] == "example.png"
+        assert attachment.reference["content_type"] == "image/png"
+
+
+def test_attachment_from_file_input_preserves_file_position(tmp_path):
+    file_path = tmp_path / "example.png"
+    file_path.write_bytes(b"abc")
+
+    with file_path.open("rb") as file_obj:
+        assert file_obj.tell() == 0
+        attachment = _attachment_from_file_input(file_obj)
+        assert isinstance(attachment, Attachment)
+        assert file_obj.tell() == 0
 
 
 def test_convert_data_url_to_attachment_preserves_invalid_base64():

--- a/py/src/braintrust/integrations/utils.py
+++ b/py/src/braintrust/integrations/utils.py
@@ -11,6 +11,8 @@ _try_to_dict``).
 
 import base64
 import binascii
+import mimetypes
+import os
 import re
 import time
 import warnings
@@ -97,6 +99,147 @@ def _is_supported_metric_value(value: Any) -> bool:
     return isinstance(value, Real) and not isinstance(value, bool)
 
 
+def _attachment_filename_for_mime_type(mime_type: str, *, prefix: str = "file") -> str:
+    """Return a stable filename for *mime_type* using *prefix*.
+
+    Examples:
+    - ``image/png`` with prefix ``image`` -> ``image.png``
+    - ``application/pdf`` with prefix ``document`` -> ``document.pdf``
+    - ``image/svg+xml`` with prefix ``file`` -> ``file.svg``
+    """
+    extension = mime_type.split("/", 1)[1] if "/" in mime_type else "bin"
+    extension = extension.split("+", 1)[0]
+    return f"{prefix}.{extension}"
+
+
+def _attachment_from_bytes(
+    data: bytes | bytearray,
+    mime_type: str,
+    *,
+    filename: str | None = None,
+    label: str = "file",
+) -> Attachment:
+    """Build an :class:`Attachment` from provider-owned binary data."""
+    resolved_filename = filename or _attachment_filename_for_mime_type(mime_type, prefix=label)
+    return Attachment(
+        data=data if isinstance(data, bytes) else bytes(data), filename=resolved_filename, content_type=mime_type
+    )
+
+
+def _attachment_from_base64_data(
+    data: str,
+    mime_type: str,
+    *,
+    filename: str | None = None,
+    label: str = "file",
+) -> Attachment | None:
+    """Decode base64 or data-URL content into an :class:`Attachment`."""
+    raw_data = data
+    if raw_data.startswith("data:"):
+        _, _, encoded = raw_data.partition(",")
+        raw_data = encoded
+
+    try:
+        decoded = base64.b64decode(raw_data, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
+    return _attachment_from_bytes(decoded, mime_type, filename=filename, label=label)
+
+
+def _image_url_payload(url: Attachment | str) -> dict[str, Any]:
+    """Return the common Braintrust multimodal image/file payload shape."""
+    return {"image_url": {"url": url}}
+
+
+def _attachment_from_file_input(
+    value: Any,
+    *,
+    filename: str | None = None,
+    content_type: str | None = None,
+    label: str = "file",
+) -> Any:
+    """Convert common provider file-input shapes into :class:`Attachment` objects.
+
+    This is for traced input logging only; callers should pass the original
+    file objects/paths to the provider API unchanged.
+    """
+    if isinstance(value, list):
+        return [
+            _attachment_from_file_input(item, filename=filename, content_type=content_type, label=label)
+            for item in value
+        ]
+
+    if isinstance(value, Attachment) or value is None:
+        return value
+
+    if isinstance(value, tuple):
+        tuple_filename = value[0] if value and isinstance(value[0], (str, os.PathLike)) else None
+        tuple_value = value[1] if len(value) > 1 else None
+        tuple_content_type = value[2] if len(value) > 2 and isinstance(value[2], str) else None
+        return _attachment_from_file_input(
+            tuple_value,
+            filename=filename or (os.path.basename(os.fspath(tuple_filename)) if tuple_filename is not None else None),
+            content_type=content_type or tuple_content_type,
+            label=label,
+        )
+
+    if isinstance(value, (str, os.PathLike)):
+        path = os.fspath(value)
+        try:
+            with open(path, "rb") as file_obj:
+                data = file_obj.read()
+        except OSError:
+            return None
+        resolved_filename = filename or os.path.basename(path)
+        resolved_content_type = (
+            content_type or mimetypes.guess_type(resolved_filename)[0] or "application/octet-stream"
+        )
+        return _attachment_from_bytes(data, resolved_content_type, filename=resolved_filename, label=label)
+
+    if isinstance(value, (bytes, bytearray)):
+        resolved_filename = filename
+        resolved_content_type = (
+            content_type
+            or (mimetypes.guess_type(resolved_filename)[0] if resolved_filename is not None else None)
+            or "application/octet-stream"
+        )
+        return _attachment_from_bytes(value, resolved_content_type, filename=resolved_filename, label=label)
+
+    read = getattr(value, "read", None)
+    if callable(read):
+        file_name_attr = getattr(value, "name", None)
+        resolved_filename = filename or (os.path.basename(file_name_attr) if isinstance(file_name_attr, str) else None)
+        resolved_content_type = (
+            content_type
+            or (mimetypes.guess_type(resolved_filename)[0] if resolved_filename is not None else None)
+            or "application/octet-stream"
+        )
+
+        position = None
+        try:
+            position = value.tell()
+        except Exception:
+            position = None
+
+        try:
+            data = value.read()
+        finally:
+            if position is not None:
+                try:
+                    value.seek(position)
+                except Exception:
+                    pass
+
+        if isinstance(data, str):
+            data = data.encode()
+        if isinstance(data, (bytes, bytearray)):
+            return _attachment_from_bytes(data, resolved_content_type, filename=resolved_filename, label=label)
+        return None
+
+    return None
+
+
 def _convert_data_url_to_attachment(data_url: str, filename: str | None = None) -> Attachment | str:
     """Convert a ``data:<mime>;base64,…`` URL into an :class:`Attachment`.
 
@@ -107,19 +250,14 @@ def _convert_data_url_to_attachment(data_url: str, filename: str | None = None) 
     if not match:
         return data_url
 
-    mime_type, base64_data = match.groups()
-
-    try:
-        binary_data = base64.b64decode(base64_data, validate=True)
-    except (binascii.Error, ValueError):
-        return data_url
-
-    if filename is None:
-        extension = mime_type.split("/")[1] if "/" in mime_type else "bin"
-        prefix = "image" if mime_type.startswith("image/") else "file"
-        filename = f"{prefix}.{extension}"
-
-    return Attachment(data=binary_data, filename=filename, content_type=mime_type)
+    mime_type, _base64_data = match.groups()
+    attachment = _attachment_from_base64_data(
+        data_url,
+        mime_type,
+        filename=filename,
+        label="image" if mime_type.startswith("image/") else "file",
+    )
+    return attachment or data_url
 
 
 def _is_not_given(value: object) -> bool:


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk-python/issues/124

Add OpenAI integration patchers and tracing wrappers for image generation, edits, and variations so image requests and responses are logged with Braintrust attachments.

Refactor shared attachment helpers into integrations.utils and add tests plus VCR cassettes for the new OpenAI images coverage.