### PR TITLE
fix(openai): log audio file attachments

### DIFF
--- a/py/src/braintrust/integrations/openai/test_openai.py
+++ b/py/src/braintrust/integrations/openai/test_openai.py
@@ -1927,6 +1927,12 @@ def _is_wrapped(client):
 TEST_AUDIO_FILE = os.path.join(os.path.dirname(__file__), "..", "..", "fixtures", "test_audio.wav")
 
 
+def _assert_audio_input_attachment(span) -> None:
+    assert isinstance(span["input"]["file"], Attachment)
+    assert span["input"]["file"].reference["filename"] == "test_audio.wav"
+    assert span["input"]["file"].reference["content_type"].startswith("audio/")
+
+
 def _write_test_png(path: str, *, width: int = 64, height: int = 64) -> None:
     """Write a simple opaque red RGBA PNG without external dependencies."""
 
@@ -2086,6 +2092,7 @@ def test_openai_audio_transcription(memory_logger):
     span = spans[0]
     assert span["metadata"]["model"] == "whisper-1"
     assert span["metadata"]["provider"] == "openai"
+    _assert_audio_input_attachment(span)
     assert span["output"] == "you"
 
 
@@ -2112,6 +2119,7 @@ def test_openai_audio_transcription_text_format(memory_logger):
     span = spans[0]
     assert span["metadata"]["model"] == "whisper-1"
     assert span["metadata"]["provider"] == "openai"
+    _assert_audio_input_attachment(span)
     assert span["output"] == "you"
 
 
@@ -2137,6 +2145,7 @@ def test_openai_audio_translation(memory_logger):
     span = spans[0]
     assert span["metadata"]["model"] == "whisper-1"
     assert span["metadata"]["provider"] == "openai"
+    _assert_audio_input_attachment(span)
     assert span["output"] == "you"
 
 
@@ -2190,6 +2199,7 @@ async def test_openai_audio_transcription_async(memory_logger):
         span = spans[0]
         assert span["metadata"]["model"] == "whisper-1"
         assert span["metadata"]["provider"] == "openai"
+        _assert_audio_input_attachment(span)
         assert span["output"] == "you"
 
 
@@ -2214,6 +2224,7 @@ async def test_openai_audio_translation_async(memory_logger):
         span = spans[0]
         assert span["metadata"]["model"] == "whisper-1"
         assert span["metadata"]["provider"] == "openai"
+        _assert_audio_input_attachment(span)
         assert span["output"] == "you"
 
 

--- a/py/src/braintrust/integrations/openai/tracing.py
+++ b/py/src/braintrust/integrations/openai/tracing.py
@@ -1288,10 +1288,12 @@ class _AudioFileWrapper(BaseWrapper):
         params = prettify_params(params)
         # Remove the file object after prettifying — prettify_params already
         # made a copy so the original kwargs (used by the API call) are preserved.
-        params.pop("file", None)
+        file_input = _materialize_logged_file_input(params.pop("file", None))
+        input_data = {"file": file_input} if file_input is not None else None
         return merge_dicts(
             ret,
             {
+                "input": input_data,
                 "metadata": {**params, "provider": "openai"},
             },
         )


### PR DESCRIPTION
Log transcription and translation file inputs as Braintrust attachments instead of dropping them from span input.

Add regression coverage for sync and async audio transcription and translation spans to verify the attachment filename and content type.