### PR TITLE
feat(litellm: instrument rerank

### DIFF
--- a/py/src/braintrust/integrations/litellm/patchers.py
+++ b/py/src/braintrust/integrations/litellm/patchers.py
@@ -7,10 +7,12 @@ from braintrust.integrations.base import FunctionWrapperPatcher
 from .tracing import (
     _acompletion_wrapper_async,
     _aembedding_wrapper_async,
+    _arerank_wrapper,
     _aresponses_wrapper_async,
     _completion_wrapper,
     _embedding_wrapper,
     _moderation_wrapper,
+    _rerank_wrapper,
     _responses_wrapper,
 )
 
@@ -62,6 +64,18 @@ class LiteLLMModerationPatcher(FunctionWrapperPatcher):
     wrapper = _moderation_wrapper
 
 
+class LiteLLMRerankPatcher(FunctionWrapperPatcher):
+    name = "litellm.rerank"
+    target_path = "rerank"
+    wrapper = _rerank_wrapper
+
+
+class LiteLLMARerankPatcher(FunctionWrapperPatcher):
+    name = "litellm.arerank"
+    target_path = "arerank"
+    wrapper = _arerank_wrapper
+
+
 # ---------------------------------------------------------------------------
 # All patchers, in declaration order
 # ---------------------------------------------------------------------------
@@ -74,6 +88,8 @@ _ALL_LITELLM_PATCHERS = (
     LiteLLMEmbeddingPatcher,
     LiteLLMAembeddingPatcher,
     LiteLLMModerationPatcher,
+    LiteLLMARerankPatcher,
+    LiteLLMRerankPatcher,
 )
 
 

--- a/py/src/braintrust/integrations/litellm/test_litellm.py
+++ b/py/src/braintrust/integrations/litellm/test_litellm.py
@@ -1,5 +1,7 @@
 import asyncio
 import time
+from os import environ
+from unittest.mock import patch
 
 import litellm
 import pytest
@@ -14,6 +16,7 @@ PROJECT_NAME = "test-project-litellm-py-tracing"
 TEST_MODEL = "gpt-4o-mini"  # cheapest model for tests
 TEST_PROMPT = "What's 12 + 12?"
 TEST_SYSTEM_PROMPT = "You are a helpful assistant that only responds with numbers."
+TEST_COHERE_KEY = "TEST_COHERE_KEY"
 
 
 @pytest.fixture(autouse=True)
@@ -542,6 +545,65 @@ async def test_litellm_async_streaming_with_break(memory_logger):
     span = spans[0]
     metrics = span["metrics"]
     assert metrics["time_to_first_token"] >= 0
+
+
+@pytest.mark.vcr
+def test_patch_litellm_rerank(memory_logger):
+    """Test for litellm rerank"""
+    assert not memory_logger.pop()
+
+    query = "What is the capital of the United States?"
+    documents = [
+        "Carson City is the capital city of the American state of Nevada.",
+        "The Commonwealth of the Northern Mariana Islands is a group of islands in the Pacific Ocean. Its capital is Saipan.",
+        "Washington, D.C. is the capital of the United States.",
+        "Capital punishment has existed in the United States since before it was a country.",
+    ]
+
+    with patch.dict(environ, {"COHERE_API_KEY": TEST_COHERE_KEY}):
+        response = litellm.rerank(
+            model="cohere/rerank-english-v3.0",
+            query=query,
+            documents=documents,
+            top_n=3,
+        )
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+
+    assert span["input"] == query
+    assert span["output"] == response.results
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_patch_litellm_arerank(memory_logger):
+    """Test for litellm arerank"""
+    assert not memory_logger.pop()
+
+    query = "What is the capital of the United States?"
+    documents = [
+        "Carson City is the capital city of the American state of Nevada.",
+        "The Commonwealth of the Northern Mariana Islands is a group of islands in the Pacific Ocean. Its capital is Saipan.",
+        "Washington, D.C. is the capital of the United States.",
+        "Capital punishment has existed in the United States since before it was a country.",
+    ]
+
+    with patch.dict(environ, {"COHERE_API_KEY": TEST_COHERE_KEY}):
+        response = await litellm.arerank(
+            model="cohere/rerank-english-v3.0",
+            query=query,
+            documents=documents,
+            top_n=3,
+        )
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+
+    assert span["input"] == query
+    assert span["output"] == response.results
 
 
 def test_patch_litellm_responses():

--- a/py/src/braintrust/integrations/litellm/tracing.py
+++ b/py/src/braintrust/integrations/litellm/tracing.py
@@ -330,6 +330,36 @@ def _moderation_wrapper(wrapped, instance, args, kwargs):
         return moderation_response
 
 
+def _rerank_wrapper(wrapped, instance, args, kwargs):
+    """wrapt wrapper for litellm.rerank."""
+    updated_span_payload = _update_span_payload_from_params(kwargs, input_key="query")
+
+    with start_span(
+        **merge_dicts(dict(name="Rerank", span_attributes={"type": SpanTypeAttribute.LLM}), updated_span_payload)
+    ) as span:
+        rerank_response = wrapped(*args, **kwargs)
+        log_response = _try_to_dict(rerank_response)
+        span.log(
+            output=log_response["results"],
+        )
+        return rerank_response
+
+
+async def _arerank_wrapper(wrapped, instance, args, kwargs):
+    """wrapt wrapper for litellm.arerank."""
+    updated_span_payload = _update_span_payload_from_params(kwargs, input_key="query")
+
+    with start_span(
+        **merge_dicts(dict(name="ARerank", span_attributes={"type": SpanTypeAttribute.LLM}), updated_span_payload)
+    ) as span:
+        arerank_response = await wrapped(*args, **kwargs)
+        log_response = _try_to_dict(arerank_response)
+        span.log(
+            output=log_response["results"],
+        )
+        return arerank_response
+
+
 # ---------------------------------------------------------------------------
 # Streaming post-processing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Instruments `litellm.rerank` api;

ref (#165)

Tests:
Running the test will raise an Invalid API key error as I didn't have a key, so I manually modified the cassette's fields. This is is not acceptable for the final version; if I can get my hands on real HTTP traffic for this API, I will update the PR.

Summary:
<img width="500" height="603" alt="image" src="https://github.com/user-attachments/assets/48cab376-31ea-4f14-ac9e-503f58cc8b63" />
