### PR TITLE
feat(anthropic): trace server tool content blocks as tool spans

### DIFF
--- a/.agents/skills/commit-message/SKILL.md
+++ b/.agents/skills/commit-message/SKILL.md
@@ -37,7 +37,7 @@ Notes:
 - This repo uses `ref`, not `refactor`.
 - Scope is common and usually names the subsystem, provider, or area being changed.
 - Commits on `main` often include a GitHub squash suffix like `(#245)`. Omit that for a normal local commit unless the user explicitly wants a PR title or squash-merge title.
-- Most commits in this repo are title-only, but the message should still be useful. Prefer a concise subject that makes the main change obvious, and add a short body when the subject alone would feel too vague.
+- This repo commonly uses commit bodies for substantive changes. Prefer a concise subject that makes the main change obvious, and add a short body unless the change is truly trivial and fully explained by the subject.
 
 ## Types
 
@@ -73,7 +73,9 @@ If the change is broad or generated, omit scope instead of forcing one.
 - Describe the primary change, not every file touched.
 - Make the subject specific enough that a reviewer can understand the change without opening the diff.
 - If the diff mixes unrelated concerns, say so instead of forcing one message.
-- Add a short body when non-obvious rationale, behavior changes, or breaking changes would make the message meaningfully clearer.
+- Add a short body by default for feature, fix, perf, or ref commits.
+- The body should briefly capture why the change was made, any important behavioral detail, and key test/coverage notes when they materially help a reviewer.
+- Only omit the body when the change is truly tiny and the subject fully explains it.
 
 ## Workflow
 
@@ -86,6 +88,7 @@ git status --short
 ```
 
 2. Pick the main intent, choose `type` and optional `scope`, then write one useful but concise commit message.
+3. Unless the change is trivial, include a body with 1-3 short paragraphs or bullets covering rationale, behavior, or test coverage.
 
 ## Output
 

--- a/.agents/skills/sdk-integrations/SKILL.md
+++ b/.agents/skills/sdk-integrations/SKILL.md
@@ -81,7 +81,9 @@ Use this order unless the task is clearly narrower:
 4. Implement or update patchers.
 5. Implement or update tracing helpers.
 6. Add or update focused tests.
-7. Run the narrowest nox session first, then expand only if shared code changed.
+7. For provider-behavior bugs, make the primary regression test cassette-backed when practical, even if the implementation change is in local tracing/span post-processing of the provider response.
+8. Be suspicious of mock/fake coverage for integrations. Do not choose mocks because they are convenient, faster, or easier to control.
+9. Run the narrowest nox session first, then expand only if shared code changed.
 
 Do not start by wiring wrappers and only later decide what the span should contain.
 
@@ -241,11 +243,18 @@ Default bug-fix workflow: red -> green.
 - Then implement the fix.
 - Only skip this when the task explicitly asks for a different approach.
 
-Prefer VCR-backed real provider coverage with `@pytest.mark.vcr`. Use mocks or fakes only for cases that are hard to drive through recordings, such as:
+Prefer VCR-backed real provider coverage with `@pytest.mark.vcr`. This includes span-shaping/tracing bugs where the bad behavior is triggered by a real provider response payload; do not treat those as mock-first just because the code path is local.
+
+Default stance: if the behavior is provider-facing, assume mocks/fakes are the wrong tool until proven otherwise. A mock should need justification, not the other way around.
+
+Use mocks or fakes only for cases that are hard to drive through recordings, such as:
 
 - narrow error injection
-- local version-routing logic
+- purely local version-routing logic
 - patcher existence checks
+- provider-independent helper logic where the provider response shape is not part of the contract being validated
+
+Do not replace or skip a cassette-backed regression with a mock/fake test merely because the implementation change lives in `tracing.py`, a serializer, or another local post-processing layer. If a real provider payload is what triggers the bug, the main regression test should reflect that real payload.
 
 Test emitted spans, not just provider return values.
 

--- a/.agents/skills/sdk-vcr-workflows/SKILL.md
+++ b/.agents/skills/sdk-vcr-workflows/SKILL.md
@@ -39,6 +39,7 @@ These rules must stay aligned with `AGENTS.md`:
 - Do not guess nox session names or provider/version coverage.
 - Default bug-fix workflow is red -> green.
 - Prefer VCR-backed provider tests over mocks or fakes whenever practical.
+- Treat mock/fake tests for provider behavior as an exception that requires justification, not as a neutral alternative.
 - Only re-record HTTP or subprocess cassettes when the behavior change is intentional. If unsure, ask the user.
 - Do not assume optional provider packages are installed outside the active nox session.
 
@@ -71,6 +72,8 @@ Implications:
 
 Do not re-record a broad provider suite when one focused test is enough.
 
+Do not default to mocks/fakes just to avoid recording work. Extra setup effort is not, by itself, a good reason to abandon cassette-backed coverage.
+
 ## Choosing The Right Coverage Style
 
 ### Prefer cassette-backed tests when:
@@ -89,6 +92,14 @@ Do not re-record a broad provider suite when one focused test is enough.
 - the code under test is entirely internal and a cassette would add little value
 
 If the task is about provider behavior and you can reasonably record it, prefer VCR.
+
+Do not use mocks/fakes as the primary regression test for provider behavior merely because:
+- the bug appears in local tracing or post-processing code
+- a mock is faster to write
+- recording requires adding a new cassette
+- an existing mock test already exists nearby
+
+In those situations, the right move is usually to add or update a focused cassette-backed test and keep any mock/unit test only as supplemental coverage.
 
 ## Cassette Locations
 
@@ -247,6 +258,7 @@ Do not try to force ordinary HTTP VCR patterns onto Claude Agent SDK subprocess 
 - Reproduce under the exact provider session and version.
 - Use red -> green when fixing a bug.
 - Prefer a focused cassette-backed test over mocks/fakes.
+- If you choose a mock/fake test for provider behavior, be able to state exactly why a cassette-backed test is impractical.
 - Re-record only when behavior intentionally changed.
 - Record the narrowest affected test first.
 - Inspect the cassette diff before finishing.
@@ -262,6 +274,7 @@ Avoid these failures:
 - letting local `record_mode="once"` hide a missing or stale cassette
 - replacing meaningful assertions with cassette churn
 - using mocks for provider behavior that should be validated from real recordings
+- treating local tracing/span-shaping bugs as mock-first when the trigger is a real provider payload
 - forgetting that Claude Agent SDK uses subprocess transport recordings, not HTTP VCR
 - leaving duplicate stale cassettes behind after moving tests or renaming scenarios
 - broad re-records that create unnecessary review noise

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ Use this file as the default playbook for work in this repository.
 
 6. **Prefer real integration coverage over mocks.**
    - For provider/integration behavior, prefer VCR-backed tests with checked-in cassettes.
+   - This includes bugs in tracing/span shaping that happen after the SDK returns a real provider payload. If the behavior depends on the provider's actual response shape, treat it as VCR-first work, not mock-first work.
+   - Be actively skeptical of mock/fake tests for provider integrations. Do not reach for mocks just because they are faster or easier to write.
    - Avoid mocks/fakes unless the code is purely local or there is no practical cassette-based option.
 
 7. **Do not assume optional provider packages are installed.**
@@ -175,6 +177,10 @@ For provider and integration behavior, the default path is:
 1. reproduce with a failing cassette-backed test
 2. implement the fix
 3. re-run the affected session
+
+Do not downgrade to a mock/fake regression test just because the bug is in local post-processing of a real provider response. If the response shape is part of the behavior under test, the primary regression test should still be cassette-backed. Mock/unit tests may be added as supplemental coverage, not as the main reproduction, unless recording is genuinely impractical.
+
+When deciding between a VCR test and a mock/fake test for provider behavior, bias heavily toward VCR. The burden of proof is on the mock: if you cannot clearly explain why a cassette-backed test is impractical, you should not be using a mock or fake as the primary regression coverage.
 
 Cassette locations:
 

--- a/py/src/braintrust/integrations/anthropic/cassettes/test_anthropic_messages_sync_server_tool_spans.yaml
+++ b/py/src/braintrust/integrations/anthropic/cassettes/test_anthropic_messages_sync_server_tool_spans.yaml
@@ -1,0 +1,123 @@
+interactions:
+- request:
+    body: '{"max_tokens":256,"messages":[{"role":"user","content":"Use the web_search
+      tool to find the Braintrust docs homepage. Then answer with exactly the homepage
+      URL and no other text."}],"model":"claude-haiku-4-5-20251001","tool_choice":{"type":"tool","name":"web_search","disable_parallel_tool_use":true},"tools":[{"type":"web_search_20250305","name":"web_search","max_uses":1}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '375'
+      Content-Type:
+      - application/json
+      Host:
+      - api.anthropic.com
+      User-Agent:
+      - Anthropic/Python 0.93.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 0.93.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.13.3
+      anthropic-version:
+      - '2023-06-01'
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: "{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_015tGoRbByHYiodGx8f64RR6\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"server_tool_use\",\"id\":\"srvtoolu_01TvxcVuELES1qHMs2vf9M63\",\"name\":\"web_search\",\"input\":{\"query\":\"Braintrust
+        docs homepage\"}},{\"type\":\"web_search_tool_result\",\"tool_use_id\":\"srvtoolu_01TvxcVuELES1qHMs2vf9M63\",\"content\":[{\"type\":\"web_search_result\",\"title\":\"Get
+        started with Braintrust - Braintrust\",\"url\":\"https://www.braintrust.dev/docs\",\"encrypted_content\":\"ErINCioIDhgCIiQyNzc5NjY2OC03MzUxLTQwYWMtYWNjNC0wMjRhZWU4OTk1YTUSDKAjd2qXCVnINHjEgxoMSPL5nFwAWTTLFbhNIjBmGIYS10O8F+J87SnbopY4PnlST0hIPP4bfRW1PVVvyfauRtblIflzrqeIvolL5KkqtQw+4+eBDfpivmMb3zqTh/yMAsd+b7XyvIo5hSHlh1HFk7M1KQKhvCzKChEurZg8VctbPqmXtNrw2540NbCb4HWhO7c1UL5AjVrH23BCJYLSr886iot2twL5UVushCv1qdnthMgVR+5VzTU6V6ykCxLmqH5QRBkR0q9u/yRe7MNSEmKStKm7qVKaQ0kOjMRFIyycPXlVMTBuC4mcNB+YuoDmTZDaAEN/QQ17Y8Dj/0Xn6BxuRXIfQqave8eL0d4O/XK4pfeEEeHSeipWlu8a1C+aznrYPNJv7a49JrVGQB7aWOM0yZ2pGv3+rEaoTgotYsaDcb3eggZIXyWcMpaK6OWfEMVyZvA85h8z+GKxBKt76WZab8UDKaAiJgLVDKKL6bQ3cAukZg2P58FkQ1o2jswc5TtXyOyb1LklWm/8bA56SJH31ctN7lb4Lnn27NrA/yXta0QjtpdXdW6xWmjOPQxnrrP4olIFiXmTGjNE2kFB6jdxb5I0xArt37/5u6oeAquq4q6sTiKAbws2Xv1WHwewHKMs8mGYXObb6D4GAf90zoEvq/YqBN2Ad/F4g9C4B+MaotnXB5VNmTDynOBdF0myej9AB3NpaJCANhIgu6hAJSfQoYh/ae8nYVyNa+tqC3yXalWHtrpZ7nPyrKic+qZwRwzPLdcP6oeZJJKb8BDJO0bnnkRCj2x5XGyUooiaE7uQqcJyiBKC94+j0Hh2iUS4bWQ5W1ia+N++jOCOeArf+Akmhb6E2RHn9pKALn2Nz2lRymOOccefIWxJ3rlKIXm5Yws7s0d0z8KE2h2as3f42K/f+fB60rxvUoac0V9OHg3seOsoEBYHBhIZBEkZsA32vI1tdf+zduOIFXCwgeRFy6IZhTFred+IBSGlfRX8mfGoOFil9CgMZvcFG/HWC/R4h8cYvejcCjiOjs+Qa5+0FEpWzHRLWsVGAheVgBsbGj1tlRigJPkp6JpsK1p7l9Osxsoehwx5wyNx0LP2vaUCsS553PoLn4XydmmO4o1QmasaVKc1Itn0QKh5I7zK0paszCN7sDuWOjTWmlhX0DbLdaX0xGGmAGVVqN4lfqRzUCvuEQWzMLMlaSWVJ7RB/3SqTEqC8rAjlkKnYm6i/d25hD3bc1k//0oaX//fejL8zTz4EE0I6JrjGFspzOx/6N/wvJfayN6mK6N97rlX+tYCTOn5kqa/7QchjH9ykPKSspvUfrBPGmab2bsLT2Q1dizdApphz2bpm6wEkjFEzmG5eAzP9Fi82bM3QlxN+4IgECtcM7GU4WhYq3JUmQnKWcp19xRJaUPp28wY919zc5NnXLMNg7tmp/6S7hNPrR3TMlzGr7MeTeEz2/7WzC/Ah0V++mscWZtIRpELwhawZFc9Swyh1J7vjVtDxJDct3/PqQfsgO+y1PvH8Zz5zKwtWOO7j3alpjy1SnDVcHA7rsGoKn7kZybD7AhMG6oVd2HlH1vE8PuK9udGLKXvi1DGLQpM1K6Jt75Y/p9WgF/lOQE+9NiIKyJ0xIJS9op+pBZYua2uOppN5edHFArRSd9ORZLbVl9i4VrcgKT6C1i6DrObFwvZLeMImaKCAomyJT3LJ3qDJRh0FogBVroY1Yphx1MPYeddT4rs2OfELPpEFPBK8rKiKo9x/swpDstkmqg0bemqzEIbt81f/Iuf3pXXqmenip7X1BPkKMM9HaIO+wWaQBJrpTQVi25sAEqv3XdgoiK60exwu5J737pakzpsvR3o5gR2qi+P33KJURiE4sPqvWwWaxTx31T3+CubVOm+8G2/nnhmSRhGwxi7M1P9P49uWP0IlvcrnEIKrXHIfyenFMsOEulc9dfNc/KXq4JCtnuvtSQcm34+IdtLKqoB0KljERbHOhBrTSr1SfYECcrwUfyEm/H+xLHugXK35pO4YyXIn4MhRohtvFsDZBRV5p2CW0GbUF2tjUI7pF+/Xri77n/9FbZG8EYUT0H86T6Vag8cvHl+kQSDU9W8rwkXVhZpqH0T528Z7dfX5B8FeMln9kCUkxye01YKnJxm2bTlO3m9OSMNFN9aEm0imXF3hc5SlDU6psIBn2DaCazvW5Bg5ByaCkRYRI6ShXdXzYvH6dZ4sPz0OxgD\",\"page_age\":null},{\"type\":\"web_search_result\",\"title\":\"Get
+        started - Docs - Braintrust\",\"url\":\"https://www.braintrust.dev/docs/start\",\"encrypted_content\":\"Ep8ICioIDhgCIiQyNzc5NjY2OC03MzUxLTQwYWMtYWNjNC0wMjRhZWU4OTk1YTUSDBo8ZMQmk0UuWp9EexoMgxSh/pmgqgXTIixRIjBJ8ixJWF9w/9QOWHp3Ctwlg3O7pWnYzTzNOirnMJx4MPkQC1FjLDN1TJFsNRZwvfkqogcFV7O2zMkuqaMFmyU/lJE2w7FsUcEXn0J74EkXc/fXVC6N7YwfCWqy5Od9l02kt2uneQnpXLNAfP6HdKMRxkAMy9H7sKHEYAhhjercuo69XadDUfKtUPqjUASR0dlSLDG9p8jf/Xy7mWcsXRJtfKEuUDnPjLvJYfS8BMTh4LknydiEKbP6ygSIGFNYmmqdHEAod9qpwYpvEB09Q4HI4r86rnnB4/uDPXYpALANWXqNypdAgBnpeT4gOMVRSxiDKib9TFPV3TpqfDja4jEikzfnjKgSfM6fr1OxlyOt0zcVQyvXl3tkE883HwPoZbm441N/xQiLk559tfwSBemlTwPuuiIOP9yqMVmqq877ndA+mFp6sVDTBkn2DLrBOllQvazkcSGVYkVE/FnoWz+0t2+ZCDnk07aEVvQCvlfjeOxMSBb0Nd6EOHE+VAteh5KY+oVzT1/fNFXzW64ROg0TP4F1Ynm9kK18obxSUZAbmTcJIeNxk8uQOh+OLXgHvCE//gGea1wyZZkeydV8qPUrTkyMXZH0OenX4HrMTh+EOSkOE801cToPggUru7arMot40huFdWy48I4oVf5Ix+xeBxYLl3qCp2P4z53dX2Dm2KVSDcIhcyFfzvTfh25XQ7OK5lZbfz/+PABedeu9sP3JUbhcR0YHnawTs8pD05EtHy/0bhul7JkQck1H2q1m5Sp2vFMcqYGNms/+p5u6iUE/X2jjen+Q8r+ma7YzWa91Fvn20x3D6umV0n4O8+fFZ/W2/Q8xiSw2XE/vZmqMgpBtk7/2oLbuPabiBT9w+DTUqU9z+uUfUldKQEONaKMn9Ml7yFse4P4Q6kFmoH9CaHNWGIMuacQtNAahbGP5LROPCg4J40r0Tm+QyISTsX7zZkqxhttGNiTlzsp1WQKNY+kClZ7v8HhhmFix0xgTlNv2Jd9j6rL5c4WUEOY7emS/tinm5wAIVkXu7iVgRfIQyovvQ2mmgZeb2JgLaoQu8GTiVbAMsEk5AD9ZBI2KfmtQXv6AQmqKjk0GRkefeOos4Z9L/TeXQvTTW7UcAip9WsKsXlAhLM8aLObRS2MNFjd8KQrcyxlMkowJcCN0BiBiaPLbFj0dVnpgLf4kmL9OcZIMzUiIUMsKZkKt5Fz3EAwS8/cv/nE8IQCWU5JnMmAJeQSUBn+i3oxbrQALkNZPy6dZ9gY+SrUWOIt35PPyydPTr08+ZbJ/sUY+F5WyDUZooeGVi06HTNoYAw==\",\"page_age\":null},{\"type\":\"web_search_result\",\"title\":\"Braintrust
+        Network Overview | Braintrust Community\",\"url\":\"https://docs.usebraintrust.com/communitydocs\",\"encrypted_content\":\"Ev4GCioIDhgCIiQyNzc5NjY2OC03MzUxLTQwYWMtYWNjNC0wMjRhZWU4OTk1YTUSDLsCxd2GmA4DtuwhExoM5P6aWBRtuw/DBDPiIjBrENs0838Ry8WBNwqM0a0ZXYCQf+i/tHV8TiDhVpTDWVfXjCiuiUV+U9jiHb9l52UqgQYV97PElkHSRYOQ2Xqg8CIPhTd0oozolk2/+ov9VRxOVHRdqGrUdZnaPPw7cMRkv7dmdLIWuvnvWeFMP22rX8tFcFF7dxyiiSa0pdwRALBlIm/I8YTFAdhBaXlsaJB55QSvSBuNVaQ/KGqQcIRv6LabKa9La8J1sfiGIoWgPzgeDjaB9Y4GIJ7FrcRvmc7NKfaszAzdZ4vG5kqPDTH25QqMj5HGlfF7qXQhhmcEfIp7/oLbpxqyaCuMoBeMXjdCCbyuzkvqxs9HXTtg2wVxokilb0XFnBsuoxR0lRtVcvTwHzNAZiYYQT6rj8JrC+/alaAJKSLZWNBmt7bPcqadKoLDqyDdKCAX+Zk1tFGQeJ9AqGmFIBJu1/VQoCKU2Ch1Uwz56izmrK4Qq8JM1NgvJlFjHfjunriNlqHrJdbrFImUMVaG0d/f7jErYVrHOS/t1n6/5Dx4Rt0Be2Nzhqc4PG+uXLAyLyJpf9r4OiZz701UerllTEx2T4cyZnVd4PhscEw8+wISwqK1XfSyYoJ8Hw16NJbUwhFsq7XS7MlgQfWlvEZNxsII2FlQpdMhieRrL8qZP7ioSzLAbzSeU3Ngo967AAqwY98aihnC4oJnpAUQQ8vdPs0SFVN/4z1cuHGv1SiAzqpv2QCsNnNkhWDl47//6cqNwinNiJ9a/+olDxQry8tXEGJoJMUCG/KoQPYUBFkehU12+VJlJXolTaI7brvhEhMVX6kjzY4k/55SAx8h0H7qNpoHFrxqNHeqQCwD6Hov66lu4v8lgG8seg0Vv/RVAFY9CQusMtAwe+dO2y0mqVMjEVCCUugJF5XUb6OpydhodqtQRK2PCrXAbrLAGsz+JAPRlesxavxx6B6WJFNjCSrvOMkLGEbjljy39C37Kw7qsa0x3uG+pOU2kHDO8N9lgveBOqJ82SmbjuaqazJcCxwu4h8FA1DavTnI6RSfT3bCESvS9hU5AuUq20YEZaxMHlwPZIpIVvl7bm4lLWvHBmD5zzg2a/buixJeBuC9fCkGGAM=\",\"page_age\":null},{\"type\":\"web_search_result\",\"title\":\"Braintrust
+        - The AI observability platform for building quality AI products\",\"url\":\"https://www.braintrust.dev/\",\"encrypted_content\":\"ErIPCioIDhgCIiQyNzc5NjY2OC03MzUxLTQwYWMtYWNjNC0wMjRhZWU4OTk1YTUSDPLwR0/erKDgzZI/RBoMzjFGTwbmAmPP7cOWIjC83FOkM+e0AVzkdeQ+AIl49+VoPL/QPpYo96RXsD08ilwiTjchz306JagAHusxfAkqtQ4Ss/nYwOsdzq4kQYxh8//ZmlEJQKTeIJ6hULeRcUZcsLfvshbuppeBBJu3/uh2juyb655nDnZ4TN8OJ6LoeNkjDrvOqjttxqfWuJIFqPzXHtWfvX7sBIjQLV3CMftZwd8GuYSVlAwZ5iJmBDpObQDf1dkP85TGN4k6k/qejFqajJ5SODUagN4y+FtbkVrjO8/1JUXKlwAxAB60Bua4icbaOEbf5nJ5u3QhrlMgn+DHRjsOEwU4/qNmIyX3zAbZiUKfsb1x8YJr3W9Y8o6Hzwv0MlRG5NL7Vkf6/4uTlWDATLVOXbIYce83lT5ciWW1M941CCS860RcV4Sin3A1lKPOujmm4dFs1NY8/uNgUYorrhmw0Vfx2sTc9K7Y/yvImjBewBCO3HL1CqUprFORxprM6r0WPexZE6uDbmgXnewopW/qKgCjWTbO9Avg1frn2WZcYxTCgClKYBlq6Rs/u21RDtZw6rKSDC4MU9/cLxXF/wcPZPmlti+uGTz9pA/jR7jYyoANWP9FeA7UEu20jQ91i/Uf+XyhuQFS2pylpvfMgrr+B9WO2oRXjrAqImBGtQMy4LsyT+/4XmuwFe24FobAHyU4FdFoHVq9qwTI+ZQMdyo1z+n4uf6NCryI52mQlgoajosPxHbpk1X2INJCsOxlfh2OAwf6gV+7D/wcp6hbXM3e5bWYxMx6RFFeJg6xTnbWNMOWhHb0qwFewkJsTflTZiHb0MXIGf8e5KhJhQiHtiJF71BIOolLW89ugMD/ZyxdMTI/kFY5MNNBZC+2ZZ7fACRuoF/tZR9Ft4XPaXSUlXeIj1ObAiL5lw+3N6/0t5tWv1cT3aSD/cdpZhRO4jhSGQpgk7KuKDSDc/zl7DMOV+CWuSUXI4iFNJm587Tq+vnwXYlt5ud48lwWCMwI92cZbzmf1rvoqHrSWp7BDbyzMs8UYjGx+PmzWW0jGgC3e1uXcilyFIfGrtj39uCA0V9wyeuhWNGVOJIJLzmI0twYkcvLEupR18rkqZlPMQm70MiKIn0895qSIE4bRSisw9k3o90b7jMQWxlJwPP7b5u8eZyuEgpX7QyHGUdL/Tfx31pAdMzwL+whESlSC6l61OBEq9+jCZqI22Bpwg+BxG7EZPoKTTG1dOMpflcRFCFs1bUmDzBCh5vN+u07VuTBm0FRYqT6qGVVMznQIhZ773dohcHbepiQJ7faHx/1c51FTrFZ9hwHq8DXFy+jYJl1tuDxUG6+7WHmWlijMBQsWPBT5++S9th7Sx23rTzAdsmn42Q76NG9RbqfAjdNqnMvKEyWsL0Ql1bkVcR5jXWhzp6+cMCIASxveKPtmEK0ImvydEBgIqAP/OSWCFCOJ0cYg2JYVPqP8eljfQkzZc6j/tOvqBtPKwPa0zb/opcMLjCMZpV+srRx/rePrv0VVo+YP40lhDIEqBEccs26KormcQmmZf9weJgAVXq25iwSz6AG9cH6re0EmEQH1ev2yg2HPRfAySp4AGA7pljclXwIO+vS8k355dYr90GxPYrfl4HzVRqpjwCY7w7EURiO9w87VCR70/34cQw28+J4uVXNwpmXt90/JIrWiF6+doT/ss8nBra4d59G4E3DWabdLQDT4WS3IrYScUQdQQYyFSV3yjFbiys2oXEgKzThR6BKsBSQgfpPhUn0J4YkvYfqLRwM0cO9Mjxdi+nxuW6+NwVwAUdc2N0UW7irNC8JZ8Sqo8Fu0+auNf+cpeoCJf5pjV6ltYG2dTcN8d/Uf2U7wt7wjtN42mg219Dv1sYckE1p2H4gEYYcpJMYRZeuLX8icYR9RUoqtA3UBm7o67MJNl7vxYq5rv2jgX1gvIZLh+itzPGEs25qIV/C3RZtf/sg03JKB4ocKZ7btAQpCYv75Ql4nfuGWt/69+AYw1EZKN+T3eVu/YH62j2/nsrx+x+newCLhvOfq5nL5xPE0/r4hqF/WlYTyPxyaZBy4pw7sM6EU0/rbVWae9aX8Cdm20PKgOZaGm3mMWc8xIUVrtmsi7HJKtz+wkZYUZzSJTeOnd5Ig2hhaV9PORTgWE4I0rAabVojT4knnoYxjAa5cCWRFcl9A3voGwHH2U+1DBKvKm/rKeEK6QyfMgJUNzOlAl/vUVsU7YkRy5vJMa4Vl+SQ8ZiNbgwPjgLWcW9AosBZcWSnfXgmeFR28X2q460McSsVInQD0I/MjLMSjT4C6ItgISfAdpw5KeJBmD2UKLZ++o5gLgbtZ8xtgQZ6+HFQmksoz/0QR+re3rXKQphnKzQELFMuGSsGWLCEuja0UEqZpgrZSP0ZIlaY7Ka2zU85bXKuPvrarUxj/E7fMnV46NHYWBU+VCT54Km+cl4PTP00xX2Q3O/CchuOnMsuWbaKQ+nK41PxZUTL/87hxKvhRhNRmfzrwwMI7RfziIhSOrDXGhaXHajUl7JafOq6k0FP5Qx6wxMAvmuAE+Gu4qgYAw==\",\"page_age\":null},{\"type\":\"web_search_result\",\"title\":\"Braintrust
+        - Chroma Docs\",\"url\":\"https://docs.trychroma.com/integrations/frameworks/braintrust\",\"encrypted_content\":\"EqgBCioIDhgCIiQyNzc5NjY2OC03MzUxLTQwYWMtYWNjNC0wMjRhZWU4OTk1YTUSDBVv8A3Jz2kKHlUZ8BoMznMvmmGrTYA852MBIjC7FGrG/mZIXVo5HL0gIWpxaUWYLkq8epnGxktM7Q7DM7No6yatgo8DBb/vexhA494qLOvCg8rqmNEdDTCywwjaViFJ0k1G7VWLG7UxkS6MNd//yohnpVVmELU0AHWfGAM=\",\"page_age\":null},{\"type\":\"web_search_result\",\"title\":\"braintrust
+        - npm\",\"url\":\"https://www.npmjs.com/package/braintrust\",\"encrypted_content\":\"EogECioIDhgCIiQyNzc5NjY2OC03MzUxLTQwYWMtYWNjNC0wMjRhZWU4OTk1YTUSDKdLue2ePF7OqY+VKRoMYKydVpcNh4/VPWP9IjCq2Q/LT26LWPAHWS699j067VPT46tY1u97DT87DA0FARm1VNX/C5Z20SqDktuxapwqiwNwodLs1G85eBOBlxC7aKFwZFgzQ8+LRT1LFKTn79/gIudcXVCy+sW3A7KG7Km58XKt+Lu40ObH//vCWuE75kfFWueTb7y2t9wicFtgVoYlV7KUOzbwXJ6DNjtyM/IJ3VcJ03ZRdV5F2uMcNMFthot0etuFQf7CW+0r+YdF8otWT70FLp0iURFwqDcCQSMK7EfGy7XTwxnXEXsHsaI/r4pVoZ6R8/NHVtWleOqtRmyIMfNyUArb8Gsn2aRJ/Ao6X/zIAFL0U8tRoL2EkW3dTILFR6n85dzeS5/pBBfYM1kM4optfscQuWCDdcpGbR+ldbuEQnEYWeKeanUns4rCSDcgCkU0cNzAIJvYTxXEyAKILEUuP7H78HWKtHbiskcFLP7mn34vpbpvdHUkFG39Z5ky4QSEzzP6q2/w3laY56u7gC5vwoOF6mjDGG9+qQ93Nc6hlb2lx8lTnaD5UhtcdsUSHRklqdGpKTCLGWmi/uvMPsjc0ho1ZWtwE2Qpl3v+JFux90q2H5H2bR63BRgD\",\"page_age\":\"1
+        month ago\"},{\"type\":\"web_search_result\",\"title\":\"Braintrust Integration
+        - Browserbase Documentation\",\"url\":\"https://docs.browserbase.com/integrations/braintrust/introduction\",\"encrypted_content\":\"EoQFCioIDhgCIiQyNzc5NjY2OC03MzUxLTQwYWMtYWNjNC0wMjRhZWU4OTk1YTUSDIYIIbuLMTJ8oFbAJhoMdYOJbgUtSR+ih+OOIjC1TbMmSa3SZhuM1H/qK4xOSkqmOleUa/6vcM/UT0u1q4KjP8SKIBswkVUAqCs2S6cqhwRrne/KpErB8P9f/OTk2LBNM3LfhtRP869GIAlxtTu9pPQR3/mbRrcrMjkC+vRCeoGKXjRhAXPgnFXqwepO5hmjdnFSCCwYCo5u9mqped9BVMh5UHox1DUdExEQC3pEKCZr1pfJaR5rgOYHTu0wjYQdNUFxpNt04+Bb5kv/AfKRqaYXPniVIUhyA8sIvTkB9FRu9kj4UEEmWwtShiYNA51Fz+L5eF6EuQAjP7DN2QPLNsXRFol5gF9jHM4c5TUu4Gkby0J66wIkfdc+jDvG1WtZOZUqg/teHJAwLLFdy0FjPztmZphE3yABsYAo2c3/xncx3PPSqPxY7YJWvXfW7T9pzsX0UXq3p1d6auEySFtjZR0mX64DguybblosnagmW8UpppsWEZefyM0BnF7Jg+T1AeY1xdfateVLo3LKBlFGdTmPPvgxfEcimr0YiDYSBhEOzacKQDFUjd0X2SLI9RrEpyBJYGVKQcBsrNjiuzefW9tPbFi0Ie94iI/mUoDYZ6YCXYoH6Z4KMOskmy1BIwnPNZhV2OmSuF/ZEVkW/oH8fWY650eucXSgcG0Nq2pmATDHCzNkyNZOEhC2HbGAOmkdhN0IeyAE1xZAGJvLnYa7qj+9qKj2VuM+0nwHLHeUATPr1Nr25QWP8zEED0326jgSm1xytvKzhodtV+k8OApcNzbHyM5v9KsYAw==\",\"page_age\":null},{\"type\":\"web_search_result\",\"title\":\"Braintrust
+        - Apps Documentation - Make\",\"url\":\"https://apps.make.com/braintrust\",\"encrypted_content\":\"Eo4LCioIDhgCIiQyNzc5NjY2OC03MzUxLTQwYWMtYWNjNC0wMjRhZWU4OTk1YTUSDKCAaY+gNAlbFvb7eBoM/7E82zLZ70EfhFqLIjBNC8wpniGwfLFUP0BeDWG8p8CG4/Btkux8yzpUH/PzxivJ2JTKjI+2ha500v7gvqEqkQq2Y8R4wITn55AmP2Yi0oW3oEhHFudKd/YfxtgLrZn+5rGAeV9gnZLz730O1wXRbwYW+VHJX2s8nnhiS/nWSDzN1v3ay/1t6B+Bb3eWjJ5JxC+gvkJigHUp0xHWN01RQwdzXnfjaigi7Ax310v1FJ4aaRbga9/5Hp/iPWRm7BFp3LO1lSjF5JhQbaQluu/KKNs6k0PapF8lsLj9eXsgmlgZf8nMuSYY8Q0xXCsuYTwDW0GZ9DIH06Wq9NW71CmEuhduvqs+a/sbCXvM4Vjc4KgF43MsGeHFS4U/yMfyBqzLOt0kwo/etmoHidyOEWV9NXH4SkPOm91T8COGKWgqYf3beN8Rpy6TQXeBON3pnz5fLeAJZCbs6xeoZyil+H8e+Gm/UTSoi4fNxoh6zQQcQntoezLSGzsKmpfvFUkXHbuXH6pfoHWT8wu89KXRVnhzMOHXFv0erQbZeFLwKC+vixJXwU5tdF5tyh/JCdoLQ2cvVVi7SPwuwnP6U+FqTtmp7wu+9ad4pQaZyLGcCoXrG95WSHnQuq6SYeNy1aQo3KdgQDBROoZhrez0VKoWfxpwlvhU4hwmamViNVfa3yAIBRymkusnkyvFvFoYGhqYcC6a7y/bcHlcrYwNxiU5m1szx1A2R/O2g73mBUF6KGgoHLcfUr0LSlcyiGIgt+h1N6rIllqnOg6TQa9xcyODJaJJmahRnkF2JjC0/+FtN4V6XBaatmo7bws1nr2dYzPzUvY7b5cfFQcVWz9rfrq6/5Lw1VSXIl3gl9iNfk3JJLZ6LxASXC888nl3eMfA3i7m9RSy8Y3cQXJ7SbcKAIzFg0/n8C7Nwl++1TSAn5WdGPNIYo5rvbjkyGxylzR4pnh6ropoVhsSvovu6JvRdCCng7EZv5LOU2KTtgpHuf4cSPrGDyJxSAniRRN6/cta4Uw8dvcpI1WEuWehmuwwJoriDotzI9+3za/iUNU7Xt/5xU8fwVxR82tE7QIDu/EVltTdv8FM2seEimtqEnttMxD4kkRGem+sMJofNVBXup6w1d1EkIoLSV8T7m/97wQplcVW4zsweKeH6qrvvumw6nwAZfiAIFrwR+LGNz8zTVzK0FryIj2TDGV0cL+0FONppIQkxLcBIijSNmrcI/uqzpUPyaktn77iFeUJLSpvA8W0MQmpAtMIFDCROxYG2Xzwv3oQHZUwXK4De4qJB1e94shJBy9DAVwQQhVP9kYnsglp/dZalqx4ej/IJqsdqp6fmNaxHOPtneO/XWp3vBQnlNRU3uzIDuvLjLziTFU5U10ECvlEsBc020rO7zMjXQW3BUlcQdX+Gey1em6A811YkaXINKZx/88MpbVhZkDEaMVXjhILlTWl5QSLbp3gLg2/EdvW3sWVyQzeXeDPd+lDcYE0n15Flv4u0ed9bQBrELX9m8PE4TF9vxWodGNKOuacFriry7mRwbmwLGMXAO48NEGwwveCKRf7cesoeDA8dwIUwkP9JKXYw8S9sMgpqnmhsQy1Liw5JBaI2NOPmkaf3LhB3iPgCD8DlX43nDX+YSXru3sCWGzlHmQupX65K9fGox9szwouZQ3OMGjZopcdheGOwVX6g9msP9W1yg9Ar5IWQ2LqXliriqNMFoj/4jIrP7z8Y8Jlwr9mcBkzdahxLnVE8/4UO86YLg/w91klNtjrfjxcArYli/6/WvXOZXA/BDEDNwMhwYEtW3Ne9YxyXXO6gSSd75HqGAM=\",\"page_age\":null},{\"type\":\"web_search_result\",\"title\":\"braintrust
+        \xB7 PyPI\",\"url\":\"https://pypi.org/project/braintrust/\",\"encrypted_content\":\"Ep8gCioIDhgCIiQyNzc5NjY2OC03MzUxLTQwYWMtYWNjNC0wMjRhZWU4OTk1YTUSDGvYZ4wEsN6LL3XQORoMb7Com4CdQohL/5JwIjCPCjN3tg5ZBspRbdrqic8HX7wHkVdl+cu0mQKccLWoJ5lPmLYgtC9+sXkTqhkpHd0qoh9TOk0JcqfT2QCRDpdTfmBVaSLI/1AQ2a/iQThcn2LYex+r8NbCIhehulDVhV9f6d0R4NcFYWOuri6XyC7e5yINB5obDONXY/zhgs+EwDFOIn+d975MUQziOZ1BHfzw70bHdmDkmiWQubpTDpbs7OFzy+wz4jsKzKnJtG6OqpkDoXhO2ejMPMpoHf8LgjA/Lv/krGYbFJ0uQKdVUESPTBrPWwShUMfKMVxbDWxrTVYpFXTDLJRIzb+2e1L9TU4sBkmnipgpfySrj6sE4TbTbzTo+dc5Wuew/7B4ihJVo93qXS67A1WqgFsH9NF0kvzLd42OG+PomZKAiFa+EEYHe56lBR1pNzYCqDMW1DiqYubZVk+B/VR+DjpGvV2d/Z36bQ1nVmYdxbwtDU4sKpu/ClurFuq+GepLATPwRbBiBgvl4XIgRYWt1VYwRcF45IAlv0EMRoB6FChinCtY7CpaIg9Jkelaci9917REwJElMNop60RGwmNQyoCbDlSwmZcd+vi8DVQ9BnyrG8hjrZBxsyNUc1ErGsUgrn5coGCtbL8xrkdQ1xd0//2Ul6mIKHtKCnHmcRaWUMEkHl46qYGi7P1LCCkm7b6XPez2OUZ5mQaehmtfcDXwnRSeBUTHgJYvJYWzXrF59zHTsesmFy2RHn278xo0p7FXMCE2aZRKmtKy3MyMuv53OofDR9mi0W8IUMazJT8oOKnDFI+abD7Y2ZI3zezNQ18+zsQzB2cHMsNwVk9vs2x51ULAtwzBKNaJY+5wr1IkK8INVMdnj/Ui+1IT+mB+QDNEteeGWOjS0EIxjekJHBSvyNSdzZDNimJhzi96H0DHWaioPkCN4mGXbfK1u9YQrsvmx/hU19p5eOV95/okyybLT44KyjM6NSdwpYmvGgJMX0c5TFjraSm9IHN9Bk2YYChq6qYPOwvxnsELCTeXk1vrG34HHgrOxGm3CpI1u1U8uNnowWpbBzZ9xrocGo8q5k5XeGs/PK8o5oQANewVJE1HDu56ly1nDtEDTydsxtbAlpVTDtsnDGVDVHw76X+YVzEZM5snALtj9BuBr666VQE3haj63n1ZD/IrFaqvw5iTWaYX/hTD0J3xzH6UqM8gB906WlDlqDjSzSPxdKCHpptoLBa/JUDmmNjYZ10bjFg/uxaVMUdQ7yqGuOY1xmtfKBVje9JbKKOpZoV91vaRlp5WNj2xb6mWkkiKoBq1eoBh/E/sCbUhtB+OwRVR7Yrw6NUGUHK78tXccidLzPKNx3lhFjVQX4fncSIA5InP1lZDOjQ8l1rzjlnLz1ExPhPgdZOlr8qgTohCtQou54TGOHAtvhFfCO9GLxfOxuaEzXNfBO9vt/RYfCc0tncyzW3dWom9R5eq8wAg4Epau2ffr2ChguiGcF9m7DWrVjzLFs8UA9x4SY2UGDRRhddlzpq14uuC8stNKRUAsDTu+StjKiYd17cb2SKq1w+NeJf+O0nECA5fhhBB6LbbgnQtok2v5KEgAar5ymJjH5tyoLXRlHDBXnAs4F4qUH0IiwAHkSavWdKI/d8iz0Tf9qkHWUFNIE8mZJfiXg4eToYyqASSlvaYfq+D3eT9rr+FyyeyU4PQjkPoTpQqIkBRa/WJKdjYHsJMecqZRXfZbOoiFcUylqxErtvQQpEx+HUzKnAjCdhC7j4oKqxFFaIrPpX5sYaG4F7g8jKK7+CJJ2nZXfWVGy8KVOlTyvlCXLbZpTXiiyjxTVcTiGZUYp00mfhKIyRHwQLc7j2QCMc/iYLMC9RJ0IKg76iFBDW4OMXWS0gwKTKfjmm/dRsTPKiFgSTxUaREIG7oTAP/vAGTmV03u6pBKsph4qUGEMAcdvjBhv4sMRO5trf2SRdpfid18debRGGCDd+krO/a25gcppnklzZNVS0FQeUP/Gfj3eFmEOqYzOZneJPr7kFwFEHkw23v/DrAYnFZxylA4oO53FW62nMCoQ/48V4ejv8JjxxhR+KPMvEgKFfkAmPw6JGHlSX2ySLWANmCNRxlE7etsHZj6QM4V/uAgdg71kBbSsaahyXEpbuHggohGUsj4QGgcITu5yS9FWHXSBpTutgDIFh9VrlRYoVlC+z6+uP3InKicsx/lkZym6kTpsO0HnNcFCbsJFWD037WSeu528kgRCKNZF5g19vRwySwRs/duP1VkwvaNRBSsM7v55+MqFz3ko/QeL9dgN7jqyrJguOafE+pdoHtvTXnlXhERB6aTxcghBkG3976RAEoy3MrgRS+Cr3oKSB0oMf1gbaytUGwPne5p3no6A5UvUOwy2wEnhlngXV4tweBytMdKGfuYS/TqXo3EDJhMIoRNf7d2ZXkI25z4vUWtHhBzxDjwCgS/oUwsq+UF4Km+KB4kFg0jNZYNAIrv3AaKXAucULxFOlZsCdwK3Bj65PGMhcqyrKMqO7pjCXTXbi+rKvBQeZqL8JKvLpDScxcWIrsXdGxPQu+h6sxynkpH6HozCeYMVjoKKukWNpcccHWRGyEbmIgzKtkq/ezG8vxAoUF/C3icBiHbOgDNNYUCyknNfJk8xMjisuL7KaJkTrmwfCylR0f40wBG1yk2pYk3ETuc58RGmW894A0umQNmvVf8Z3qGCr+UyV1ZfqELxrwT/kk7FtBAtxPLYTo5RsPxV9bvLmEhdyd3/L4ZGEpDlHCJhir6m17ybz23UO/rb5S45xN7u4dk4tTeqlTCCpOSnwjX4nnmBamVC6+paL1MGfw4E4kNHz2EkT8FsvcpPnFXY6fqxZ24sCOEP/3cUWSFR20n+KV1lLmggFQJKdJMRNLmhfVkrNJqgLKu/6jl5KhGlRtAj24yZZ380Nke5srVuyy+6XHiznoJ5TYwJNrwRnTEjbu6YmkAHG/8nabQEWHBf4JgSpOWIcXvsk+lSwxXVYwKSRAB3eF1CkEVrMCHSeDGmkgcL0o45DGH0UwB3hUXzhJFtmzw5RzHTaEfUqE5I24bPt7X89x331JdvWni6H3VBCtHU2J1DJNwKk8wjHJLNb/08LLjmS0v3mFApVL1ASpsF+o9M5xmEw5hL66c5pKI7L6rZPA0butd9ciX1EJrgXpSK5AziI9CW89OiVRU4mQuI6lZ+eDSIWGiveRzQmPhhkchFQ3x1hfdDolEG8mvJvjidvucaDFJx+iwAmqz1Sbm1a14QUl/8zfN63Y6whyM6NdDEkBoznauuNZCkojvT7sslg5xZM1C3jpyQu8ivkkpc1LnPCaGu84ovKjY9tSHls7eJ+ULMvZaiLVp82kkUGuOSk/Y70+G2+Yw9KWXGKK0bPR30rOWnBQTZYO8J2AZH91Cq0ovAM73bG0PY7f91CF/B4vTnxZOEhQQlHzZf43DAcOW5ePQIhmXiUovCe3ZWPb7Oh41EYBYiRWvTjGVxhPuzcdVujW7iz036lrZeugrQub3Rls3kHsFqQj87G+AdzhKAZfyT/qLVcuLa42dJzirfyTz2NLON7vXD7bIu7KV6rENvcMylBtx/T97W75fFxIx8eiG1E15KtpLxn2GXN1QSfC7CS9+LuZgsfhqqWsTt0wWATwiTiowxSkCOxkqlY0YNI7f8Eh8++GqX73toNZGhZ0McyI7mzAG/mRv4+avQnQkVlQYOTrSMJHyJI9RlnWnCvdOdeJWj362efEqG2zqJL/yOT+N/0dFehJeg5Bge4iWTC9107Pj1LyUBrSlES42pvI4y1UiOQpNCnvu/s9zravVzgJhsSxVxJ7GJFNfB44tFBFGuckecBqzbYhnSihEN+3xwFtO7h0HnPXNQVJsjs7VTuXORus0lUUO0anAwceiQ9kQM1OMhfIKUaJMy9l21hyRvvdnqlSlK9+7yjWwnQKCQnU83n7c325CUKmV2NL55bcHlxEDZqxlimw3+5eJeUnyxFVXtn3W8pmtklS3r8KrojswQVtsi7pGsl6elnx9La8lPo90KfCb41AWBf2XMyAtwsUKCZAC0vu/fsaCJdMVOzOe6EBu0AclZMbFMTf1OqeXS0Lx1j5LGEnDLKXQpNfH/aBbFrMmSnP2XBoLdlB5QnQnE0bWOaJm4B4TO9e6pMipeyQ2ruYLbzt3QMMS2/wepVpIWXoFfSe7Iil0p6XpHDZkYjXmCDUkFMTxC9RtB0VqgP9CFv/wt7dEoJMNh67QbS8LVBZM3H29JWpxD8cfw8q7DSSVKZPavaGACRReKdEKsVMiGvcXmTgYP96vpA9gxt8s/0OovBv3cxlIF9LEXJYYGWmGBNGJUqBxtj/wVxh4vjY9JYj1czlFBrYo4yl+hcFWSPKj4zy+Jx2FOk+fDmX+QbDL3lRKNm6I8LkSUxRaRUdkWgUaCVKH20xQF2QFrJexYyXZNBHO2gewNkJEWDqJICGMdnwauEf8XZv5fJ/h4lH8EtElDPjU4RaUMfY+S5PFTp8jWW/rwoykjfFHvX8pL7mRpVOalD/rSKiMpLAI2ZwHZcOQ+Zrli0MsCpsqVZSk5lXsh+RGzHSBGd0LTSK//4gnwC0YSgoySJ7gUGCW9tRiROv6eG57Ekw5dI/Nmvn8oXX32t5MwpbkOCnajG1pbffkjUe/bFylPrnhmDC8VIrV5t0Yl2G3Wj57zGHc04xbk84LCyjy6dnko+ZZacCtZXTlo/TMxTSejHRMEgDN6SYEjlK6/BqosJKLEmE1hiM0Xy448d2YTX2bAA2nsexwFN8QTPNFFKe7lXrRtX1VqI28cHdh5fghVLCQ1ua9r85As233EIJFrNZdsUgnffu2r9dRniJgt7ADxjYUH7Iz67Pttp6wPa1s7b//AQktphosarWonzIsmXL5M0feRGtsn4mYLh6kS5FhAMQgh9Q6pSAgVpijRFkTfjuOU6awaZXhGcvXILvsG8sX98NEC9AkDhXDAWeo9zIAvIj7jtaCBr1ioJgSYnVO2Akbp5ViEI5l8c0qH9LsZW5zA4GmJ0xzAkxnQGjs1YGKSJMmNGSjmYH1qXGtFmshTYAkGXhcnlun3LLaqDlcRCIGUCsU0Rm2w6wC/Y4yU1tp7dspatqywoCrLWWU5Zz3tUnuAKk/kwBkqBMDeaNj/w16gk/rQe1/ZOQPsv/zxs0CUrxe9LA/ooTtx9sOcVfqFtHR5/GwZY7lYr1fsRIQSKAlI61sK8YfUbqedlV2HhJlLT8YzxeRy76Gm92pePRVURHQglsKM3uz58PJ6aobzv04UxbwkSUEgt7uuFk8hKhGZY2OOfu55p+eS1cpoFAFc2WAxundOkyVR6Kn7N/8JxeKqLbC4wK+EzR2XYcWjveiv8pX3dJX4+B1pjE41HB7HwdNTCh2jrpp1jId80KZfPmoH2sYfezmpalp0gYAw==\",\"page_age\":null},{\"type\":\"web_search_result\",\"title\":\"Guides
+        - Docs - Braintrust\",\"url\":\"https://www.braintrust.dev/docs/guides\",\"encrypted_content\":\"EvUCCioIDhgCIiQyNzc5NjY2OC03MzUxLTQwYWMtYWNjNC0wMjRhZWU4OTk1YTUSDKNCqb5VrM52TFV4FxoMSCfdAC3m1Bh+MgygIjBeZGQSo09mQ4m8st/Ki1MmpyT878YrYTuvfzEZCavX98CxpqUT8B+nLE5LuES0LFAq+AFm1xd5RvZ8+FA9/TTI5HB4ns70YvgKnJvTSveZ9p8yMG4DCABR5p4JWGtq5ccMtru4JVTcsu7xb0e2jxAQT59pnV0TsrItFeScGBq/ViG9wxhdBy9tDcmSUJKPtvNW6mRjMMWuEZqc8R0+uR2EdJ7IzzHybdUvBO2YHV66iF6Vz9m9mrH404Q8i8OnBd66rVGo50+ml/XsIsS+rNH7w7Lcbg9OxK1Cr9axb5p0O47m6P9An9v8gry87Yzm6Yl1avaR6VsKO06KbCZ8Hu6dbjCTHim6SD6SIoYk9sxSt/zSQd7FLTFdIfedofa32/yx6pQHsg5JFaiGlRgD\",\"page_age\":null}],\"caller\":{\"type\":\"direct\"}},{\"type\":\"text\",\"text\":\"https://www.braintrust.dev/docs\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":9716,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":43,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\",\"server_tool_use\":{\"web_search_requests\":1,\"web_fetch_requests\":0}}}"
+    headers:
+      CF-RAY:
+      - 9ea4db74cc564c9b-YYZ
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 10 Apr 2026 21:31:15 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 27796668-7351-40ac-acc4-024aee8995a5
+      anthropic-ratelimit-input-tokens-limit:
+      - '4000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '3993000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2026-04-10T21:31:15Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '800000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '800000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2026-04-10T21:31:15Z'
+      anthropic-ratelimit-requests-limit:
+      - '20000'
+      anthropic-ratelimit-requests-remaining:
+      - '19999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-04-10T21:31:14Z'
+      anthropic-ratelimit-tokens-limit:
+      - '4800000'
+      anthropic-ratelimit-tokens-remaining:
+      - '4793000'
+      anthropic-ratelimit-tokens-reset:
+      - '2026-04-10T21:31:15Z'
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '19745'
+      request-id:
+      - req_011CZvobkA7cGuGEWQ5ZjMN4
+      server-timing:
+      - x-originResponse;dur=1528
+      set-cookie:
+      - _cfuvid=R7oe2JRXSnVuxyfgfECyqePfYOZkCXUE0OsX6JvmP9U-1775856674.0493748-1.0.1.1-0yBoXdAM5zZ27DU_uviq1_Vbg.ADrUOBxtNNC2lvlFY;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=api.anthropic.com
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      vary:
+      - Accept-Encoding
+      x-envoy-upstream-service-time:
+      - '1526'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/anthropic/test_anthropic.py
+++ b/py/src/braintrust/integrations/anthropic/test_anthropic.py
@@ -19,7 +19,8 @@ from braintrust.integrations.anthropic.tracing import (
     _get_metadata_from_kwargs,
     _log_message_to_span,
 )
-from braintrust.test_helpers import init_test_logger
+from braintrust.span_types import SpanTypeAttribute
+from braintrust.test_helpers import find_span_by_name, find_spans_by_type, init_test_logger
 
 
 PROJECT_NAME = "test-anthropic-app"
@@ -73,6 +74,12 @@ def _get_supported_structured_output_param():
             },
         )
     pytest.skip("Installed anthropic SDK does not support structured outputs parameters")
+
+
+def _skip_if_server_tool_content_blocks_unsupported():
+    required_type_names = ("ServerToolUseBlock", "WebSearchToolResultBlock")
+    if not all(hasattr(anthropic.types, type_name) for type_name in required_type_names):
+        pytest.skip("Installed anthropic SDK does not support Anthropic server tool content blocks")
 
 
 @pytest.fixture
@@ -797,6 +804,73 @@ def test_anthropic_messages_sync(memory_logger):
     assert log["metadata"]["model"] == MODEL
     assert log["output"]["model"] == msg.model
     assert log["output"]["stop_reason"] == msg.stop_reason
+
+
+@pytest.mark.vcr
+def test_anthropic_messages_sync_server_tool_spans(memory_logger):
+    _skip_if_server_tool_content_blocks_unsupported()
+    assert not memory_logger.pop()
+
+    client = wrap_anthropic(_get_client())
+
+    start = time.time()
+    msg = client.messages.create(
+        model=MULTIMODAL_MODEL,
+        max_tokens=256,
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    "Use the web_search tool to find the Braintrust docs homepage. "
+                    "Then answer with exactly the homepage URL and no other text."
+                ),
+            }
+        ],
+        tools=[{"type": "web_search_20250305", "name": "web_search", "max_uses": 1}],
+        tool_choice={"type": "tool", "name": "web_search", "disable_parallel_tool_use": True},
+    )
+    end = time.time()
+
+    tool_use_block = next(block for block in msg.content if block.type == "server_tool_use")
+    result_block = next(block for block in msg.content if block.type == "web_search_tool_result")
+    text_block = next(block for block in msg.content if block.type == "text")
+
+    assert text_block.text == "https://www.braintrust.dev/docs"
+
+    spans = memory_logger.pop()
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
+    tool_spans = find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+
+    assert len(llm_spans) == 1
+    assert len(tool_spans) == 1
+
+    llm_span = find_span_by_name(llm_spans, "anthropic.messages.create")
+    tool_span = find_span_by_name(tool_spans, "web_search")
+
+    _assert_metrics_are_valid(llm_span["metrics"], start, end)
+    assert llm_span["metadata"]["model"] == MULTIMODAL_MODEL
+    assert llm_span["metrics"]["server_tool_use_web_search_requests"] == 1
+    assert llm_span["output"]["model"] == msg.model
+    assert llm_span["output"]["stop_reason"] == msg.stop_reason
+
+    llm_result_block = next(
+        block for block in llm_span["output"]["content"] if block["type"] == "web_search_tool_result"
+    )
+    assert "encrypted_content" in llm_result_block["content"][0]
+
+    assert tool_span["input"] == tool_use_block.input
+    assert isinstance(tool_span["output"], list)
+    assert tool_span["output"][0]["type"] == "web_search_result"
+    assert tool_span["output"][0]["url"] == text_block.text
+    assert tool_span["output"][0]["encrypted_content"] == "<redacted>"
+    assert tool_span["metadata"] == {
+        "tool_use_id": tool_use_block.id,
+        "tool_call_type": "server_tool_use",
+        "tool_result_type": result_block.type,
+        "caller": {"type": "direct"},
+    }
+    assert tool_span["span_parents"] == [llm_span["span_id"]]
+    assert tool_span["root_span_id"] == llm_span["root_span_id"]
 
 
 def _assert_metrics_are_valid(metrics, start, end):

--- a/py/src/braintrust/integrations/anthropic/tracing.py
+++ b/py/src/braintrust/integrations/anthropic/tracing.py
@@ -1,11 +1,13 @@
 import logging
 import time
 import warnings
+from typing import Any
 
 from braintrust.bt_json import bt_safe_deep_copy
-from braintrust.integrations.anthropic._utils import Wrapper, extract_anthropic_usage
+from braintrust.integrations.anthropic._utils import Wrapper, _try_to_dict, extract_anthropic_usage
 from braintrust.integrations.utils import _materialize_attachment
 from braintrust.logger import log_exc_info_to_span, start_span
+from braintrust.span_types import SpanTypeAttribute
 
 
 log = logging.getLogger(__name__)
@@ -475,6 +477,179 @@ def _start_span(name, kwargs):
     return start_span(name=name, type="llm", metadata=metadata, input=_input)
 
 
+_SERVER_TOOL_USE_TYPE = "server_tool_use"
+
+
+def _is_server_tool_result_type(item_type: Any) -> bool:
+    return isinstance(item_type, str) and item_type.endswith("_tool_result") and item_type != "tool_result"
+
+
+def _tool_span_name(call_item: dict[str, Any] | None, result_item: dict[str, Any] | None) -> str:
+    if isinstance((call_item or {}).get("name"), str):
+        return call_item["name"]
+
+    result_type = (result_item or {}).get("type")
+    if isinstance(result_type, str) and result_type.endswith("_tool_result"):
+        return result_type.removesuffix("_tool_result")
+
+    return "server_tool"
+
+
+def _tool_span_input(call_item: dict[str, Any] | None) -> Any:
+    if not call_item:
+        return None
+
+    if call_item.get("input") is not None:
+        return call_item["input"]
+
+    return {key: value for key, value in call_item.items() if key not in {"id", "type", "name", "caller"}} or None
+
+
+_SERVER_TOOL_SPAN_REDACTED_KEYS = frozenset({"encrypted_content"})
+
+
+def _redact_server_tool_output(value: Any) -> Any:
+    value = bt_safe_deep_copy(value)
+
+    def _redact(inner: Any) -> Any:
+        if isinstance(inner, list):
+            return [_redact(item) for item in inner]
+        if isinstance(inner, dict):
+            return {
+                key: ("<redacted>" if key in _SERVER_TOOL_SPAN_REDACTED_KEYS else _redact(item))
+                for key, item in inner.items()
+            }
+        return inner
+
+    return _redact(value)
+
+
+def _tool_span_output(result_item: dict[str, Any] | None) -> Any:
+    if not result_item:
+        return None
+
+    if "content" in result_item:
+        return _redact_server_tool_output(result_item.get("content"))
+
+    return (
+        _redact_server_tool_output(
+            {key: value for key, value in result_item.items() if key not in {"tool_use_id", "type", "caller"}}
+        )
+        or None
+    )
+
+
+def _tool_span_error(result_item: dict[str, Any] | None) -> str | None:
+    if not result_item:
+        return None
+
+    content = result_item.get("content")
+    if not isinstance(content, dict):
+        content = _try_to_dict(content)
+    if not isinstance(content, dict):
+        return None
+
+    content_type = content.get("type")
+    if not (isinstance(content_type, str) and content_type.endswith("_error")):
+        return None
+
+    error_message = content.get("error_message")
+    if isinstance(error_message, str) and error_message:
+        return error_message
+
+    error_code = content.get("error_code")
+    if isinstance(error_code, str) and error_code:
+        return error_code
+
+    return content_type
+
+
+def _tool_span_metadata(call_item: dict[str, Any] | None, result_item: dict[str, Any] | None) -> dict[str, Any] | None:
+    metadata = {
+        key: value
+        for key, value in {
+            "tool_use_id": (call_item or {}).get("id") or (result_item or {}).get("tool_use_id"),
+            "tool_call_type": (call_item or {}).get("type"),
+            "tool_result_type": (result_item or {}).get("type"),
+            "caller": (call_item or {}).get("caller") or (result_item or {}).get("caller"),
+        }.items()
+        if value is not None
+    }
+    return metadata or None
+
+
+def _log_server_tool_span(parent_span, call_item: dict[str, Any] | None, result_item: dict[str, Any] | None) -> None:
+    tool_span = start_span(
+        name=_tool_span_name(call_item, result_item),
+        type=SpanTypeAttribute.TOOL,
+        parent=parent_span.export(),
+        input=_tool_span_input(call_item),
+        metadata=_tool_span_metadata(call_item, result_item),
+    )
+    try:
+        output = _tool_span_output(result_item)
+        if output is None:
+            return
+
+        error = _tool_span_error(result_item)
+        if error is not None:
+            tool_span.log(output=output, error=error)
+        else:
+            tool_span.log(output=output)
+    finally:
+        tool_span.end()
+
+
+def _log_server_tool_spans(content: Any, parent_span) -> None:
+    if not isinstance(content, list):
+        return
+
+    calls_by_id: dict[str, dict[str, Any]] = {}
+    pending_results_by_id: dict[str, list[dict[str, Any]]] = {}
+    matched_call_ids: set[str] = set()
+    pairs: list[tuple[dict[str, Any] | None, dict[str, Any] | None]] = []
+
+    for item in content:
+        item = _try_to_dict(item)
+        if not isinstance(item, dict):
+            continue
+
+        item_type = item.get("type")
+        if item_type == _SERVER_TOOL_USE_TYPE:
+            call_id = item.get("id")
+            if isinstance(call_id, str):
+                calls_by_id[call_id] = item
+                for pending_result in pending_results_by_id.pop(call_id, []):
+                    pairs.append((item, pending_result))
+                    matched_call_ids.add(call_id)
+            else:
+                pairs.append((item, None))
+            continue
+
+        if not _is_server_tool_result_type(item_type):
+            continue
+
+        tool_use_id = item.get("tool_use_id")
+        if isinstance(tool_use_id, str) and tool_use_id in calls_by_id:
+            pairs.append((calls_by_id[tool_use_id], item))
+            matched_call_ids.add(tool_use_id)
+        elif isinstance(tool_use_id, str):
+            pending_results_by_id.setdefault(tool_use_id, []).append(item)
+        else:
+            pairs.append((None, item))
+
+    for call_item, result_item in pairs:
+        _log_server_tool_span(parent_span, call_item, result_item)
+
+    for call_id, call_item in calls_by_id.items():
+        if call_id not in matched_call_ids:
+            _log_server_tool_span(parent_span, call_item, None)
+
+    for pending_results in pending_results_by_id.values():
+        for result_item in pending_results:
+            _log_server_tool_span(parent_span, None, result_item)
+
+
 def _log_message_to_span(message, span, time_to_first_token: float | None = None):
     usage = getattr(message, "usage", {})
     metrics, metadata = extract_anthropic_usage(usage)
@@ -482,11 +657,12 @@ def _log_message_to_span(message, span, time_to_first_token: float | None = None
     if time_to_first_token is not None:
         metrics["time_to_first_token"] = time_to_first_token
 
+    content = getattr(message, "content", None)
     output = {
         k: v
         for k, v in {
             "role": getattr(message, "role", None),
-            "content": getattr(message, "content", None),
+            "content": content,
             "model": getattr(message, "model", None),
             "stop_reason": getattr(message, "stop_reason", None),
             "stop_sequence": getattr(message, "stop_sequence", None),
@@ -495,6 +671,7 @@ def _log_message_to_span(message, span, time_to_first_token: float | None = None
     } or None
 
     span.log(output=output, metrics=metrics, metadata=metadata)
+    _log_server_tool_spans(content, span)
 
 
 _BRAINTRUST_TRACED = "__braintrust_traced__"

--- a/py/src/braintrust/integrations/claude_agent_sdk/test_claude_agent_sdk.py
+++ b/py/src/braintrust/integrations/claude_agent_sdk/test_claude_agent_sdk.py
@@ -40,7 +40,7 @@ from braintrust.integrations.claude_agent_sdk.tracing import (
 )
 from braintrust.logger import start_span
 from braintrust.span_types import SpanTypeAttribute
-from braintrust.test_helpers import init_test_logger
+from braintrust.test_helpers import find_span_by_name, find_spans_by_type, init_test_logger
 from braintrust.wrappers.test_utils import verify_autoinstrument_script
 
 
@@ -382,11 +382,11 @@ async def test_user_prompt_submit_hook_creates_function_span(memory_logger):
     assert hook_invocations, "Expected the UserPromptSubmit hook to be invoked"
 
     spans = memory_logger.pop()
-    task_span = _find_span_by_name(_find_spans_by_type(spans, SpanTypeAttribute.TASK), "Claude Agent")
-    llm_spans = _find_spans_by_type(spans, SpanTypeAttribute.LLM)
+    task_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.TASK), "Claude Agent")
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
     function_spans = [
         span
-        for span in _find_spans_by_type(spans, SpanTypeAttribute.FUNCTION)
+        for span in find_spans_by_type(spans, SpanTypeAttribute.FUNCTION)
         if span.get("metadata", {}).get("claude_agent_sdk.hook.event_name") == "UserPromptSubmit"
     ]
 
@@ -472,10 +472,10 @@ async def test_tool_hooks_create_function_spans(memory_logger):
     )
 
     spans = memory_logger.pop()
-    task_span = _find_span_by_name(_find_spans_by_type(spans, SpanTypeAttribute.TASK), "Claude Agent")
+    task_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.TASK), "Claude Agent")
     hook_spans = [
         span
-        for span in _find_spans_by_type(spans, SpanTypeAttribute.FUNCTION)
+        for span in find_spans_by_type(spans, SpanTypeAttribute.FUNCTION)
         if span.get("metadata", {}).get("claude_agent_sdk.hook.event_name") in {"PreToolUse", "PostToolUse"}
     ]
 
@@ -542,11 +542,11 @@ async def test_hook_spans_parent_to_matching_tool_and_final_llm(memory_logger):
     )
 
     spans = memory_logger.pop()
-    tool_spans = _find_spans_by_type(spans, SpanTypeAttribute.TOOL)
-    llm_spans = _find_spans_by_type(spans, SpanTypeAttribute.LLM)
+    tool_spans = find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
     hook_spans = [
         span
-        for span in _find_spans_by_type(spans, SpanTypeAttribute.FUNCTION)
+        for span in find_spans_by_type(spans, SpanTypeAttribute.FUNCTION)
         if span.get("metadata", {}).get("claude_agent_sdk.hook.event_name") in {"PreToolUse", "PostToolUse", "Stop"}
     ]
 
@@ -615,7 +615,7 @@ async def test_bundled_subagent_creates_task_span(memory_logger):
     task_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.TASK]
     assert len(task_spans) >= 2, f"Expected root task span and subagent span, got {len(task_spans)}"
 
-    root_task_span = _find_span_by_name(task_spans, "Claude Agent")
+    root_task_span = find_span_by_name(task_spans, "Claude Agent")
     subagent_spans = [s for s in task_spans if s["span_attributes"]["name"] != "Claude Agent"]
     tool_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.TOOL]
     assert subagent_spans, "Expected at least one subagent task span"
@@ -707,7 +707,7 @@ async def test_multiple_bundled_subagents_keep_outer_orchestration_separate(memo
     llm_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.LLM]
     tool_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.TOOL]
 
-    root_task_span = _find_span_by_name(task_spans, "Claude Agent")
+    root_task_span = find_span_by_name(task_spans, "Claude Agent")
     subagent_spans = [s for s in task_spans if s["span_attributes"]["name"] != "Claude Agent"]
     assert len(subagent_spans) >= 2, f"Expected at least two delegated task spans, got {len(subagent_spans)}"
 
@@ -773,10 +773,10 @@ async def test_five_parallel_bundled_subagents_preserve_task_parenting(memory_lo
                     break
 
     spans = memory_logger.pop()
-    task_spans = _find_spans_by_type(spans, SpanTypeAttribute.TASK)
-    tool_spans = _find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+    task_spans = find_spans_by_type(spans, SpanTypeAttribute.TASK)
+    tool_spans = find_spans_by_type(spans, SpanTypeAttribute.TOOL)
 
-    root_task_span = _find_span_by_name(task_spans, "Claude Agent")
+    root_task_span = find_span_by_name(task_spans, "Claude Agent")
     subagent_spans = [span for span in task_spans if span["span_id"] != root_task_span["span_id"]]
     assert len(subagent_spans) == 5, f"Expected 5 delegated task spans, got {len(subagent_spans)}"
 
@@ -859,13 +859,13 @@ async def test_delegated_subagent_llm_and_tool_spans_nest_under_task_span(memory
             break
 
     spans = memory_logger.pop()
-    task_spans = _find_spans_by_type(spans, SpanTypeAttribute.TASK)
-    llm_spans = _find_spans_by_type(spans, SpanTypeAttribute.LLM)
-    tool_spans = _find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+    task_spans = find_spans_by_type(spans, SpanTypeAttribute.TASK)
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
+    tool_spans = find_spans_by_type(spans, SpanTypeAttribute.TOOL)
 
-    subagent_task_span = _find_span_by_name(task_spans, "Inspect release notes")
-    agent_tool_span = _find_span_by_name(tool_spans, "Agent")
-    read_tool_span = _find_span_by_name(tool_spans, "Read")
+    subagent_task_span = find_span_by_name(task_spans, "Inspect release notes")
+    agent_tool_span = find_span_by_name(tool_spans, "Agent")
+    read_tool_span = find_span_by_name(tool_spans, "Read")
 
     assert agent_tool_span["span_id"] in subagent_task_span["span_parents"]
 
@@ -977,13 +977,13 @@ async def test_multiple_subagent_orchestration_keeps_outer_agent_tool_calls_outs
             break
 
     spans = memory_logger.pop()
-    task_spans = _find_spans_by_type(spans, SpanTypeAttribute.TASK)
-    llm_spans = _find_spans_by_type(spans, SpanTypeAttribute.LLM)
-    tool_spans = _find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+    task_spans = find_spans_by_type(spans, SpanTypeAttribute.TASK)
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
+    tool_spans = find_spans_by_type(spans, SpanTypeAttribute.TOOL)
 
-    root_task_span = _find_span_by_name(task_spans, "Claude Agent")
-    alpha_task_span = _find_span_by_name(task_spans, "Read alpha release notes")
-    beta_task_span = _find_span_by_name(task_spans, "Read beta release notes")
+    root_task_span = find_span_by_name(task_spans, "Claude Agent")
+    alpha_task_span = find_span_by_name(task_spans, "Read alpha release notes")
+    beta_task_span = find_span_by_name(task_spans, "Read beta release notes")
 
     agent_tool_spans = [span for span in tool_spans if span["span_attributes"]["name"] == "Agent"]
     assert len(agent_tool_spans) == 2
@@ -1114,11 +1114,11 @@ async def test_relay_user_messages_between_parallel_agent_calls_do_not_split_llm
             break
 
     spans = memory_logger.pop()
-    task_spans = _find_spans_by_type(spans, SpanTypeAttribute.TASK)
-    llm_spans = _find_spans_by_type(spans, SpanTypeAttribute.LLM)
-    tool_spans = _find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+    task_spans = find_spans_by_type(spans, SpanTypeAttribute.TASK)
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
+    tool_spans = find_spans_by_type(spans, SpanTypeAttribute.TOOL)
 
-    root_task_span = _find_span_by_name(task_spans, "Claude Agent")
+    root_task_span = find_span_by_name(task_spans, "Claude Agent")
 
     # Both Agent tool spans should exist
     agent_tool_spans = [span for span in tool_spans if span["span_attributes"]["name"] == "Agent"]
@@ -1250,8 +1250,8 @@ async def test_agent_tool_spans_encapsulate_child_task_spans(memory_logger):
             break
 
     spans = memory_logger.pop()
-    task_spans = _find_spans_by_type(spans, SpanTypeAttribute.TASK)
-    tool_spans = _find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+    task_spans = find_spans_by_type(spans, SpanTypeAttribute.TASK)
+    tool_spans = find_spans_by_type(spans, SpanTypeAttribute.TOOL)
 
     agent_tool_spans = [s for s in tool_spans if s["span_attributes"]["name"] == "Agent"]
     assert len(agent_tool_spans) == 2, f"Expected 2 Agent tool spans, got {len(agent_tool_spans)}"
@@ -1423,10 +1423,6 @@ class FakeCancelledClaudeSDKClient(FakeClaudeSDKClient):
         raise asyncio.CancelledError
 
 
-def _find_spans_by_type(spans: list[dict[str, Any]], span_type: str) -> list[dict[str, Any]]:
-    return [span for span in spans if span.get("span_attributes", {}).get("type") == span_type]
-
-
 def _make_fake_sdk_mcp_tool_class():
     class FakeSdkMcpTool:
         def __init__(self, name, description, input_schema, handler, **kwargs):
@@ -1437,15 +1433,6 @@ def _make_fake_sdk_mcp_tool_class():
             self.handler = handler
 
     return FakeSdkMcpTool
-
-
-def _find_span_by_name(spans: list[dict[str, Any]], name: str) -> dict[str, Any]:
-    for span in spans:
-        if span["span_attributes"]["name"] == name:
-            return span
-
-    available_names = [span["span_attributes"]["name"] for span in spans]
-    raise AssertionError(f"Expected span named {name!r}. Available spans: {available_names}")
 
 
 def _clear_tool_span_tracker() -> None:
@@ -1470,7 +1457,7 @@ async def test_receive_response_suppresses_unexpected_cancelled_error_empty_stre
     assert received == []
 
     spans = memory_logger.pop()
-    task_spans = _find_spans_by_type(spans, SpanTypeAttribute.TASK)
+    task_spans = find_spans_by_type(spans, SpanTypeAttribute.TASK)
     assert len(task_spans) == 1
     assert task_spans[0]["span_attributes"]["name"] == "Claude Agent"
     assert task_spans[0].get("error") is None
@@ -1497,7 +1484,7 @@ async def test_receive_response_suppresses_cancelled_error_after_messages(memory
     assert len(received) == 2
 
     spans = memory_logger.pop()
-    task_spans = _find_spans_by_type(spans, SpanTypeAttribute.TASK)
+    task_spans = find_spans_by_type(spans, SpanTypeAttribute.TASK)
     assert len(task_spans) == 1
     task_span = task_spans[0]
     assert task_span["span_attributes"]["name"] == "Claude Agent"
@@ -1506,7 +1493,7 @@ async def test_receive_response_suppresses_cancelled_error_after_messages(memory
     assert task_span.get("output") is not None
     assert task_span["output"]["role"] == "assistant"
 
-    llm_spans = _find_spans_by_type(spans, SpanTypeAttribute.LLM)
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
     assert len(llm_spans) == 1
 
 
@@ -1540,7 +1527,7 @@ async def test_receive_response_suppresses_cancelled_error_mid_stream(memory_log
     assert len(received) == 1
 
     spans = memory_logger.pop()
-    task_spans = _find_spans_by_type(spans, SpanTypeAttribute.TASK)
+    task_spans = find_spans_by_type(spans, SpanTypeAttribute.TASK)
     assert len(task_spans) == 1
     task_span = task_spans[0]
     assert task_span.get("error") is None
@@ -1647,8 +1634,8 @@ def test_tool_span_tracker_lifecycle(memory_logger):
         llm_span.end()
 
     spans = memory_logger.pop()
-    llm_span_log = _find_span_by_name(spans, "anthropic.messages.create")
-    tool_span = _find_span_by_name(spans, "calculator")
+    llm_span_log = find_span_by_name(spans, "anthropic.messages.create")
+    tool_span = find_span_by_name(spans, "calculator")
 
     assert tool_span["input"] == {"operation": "multiply", "a": 6, "b": 7}
     assert tool_span["output"] == {"content": "42"}
@@ -1682,7 +1669,7 @@ def test_tool_span_tracker_logs_errors(memory_logger):
         llm_span.end()
 
     spans = memory_logger.pop()
-    tool_span = _find_span_by_name(spans, "calculator")
+    tool_span = find_span_by_name(spans, "calculator")
 
     assert tool_span["output"] == {"content": "Division by zero", "is_error": True}
     assert tool_span["error"] == "Division by zero"
@@ -1707,7 +1694,7 @@ def test_tool_span_tracker_cleanup_closes_unmatched_spans(memory_logger):
         llm_span.end()
 
     spans = memory_logger.pop()
-    tool_span = _find_span_by_name(spans, "weather")
+    tool_span = find_span_by_name(spans, "weather")
 
     assert tool_span["input"] == {"city": "Toronto"}
     assert tool_span.get("output") is None
@@ -1752,7 +1739,7 @@ async def test_wrapped_tool_handler_creates_fallback_tool_span_without_active_st
     assert result == {"content": [{"type": "text", "text": "42"}]}
 
     spans = memory_logger.pop()
-    tool_span = _find_span_by_name(_find_spans_by_type(spans, SpanTypeAttribute.TOOL), "calculator")
+    tool_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.TOOL), "calculator")
 
     assert tool_span["input"] == {"operation": "multiply", "a": 6, "b": 7}
     assert tool_span["output"] == {"content": [{"type": "text", "text": "42"}]}
@@ -1932,7 +1919,7 @@ def test_tool_span_tracker_records_mcp_metadata(memory_logger):
         llm_span.end()
 
     spans = memory_logger.pop()
-    tool_span = _find_span_by_name(spans, "read_file")
+    tool_span = find_span_by_name(spans, "read_file")
 
     assert tool_span["input"] == {"path": "/tmp/test.txt"}
     assert tool_span["output"] == {"content": "file contents"}
@@ -1992,8 +1979,8 @@ async def test_wrapped_tool_handler_keeps_nested_traces_under_stream_tool_span(m
     assert result == {"content": [{"type": "text", "text": "42"}]}
 
     spans = memory_logger.pop()
-    tool_span = _find_span_by_name(_find_spans_by_type(spans, SpanTypeAttribute.TOOL), "calculator")
-    nested_span = _find_span_by_name(spans, "nested_tool_work")
+    tool_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.TOOL), "calculator")
+    nested_span = find_span_by_name(spans, "nested_tool_work")
 
     assert tool_span["span_id"] in nested_span["span_parents"]
 
@@ -2053,12 +2040,12 @@ async def test_wrapped_tool_handler_matches_same_name_tool_spans_by_input(memory
     spans = memory_logger.pop()
     calculator_spans = [
         span
-        for span in _find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+        for span in find_spans_by_type(spans, SpanTypeAttribute.TOOL)
         if span["span_attributes"]["name"] == "calculator"
     ]
     tool_span_by_input = {tuple(sorted(span["input"].items())): span for span in calculator_spans}
-    nested_span_first = _find_span_by_name(spans, "nested_tool_work_2")
-    nested_span_second = _find_span_by_name(spans, "nested_tool_work_10")
+    nested_span_first = find_span_by_name(spans, "nested_tool_work_2")
+    nested_span_second = find_span_by_name(spans, "nested_tool_work_10")
 
     assert (
         tool_span_by_input[(("a", 2), ("b", 3), ("operation", "add"))]["span_id"] in nested_span_first["span_parents"]
@@ -2242,14 +2229,14 @@ async def test_concurrent_subagents_produce_parallel_llm_spans_with_correct_pare
                     break
 
     spans = memory_logger.pop()
-    task_spans = _find_spans_by_type(spans, SpanTypeAttribute.TASK)
-    llm_spans = _find_spans_by_type(spans, SpanTypeAttribute.LLM)
-    tool_spans = _find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+    task_spans = find_spans_by_type(spans, SpanTypeAttribute.TASK)
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
+    tool_spans = find_spans_by_type(spans, SpanTypeAttribute.TOOL)
 
     all_tools = round1_tools + round2_tools
 
     # --- 1. Root TASK span exists ---
-    _find_span_by_name(task_spans, "Claude Agent")
+    find_span_by_name(task_spans, "Claude Agent")
 
     if not _sdk_version_at_least("0.1.11"):
         # SDK 0.1.10 replays a limited cassette (single assistant + result);
@@ -2259,7 +2246,7 @@ async def test_concurrent_subagents_produce_parallel_llm_spans_with_correct_pare
     # --- 2. All subagent TASK spans exist ---
     subagent_task_by_label: dict[str, dict[str, Any]] = {}
     for sa in subagents:
-        subagent_task_by_label[sa["label"]] = _find_span_by_name(task_spans, f"Task {sa['label']}")
+        subagent_task_by_label[sa["label"]] = find_span_by_name(task_spans, f"Task {sa['label']}")
 
     task_id_by_span = {t["span_id"]: label for label, t in subagent_task_by_label.items()}
 
@@ -2369,10 +2356,10 @@ async def test_interleaved_subagent_tool_spans_preserve_output(memory_logger):
                     break
 
     spans = memory_logger.pop()
-    tool_spans = _find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+    tool_spans = find_spans_by_type(spans, SpanTypeAttribute.TOOL)
 
-    bash_span = _find_span_by_name(tool_spans, "Bash")
-    read_span = _find_span_by_name(tool_spans, "Read")
+    bash_span = find_span_by_name(tool_spans, "Bash")
+    read_span = find_span_by_name(tool_spans, "Read")
 
     # Both tool spans should have their output recorded
     assert bash_span.get("output") is not None, (
@@ -2420,21 +2407,21 @@ async def test_interleaved_subagent_tool_spans_parent_to_correct_llm(memory_logg
                     break
 
     spans = memory_logger.pop()
-    llm_spans = _find_spans_by_type(spans, SpanTypeAttribute.LLM)
-    tool_spans = _find_spans_by_type(spans, SpanTypeAttribute.TOOL)
-    task_spans = _find_spans_by_type(spans, SpanTypeAttribute.TASK)
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
+    tool_spans = find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+    task_spans = find_spans_by_type(spans, SpanTypeAttribute.TASK)
 
-    _find_span_by_name(task_spans, "Claude Agent")
+    find_span_by_name(task_spans, "Claude Agent")
 
     if not _sdk_version_at_least("0.1.11"):
         # SDK 0.1.10 replays a limited cassette; only assert root task span.
         return
 
-    alpha_task = _find_span_by_name(task_spans, "Process alpha file")
-    beta_task = _find_span_by_name(task_spans, "Process beta file")
+    alpha_task = find_span_by_name(task_spans, "Process alpha file")
+    beta_task = find_span_by_name(task_spans, "Process beta file")
 
-    bash_span = _find_span_by_name(tool_spans, "Bash")
-    read_span = _find_span_by_name(tool_spans, "Read")
+    bash_span = find_span_by_name(tool_spans, "Bash")
+    read_span = find_span_by_name(tool_spans, "Read")
 
     # Find each tool's parent LLM span
     bash_parent_llm_id = bash_span["span_parents"][0]
@@ -2499,7 +2486,7 @@ async def test_concurrent_subagent_tool_output_not_silently_dropped(memory_logge
         llm_span.end()
 
     spans = memory_logger.pop()
-    bash_span = _find_span_by_name(
+    bash_span = find_span_by_name(
         [s for s in spans if s.get("span_attributes", {}).get("type") == SpanTypeAttribute.TOOL],
         "Bash",
     )
@@ -2642,7 +2629,7 @@ async def test_identical_concurrent_tool_calls_from_sibling_subagents_disambigua
 
     spans = memory_logger.pop()
     echo_spans = [
-        s for s in _find_spans_by_type(spans, SpanTypeAttribute.TOOL) if s["span_attributes"]["name"] == "echo"
+        s for s in find_spans_by_type(spans, SpanTypeAttribute.TOOL) if s["span_attributes"]["name"] == "echo"
     ]
     assert len(echo_spans) == 2, f"Expected 2 echo tool spans, got {len(echo_spans)}"
 

--- a/py/src/braintrust/integrations/google_genai/test_google_genai.py
+++ b/py/src/braintrust/integrations/google_genai/test_google_genai.py
@@ -9,7 +9,7 @@ from braintrust import logger
 from braintrust.integrations.google_genai import setup_genai
 from braintrust.logger import Attachment
 from braintrust.span_types import SpanTypeAttribute
-from braintrust.test_helpers import init_test_logger
+from braintrust.test_helpers import find_span_by_name, find_spans_by_type, init_test_logger
 from braintrust.wrappers.test_utils import verify_autoinstrument_script
 from google.genai import types
 
@@ -1218,14 +1218,6 @@ async def test_google_search_grounding_async(memory_logger, mode):
     _assert_grounding_metadata(span["output"])
 
 
-def _find_spans_by_type(spans, span_type):
-    return [span for span in spans if span["span_attributes"]["type"] == span_type]
-
-
-def _find_span_by_name(spans, name):
-    return next(span for span in spans if span["span_attributes"]["name"] == name)
-
-
 def _interaction_function_tool():
     return interactions.Function(
         type="function",
@@ -1256,8 +1248,8 @@ def test_interactions_create_and_get(memory_logger):
     assert fetched.status == "completed"
 
     spans = memory_logger.pop()
-    create_span = _find_span_by_name(_find_spans_by_type(spans, SpanTypeAttribute.LLM), "interactions.create")
-    get_span = _find_span_by_name(_find_spans_by_type(spans, SpanTypeAttribute.TASK), "interactions.get")
+    create_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.LLM), "interactions.create")
+    get_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.TASK), "interactions.get")
 
     assert create_span["metadata"]["model"] == INTERACTIONS_MODEL
     assert create_span["metadata"]["interaction_id"] == response.id
@@ -1290,7 +1282,7 @@ def test_interactions_create_stream(memory_logger):
     assert events
 
     spans = memory_logger.pop()
-    create_span = _find_span_by_name(_find_spans_by_type(spans, SpanTypeAttribute.LLM), "interactions.create")
+    create_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.LLM), "interactions.create")
 
     assert create_span["metadata"]["model"] == INTERACTIONS_MODEL
     assert create_span["output"]["status"] == "completed"
@@ -1333,12 +1325,12 @@ def test_interactions_tool_call_and_follow_up(memory_logger):
     assert "sunny" in second_response.outputs[-1].text.lower()
 
     spans = memory_logger.pop()
-    llm_spans = _find_spans_by_type(spans, SpanTypeAttribute.LLM)
-    tool_spans = _find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
+    tool_spans = find_spans_by_type(spans, SpanTypeAttribute.TOOL)
 
     first_span = next(span for span in llm_spans if span["metadata"]["interaction_id"] == first_response.id)
     second_span = next(span for span in llm_spans if span["metadata"]["interaction_id"] == second_response.id)
-    tool_span = _find_span_by_name(tool_spans, "get_weather")
+    tool_span = find_span_by_name(tool_spans, "get_weather")
 
     assert first_span["output"]["status"] == "requires_action"
     assert second_span["metadata"]["previous_interaction_id"] == first_response.id
@@ -1383,13 +1375,13 @@ def test_interactions_tool_span_stays_active_during_local_tool_work(memory_logge
     assert second_response.status == "completed"
 
     spans = memory_logger.pop()
-    llm_spans = _find_spans_by_type(spans, SpanTypeAttribute.LLM)
-    tool_spans = _find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
+    tool_spans = find_spans_by_type(spans, SpanTypeAttribute.TOOL)
 
     first_span = next(span for span in llm_spans if span["metadata"]["interaction_id"] == first_response.id)
     second_span = next(span for span in llm_spans if span["metadata"]["interaction_id"] == second_response.id)
-    tool_span = _find_span_by_name(tool_spans, "get_weather")
-    nested_span = _find_span_by_name(spans, "nested_tool_work")
+    tool_span = find_span_by_name(tool_spans, "get_weather")
+    nested_span = find_span_by_name(spans, "nested_tool_work")
 
     assert tool_span["span_parents"] == [first_span["span_id"]]
     assert nested_span["span_parents"] == [tool_span["span_id"]]
@@ -1417,7 +1409,7 @@ def test_interactions_delete(memory_logger):
     assert delete_response == {}
 
     spans = memory_logger.pop()
-    delete_span = _find_span_by_name(_find_spans_by_type(spans, SpanTypeAttribute.TASK), "interactions.delete")
+    delete_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.TASK), "interactions.delete")
 
     assert delete_span["input"]["id"] == response.id
     assert delete_span["output"] == {}
@@ -1443,9 +1435,9 @@ async def test_interactions_async_round_trip(memory_logger):
     assert deleted == {}
 
     spans = memory_logger.pop()
-    create_span = _find_span_by_name(_find_spans_by_type(spans, SpanTypeAttribute.LLM), "interactions.create")
-    get_span = _find_span_by_name(_find_spans_by_type(spans, SpanTypeAttribute.TASK), "interactions.get")
-    delete_span = _find_span_by_name(_find_spans_by_type(spans, SpanTypeAttribute.TASK), "interactions.delete")
+    create_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.LLM), "interactions.create")
+    get_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.TASK), "interactions.get")
+    delete_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.TASK), "interactions.delete")
 
     assert create_span["metadata"]["model"] == INTERACTIONS_MODEL
     assert create_span["output"]["status"] == "completed"
@@ -1478,7 +1470,7 @@ async def test_interactions_async_stream(memory_logger):
     assert events
 
     spans = memory_logger.pop()
-    create_span = _find_span_by_name(_find_spans_by_type(spans, SpanTypeAttribute.LLM), "interactions.create")
+    create_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.LLM), "interactions.create")
 
     assert create_span["output"]["status"] == "completed"
     assert create_span["output"]["text"]

--- a/py/src/braintrust/test_helpers.py
+++ b/py/src/braintrust/test_helpers.py
@@ -115,6 +115,20 @@ def init_test_logger(project_name: str):
     return l
 
 
+def find_spans_by_type(spans, span_type):
+    """Filter spans by their span_attributes type."""
+    return [span for span in spans if span.get("span_attributes", {}).get("type") == span_type]
+
+
+def find_span_by_name(spans, name):
+    """Find a single span by its span_attributes name. Raises AssertionError with available names if not found."""
+    for span in spans:
+        if span["span_attributes"]["name"] == name:
+            return span
+    available_names = [span["span_attributes"]["name"] for span in spans]
+    raise AssertionError(f"Expected span named {name!r}. Available spans: {available_names}")
+
+
 def init_test_exp(experiment_name: str, project_name: str = None):
     """
     Initialize an experiment for testing with fake project and experiment metadata.


### PR DESCRIPTION
Add VCR-backed coverage for Anthropic server-side web search responses and emit child TOOL spans for server_tool_use / *_tool_result content blocks.

Keep the full provider payload on the parent LLM span, but redact bulky encrypted_content fields from child TOOL span output to avoid duplicating large payloads in traces.

resolves https://github.com/braintrustdata/braintrust-sdk-python/issues/250