### PR TITLE
feat(mistral): trace OCR API calls

### DIFF
--- a/py/src/braintrust/integrations/mistral/cassettes/test_wrap_mistral_ocr_process_async.yaml
+++ b/py/src/braintrust/integrations/mistral/cassettes/test_wrap_mistral_ocr_process_async.yaml
@@ -1,0 +1,281 @@
+interactions:
+- request:
+    body: '{"model":"mistral-ocr-latest","document":{"image_url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==","type":"image_url"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.3.2
+    method: POST
+    uri: https://api.mistral.ai/v1/ocr
+  response:
+    body:
+      string: '{"pages":[{"index":0,"markdown":"|  Net cash used in financing activities
+        | Net cash used in financing activities | Net interest income | Net interest
+        income | Net interest income | Net interest income | Net interest income |
+        Net cash used in financing activities  |\n| --- | --- | --- | --- | --- |
+        --- | --- | --- |\n|  Net cash used in financing activities | Net cash used
+        in financing activities | Other income | Other income, net | Other income,
+        net | Other | Other | Net cash used in financing activities  |\n|  Net cash
+        used in financing activities | Net cash used in financing activities | Net
+        cash used in financing activities | Other income, net | Other | Other | Other
+        | Other  |\n|  Net cash provided by used in financing activities | Net cash
+        used in financing activities | Net interest income | Other | Other | Other
+        | Other | Other  |\n|  Other | Net cash provided by used in financing activities
+        | Other | Other | Other | Other | Other | Other  |\n|  Other | Other | Other
+        | Other | Other | Other | Other | Other  |\n|  Other | Other | Other | Other
+        | Other | Other | Other | Other  |\n|  Other | Other | Other | Other | Other
+        | Other | Other | Other  |\n|  Other | Other | Other | Other | Other | Other
+        | Other | Other  |\n|  Other | Other | Other | Other | Other | Other | Other
+        | Other  |\n|  Other | Other | Other | Other | Other | Other | Other | Other  |\n|  Other
+        | Other | Other | Other | Other | Other | Other | Other  |\n|  Other | Other
+        | Other | Other | Other | Other | Other assets | Other  |\n|  Other assets
+        | Other assets | Other assets | Other assets | Other assets | Other assets
+        | Other assets | Other assets  |\n|  Other assets | Other assets | Other assets
+        | Other assets | Other assets | Other assets | Other assets | Other assets  |\n|  Other
+        assets | Other assets | Other assets | Other assets | Other assets | Other
+        assets | Other assets | Other assets  |\n|  Other assets | Other assets |
+        Other assets | Other assets | Other assets | Other assets | Other assets |
+        Other assets  |\n|  Other assets | Other assets | Other assets | Other assets
+        | Other assets | Other assets | Other assets | Other assets  |","images":[],"tables":[],"hyperlinks":[],"header":null,"footer":null,"dimensions":{"dpi":200,"height":1,"width":1},"confidence_scores":null}],"model":"mistral-ocr-latest","document_annotation":null,"usage_info":{"pages_processed":1,"doc_size_bytes":70}}'
+    headers:
+      CF-RAY:
+      - 9ebb9a0f98b1c4c7-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Apr 2026 15:46:08 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '2400'
+      mistral-correlation-id:
+      - 019d8785-8600-7e16-9859-7708348b6175
+      set-cookie:
+      - __cf_bm=IH7I6n2GZmDJOfMjqfWYKnJMKcznBwjzQQkRXJ6GO_8-1776095167.932906-1.0.1.1-AGNeOifKcmA4gdce0B63TkhwAHVWZ9xIDHS0mHC4h8MphxELtmtVENMNM.r5dcWhqiTRMv6jHoQloXu1dagdVq6ABbSDOjU2lUt6PHD4uZ2nAm3LjiQ4L6ffc3Epi53k;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Mon, 13 Apr 2026 16:16:08
+        GMT
+      - _cfuvid=f53rlc3o9oMYNxfeKwsm4W.SXtpRYpjDPIWrsq933CY-1776095167.932906-1.0.1.1-FPFlp50Oi__wvXUGpA_6luK6ulLAu.UfdHO7cU0XIR8;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '32'
+      x-kong-proxy-latency:
+      - '10'
+      x-kong-request-id:
+      - 019d8785-8600-7e16-9859-7708348b6175
+      x-kong-upstream-latency:
+      - '33'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"model":"mistral-ocr-latest","document":{"image_url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==","type":"image_url"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.3.2
+    method: POST
+    uri: https://api.mistral.ai/v1/ocr
+  response:
+    body:
+      string: '{"pages":[{"index":0,"markdown":"|  Net cash used in financing activities
+        | Net cash used in financing activities | Net interest income | Net interest
+        income | Net interest income | Net interest income | Net interest income |
+        Net cash used in financing activities  |\n| --- | --- | --- | --- | --- |
+        --- | --- | --- |\n|  Net cash used in financing activities | Net cash used
+        in financing activities | Other income | Other income, net | Other income,
+        net | Other | Other | Net cash used in financing activities  |\n|  Net cash
+        used in financing activities | Net cash used in financing activities | Net
+        cash used in financing activities | Other income, net | Other | Other | Other
+        | Other  |\n|  Net cash provided by used in financing activities | Net cash
+        used in financing activities | Net interest income | Other | Other | Other
+        | Other | Other  |\n|  Other | Net cash provided by used in financing activities
+        | Other | Other | Other | Other | Other | Other  |\n|  Other | Other | Other
+        | Other | Other | Other | Other | Other  |\n|  Other | Other | Other | Other
+        | Other | Other | Other | Other  |\n|  Other | Other | Other | Other | Other
+        | Other | Other | Other  |\n|  Other | Other | Other | Other | Other | Other
+        | Other | Other  |\n|  Other | Other | Other | Other | Other | Other | Other
+        | Other  |\n|  Other | Other | Other | Other | Other | Other | Other | Other  |\n|  Other
+        | Other | Other | Other | Other | Other | Other | Other  |\n|  Other | Other
+        | Other | Other | Other | Other | Other assets | Other  |\n|  Other assets
+        | Other assets | Other assets | Other assets | Other assets | Other assets
+        | Other assets | Other assets  |\n|  Other assets | Other assets | Other assets
+        | Other assets | Other assets | Other assets | Other assets | Other assets  |\n|  Other
+        assets | Other assets | Other assets | Other assets | Other assets | Other
+        assets | Other assets | Other assets  |\n|  Other assets | Other assets |
+        Other assets | Other assets | Other assets | Other assets | Other assets |
+        Other assets  |\n|  Other assets | Other assets | Other assets | Other assets
+        | Other assets | Other assets | Other assets | Other assets  |","images":[],"tables":[],"hyperlinks":[],"header":null,"footer":null,"dimensions":{"dpi":200,"height":1,"width":1},"confidence_scores":null}],"model":"mistral-ocr-latest","document_annotation":null,"usage_info":{"pages_processed":1,"doc_size_bytes":70}}'
+    headers:
+      CF-RAY:
+      - 9ebb9c85199b94e3-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Apr 2026 15:47:48 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '2400'
+      mistral-correlation-id:
+      - 019d8787-0f66-7b82-81a2-3aff096522da
+      set-cookie:
+      - __cf_bm=sNay.R7C0fGQ17HAOFqtk8hykzL_PV3eQNi8NWO3I40-1776095268.6519113-1.0.1.1-EHcbN.Yo9IFeu8vevjgGJMS47H3HikbUDljyndlb.oS8EFr2sRikqUa0lgOCHsxCc4PPRiLbpW7xd.XUIAWv8Y4p8O3zWpTKGV1jdmiTAFHzcZpN98Qnv0MB0Rmyj.4i;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Mon, 13 Apr 2026 16:17:48
+        GMT
+      - _cfuvid=3VrNuUGObin9d34K1eUZvmcLtJ0YSHlSwwrP6NeX5Jo-1776095268.6519113-1.0.1.1-qVs_EFjl8Nvhz.jgKKL5MItg59J393I.TzumDaw3Hn4;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '31'
+      x-kong-proxy-latency:
+      - '11'
+      x-kong-request-id:
+      - 019d8787-0f66-7b82-81a2-3aff096522da
+      x-kong-upstream-latency:
+      - '31'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"model":"mistral-ocr-latest","document":{"image_url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==","type":"image_url"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.3.2
+    method: POST
+    uri: https://api.mistral.ai/v1/ocr
+  response:
+    body:
+      string: '{"pages":[{"index":0,"markdown":"|  Net cash used in financing activities
+        | Net cash used in financing activities | Net interest income | Net interest
+        income | Net interest income | Net interest income | Net interest income |
+        Net cash used in financing activities  |\n| --- | --- | --- | --- | --- |
+        --- | --- | --- |\n|  Net cash used in financing activities | Net cash used
+        in financing activities | Other income | Other income, net | Other income,
+        net | Other | Other | Net cash used in financing activities  |\n|  Net cash
+        used in financing activities | Net cash used in financing activities | Net
+        cash used in financing activities | Other income, net | Other | Other | Other
+        | Other  |\n|  Net cash provided by used in financing activities | Net cash
+        used in financing activities | Net interest income | Other | Other | Other
+        | Other | Other  |\n|  Other | Net cash provided by used in financing activities
+        | Other | Other | Other | Other | Other | Other  |\n|  Other | Other | Other
+        | Other | Other | Other | Other | Other  |\n|  Other | Other | Other | Other
+        | Other | Other | Other | Other  |\n|  Other | Other | Other | Other | Other
+        | Other | Other | Other  |\n|  Other | Other | Other | Other | Other | Other
+        | Other | Other  |\n|  Other | Other | Other | Other | Other | Other | Other
+        | Other  |\n|  Other | Other | Other | Other | Other | Other | Other | Other  |\n|  Other
+        | Other | Other | Other | Other | Other | Other | Other  |\n|  Other | Other
+        | Other | Other | Other | Other | Other assets | Other  |\n|  Other assets
+        | Other assets | Other assets | Other assets | Other assets | Other assets
+        | Other assets | Other assets  |\n|  Other assets | Other assets | Other assets
+        | Other assets | Other assets | Other assets | Other assets | Other assets  |\n|  Other
+        assets | Other assets | Other assets | Other assets | Other assets | Other
+        assets | Other assets | Other assets  |\n|  Other assets | Other assets |
+        Other assets | Other assets | Other assets | Other assets | Other assets |
+        Other assets  |\n|  Other assets | Other assets | Other assets | Other assets
+        | Other assets | Other assets | Other assets | Other assets  |","images":[],"tables":[],"hyperlinks":[],"header":null,"footer":null,"dimensions":{"dpi":200,"height":1,"width":1},"confidence_scores":null}],"model":"mistral-ocr-latest","document_annotation":null,"usage_info":{"pages_processed":1,"doc_size_bytes":70}}'
+    headers:
+      CF-RAY:
+      - 9ebb9cffd8d539f7-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Apr 2026 15:48:08 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '2400'
+      mistral-correlation-id:
+      - 019d8787-5c30-78bc-a3a6-ff7b7555c884
+      set-cookie:
+      - __cf_bm=o6Az8UPZp2UhR5z8K4Lfq.gwFA_HsCeq4MXAfz0Qpy8-1776095288.3010094-1.0.1.1-6D5NsS_IB.uIi8kfv5v3lb_AqQS8ylImm2ASEp.iTvWUZVVpQTkFDVD4.ofLXny0DDt3_4ekiLDfPg6vHLBu7sb77eJlQIcKxGLkmPJ3sNInvXdDEnQ_GVNMYgYOFcmD;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Mon, 13 Apr 2026 16:18:08
+        GMT
+      - _cfuvid=FqS_zjNkDpLPELJnsQSIcHOFkGJSJLRFQNEqyOLR75c-1776095288.3010094-1.0.1.1-90Z07Q9cozksCwt.cmHumKtBC2EZ2ItecgCOAdz3ncU;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '38'
+      x-kong-proxy-latency:
+      - '11'
+      x-kong-request-id:
+      - 019d8787-5c30-78bc-a3a6-ff7b7555c884
+      x-kong-upstream-latency:
+      - '39'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/mistral/cassettes/test_wrap_mistral_ocr_process_sync.yaml
+++ b/py/src/braintrust/integrations/mistral/cassettes/test_wrap_mistral_ocr_process_sync.yaml
@@ -1,0 +1,200 @@
+interactions:
+- request:
+    body: '{"model":"mistral-ocr-latest","document":{"document_url":"data:application/pdf;base64,JVBERi0xLjAKMSAwIG9iago8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiAwIFI+PmVuZG9iagoyIDAgb2JqCjw8L1R5cGUvUGFnZXMvS2lkc1szIDAgUl0vQ291bnQgMT4+ZW5kb2JqCjMgMCBvYmoKPDwvVHlwZS9QYWdlL01lZGlhQm94WzAgMCA2MTIgNzkyXT4+ZW5kb2JqCnhyZWYKMCA0CjAwMDAwMDAwMDAgNjU1MzUgZg0KMDAwMDAwMDAxMCAwMDAwMCBuDQowMDAwMDAwMDUzIDAwMDAwIG4NCjAwMDAwMDAxMDIgMDAwMDAgbg0KdHJhaWxlcgo8PC9TaXplIDQvUm9vdCAxIDAgUj4+CnN0YXJ0eHJlZgoxNDkKJUVPRg==","type":"document_url","document_name":"test.pdf"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '530'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.3.2
+    method: POST
+    uri: https://api.mistral.ai/v1/ocr
+  response:
+    body:
+      string: '{"pages":[{"index":0,"markdown":".","images":[],"tables":[],"hyperlinks":[],"header":null,"footer":null,"dimensions":{"dpi":93,"height":1023,"width":791},"confidence_scores":null}],"model":"mistral-ocr-latest","document_annotation":null,"usage_info":{"pages_processed":1,"doc_size_bytes":292}}'
+    headers:
+      CF-RAY:
+      - 9ebb9a0d4b51aaa4-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Apr 2026 15:46:07 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '293'
+      mistral-correlation-id:
+      - 019d8785-848f-736d-b6d7-956d68b25ce3
+      set-cookie:
+      - __cf_bm=7A91tdWFz370qPz8WSAq0YS99XUhHBEDuXg_ioRP0eg-1776095167.5688546-1.0.1.1-IjQLaeiN586xaGKHIzkyl2oLFDaGNiYqRopDMsOOsnqWix0oslcBNq9Uexi4bLhZ72rDVQcY_GTOPXwbnLiLMx7TvbhTRAbtOXZIzA25xKg.mJhSz1NU_rUdUiEgOkOM;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Mon, 13 Apr 2026 16:16:07
+        GMT
+      - _cfuvid=ucB9tvVhS90ALzq9k3ioTQxhvBrqqWWYyVu5Bo7AKR8-1776095167.5688546-1.0.1.1-z68YNgGE4jZk3dMSqFPnRqZIHiPjwjPDL9bqd4s3PUY;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '34'
+      x-kong-proxy-latency:
+      - '11'
+      x-kong-request-id:
+      - 019d8785-848f-736d-b6d7-956d68b25ce3
+      x-kong-upstream-latency:
+      - '34'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"model":"mistral-ocr-latest","document":{"document_url":"data:application/pdf;base64,JVBERi0xLjAKMSAwIG9iago8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiAwIFI+PmVuZG9iagoyIDAgb2JqCjw8L1R5cGUvUGFnZXMvS2lkc1szIDAgUl0vQ291bnQgMT4+ZW5kb2JqCjMgMCBvYmoKPDwvVHlwZS9QYWdlL01lZGlhQm94WzAgMCA2MTIgNzkyXT4+ZW5kb2JqCnhyZWYKMCA0CjAwMDAwMDAwMDAgNjU1MzUgZg0KMDAwMDAwMDAxMCAwMDAwMCBuDQowMDAwMDAwMDUzIDAwMDAwIG4NCjAwMDAwMDAxMDIgMDAwMDAgbg0KdHJhaWxlcgo8PC9TaXplIDQvUm9vdCAxIDAgUj4+CnN0YXJ0eHJlZgoxNDkKJUVPRg==","type":"document_url","document_name":"test.pdf"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '530'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.3.2
+    method: POST
+    uri: https://api.mistral.ai/v1/ocr
+  response:
+    body:
+      string: '{"pages":[{"index":0,"markdown":".","images":[],"tables":[],"hyperlinks":[],"header":null,"footer":null,"dimensions":{"dpi":93,"height":1023,"width":791},"confidence_scores":null}],"model":"mistral-ocr-latest","document_annotation":null,"usage_info":{"pages_processed":1,"doc_size_bytes":292}}'
+    headers:
+      CF-RAY:
+      - 9ebb9c82da79ac5e-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Apr 2026 15:47:48 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '293'
+      mistral-correlation-id:
+      - 019d8787-0e08-7346-9ff5-4ebb907ef514
+      set-cookie:
+      - __cf_bm=mvzpjP4Uz4KGOfkJvdD_jT_VvoIdPYFboa1aQgUTmls-1776095268.2986305-1.0.1.1-M6v.UZ5w8B9VM59BOLQhdt7TKxDvHQpJIyTkuf84JUmlucfP35pPToX9oECmXcuBD5Wwy_yJJq.0e0STzXQ3hyWjmX2I1NAFnnBmAXLZ.ree6OrVTSfoItU6wMTm8B32;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Mon, 13 Apr 2026 16:17:48
+        GMT
+      - _cfuvid=lEjorf_qXjN_5yZGLTCNVQDLKiebQNV92ipkC1v.Ehw-1776095268.2986305-1.0.1.1-PDfwXtdB3Q6X1KpfsCbdIX52H_22kKZJDswXWDJRC.0;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '45'
+      x-kong-proxy-latency:
+      - '15'
+      x-kong-request-id:
+      - 019d8787-0e08-7346-9ff5-4ebb907ef514
+      x-kong-upstream-latency:
+      - '45'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"model":"mistral-ocr-latest","document":{"document_url":"data:application/pdf;base64,JVBERi0xLjAKMSAwIG9iago8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiAwIFI+PmVuZG9iagoyIDAgb2JqCjw8L1R5cGUvUGFnZXMvS2lkc1szIDAgUl0vQ291bnQgMT4+ZW5kb2JqCjMgMCBvYmoKPDwvVHlwZS9QYWdlL01lZGlhQm94WzAgMCA2MTIgNzkyXT4+ZW5kb2JqCnhyZWYKMCA0CjAwMDAwMDAwMDAgNjU1MzUgZg0KMDAwMDAwMDAxMCAwMDAwMCBuDQowMDAwMDAwMDUzIDAwMDAwIG4NCjAwMDAwMDAxMDIgMDAwMDAgbg0KdHJhaWxlcgo8PC9TaXplIDQvUm9vdCAxIDAgUj4+CnN0YXJ0eHJlZgoxNDkKJUVPRg==","type":"document_url","document_name":"test.pdf"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '530'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.3.2
+    method: POST
+    uri: https://api.mistral.ai/v1/ocr
+  response:
+    body:
+      string: '{"pages":[{"index":0,"markdown":".","images":[],"tables":[],"hyperlinks":[],"header":null,"footer":null,"dimensions":{"dpi":93,"height":1023,"width":791},"confidence_scores":null}],"model":"mistral-ocr-latest","document_annotation":null,"usage_info":{"pages_processed":1,"doc_size_bytes":292}}'
+    headers:
+      CF-RAY:
+      - 9ebb9cfdf94cdde5-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Apr 2026 15:48:08 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '293'
+      mistral-correlation-id:
+      - 019d8787-5af5-701f-9719-60c8e5fa3cca
+      set-cookie:
+      - __cf_bm=_g5G6AyQCBNhfs_Q5Ww1JVARolpIgJOULlD90y_KiZs-1776095287.9923806-1.0.1.1-5juDeZAoN6MNR4RPjavcQYQfXQOGyAgdQupVDZAFQNl.ARtKcqNYPY5m4sM0.5OzoCEQPhazyv3coT2MvTdciaTQnyFGNqz9ibJwwZSSDxzQopwx8K0zij4Jr7ikiNd8;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Mon, 13 Apr 2026 16:18:08
+        GMT
+      - _cfuvid=TZ3jg8sK81a9zVm3XTuBh1J5xX_6.WLSW5ihkby6FEE-1776095287.9923806-1.0.1.1-75eNMdwgVeWXgKK7E6W3P825qufc9lbMOIWZipM8X4s;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '47'
+      x-kong-proxy-latency:
+      - '11'
+      x-kong-request-id:
+      - 019d8787-5af5-701f-9719-60c8e5fa3cca
+      x-kong-upstream-latency:
+      - '47'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/mistral/integration.py
+++ b/py/src/braintrust/integrations/mistral/integration.py
@@ -2,7 +2,7 @@
 
 from braintrust.integrations.base import BaseIntegration
 
-from .patchers import AgentsPatcher, ChatPatcher, EmbeddingsPatcher, FimPatcher
+from .patchers import AgentsPatcher, ChatPatcher, EmbeddingsPatcher, FimPatcher, OcrPatcher
 
 
 class MistralIntegration(BaseIntegration):
@@ -16,4 +16,5 @@ class MistralIntegration(BaseIntegration):
         EmbeddingsPatcher,
         FimPatcher,
         AgentsPatcher,
+        OcrPatcher,
     )

--- a/py/src/braintrust/integrations/mistral/patchers.py
+++ b/py/src/braintrust/integrations/mistral/patchers.py
@@ -17,6 +17,8 @@ from .tracing import (
     _fim_complete_wrapper,
     _fim_stream_async_wrapper,
     _fim_stream_wrapper,
+    _ocr_process_async_wrapper,
+    _ocr_process_wrapper,
 )
 
 
@@ -279,4 +281,44 @@ class AgentsPatcher(CompositeFunctionWrapperPatcher):
         _AgentsStreamV1Patcher,
         _AgentsStreamAsyncV2Patcher,
         _AgentsStreamAsyncV1Patcher,
+    )
+
+
+class _OcrProcessV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.ocr.process.v2"
+    target_module = "mistralai.client.ocr"
+    target_path = "Ocr.process"
+    wrapper = _ocr_process_wrapper
+
+
+class _OcrProcessV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.ocr.process.v1"
+    target_module = "mistralai.ocr"
+    target_path = "Ocr.process"
+    wrapper = _ocr_process_wrapper
+    superseded_by = (_OcrProcessV2Patcher,)
+
+
+class _OcrProcessAsyncV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.ocr.process_async.v2"
+    target_module = "mistralai.client.ocr"
+    target_path = "Ocr.process_async"
+    wrapper = _ocr_process_async_wrapper
+
+
+class _OcrProcessAsyncV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.ocr.process_async.v1"
+    target_module = "mistralai.ocr"
+    target_path = "Ocr.process_async"
+    wrapper = _ocr_process_async_wrapper
+    superseded_by = (_OcrProcessAsyncV2Patcher,)
+
+
+class OcrPatcher(CompositeFunctionWrapperPatcher):
+    name = "mistral.ocr"
+    sub_patchers = (
+        _OcrProcessV2Patcher,
+        _OcrProcessV1Patcher,
+        _OcrProcessAsyncV2Patcher,
+        _OcrProcessAsyncV1Patcher,
     )

--- a/py/src/braintrust/integrations/mistral/test_mistral.py
+++ b/py/src/braintrust/integrations/mistral/test_mistral.py
@@ -31,12 +31,14 @@ try:
     Embeddings = importlib.import_module("mistralai.client.embeddings").Embeddings
     Fim = importlib.import_module("mistralai.client.fim").Fim
     Agents = importlib.import_module("mistralai.client.agents").Agents
+    Ocr = importlib.import_module("mistralai.client.ocr").Ocr
     models = importlib.import_module("mistralai.client.models")
 except ImportError:
     Chat = importlib.import_module("mistralai.chat").Chat
     Embeddings = importlib.import_module("mistralai.embeddings").Embeddings
     Fim = importlib.import_module("mistralai.fim").Fim
     Agents = importlib.import_module("mistralai.agents").Agents
+    Ocr = importlib.import_module("mistralai.ocr").Ocr
     models = importlib.import_module("mistralai.models")
 
 
@@ -45,6 +47,15 @@ CHAT_MODEL = "mistral-small-latest"
 AGENT_MODEL = CHAT_MODEL
 EMBEDDING_MODEL = "mistral-embed"
 FIM_MODEL = "codestral-latest"
+OCR_MODEL = "mistral-ocr-latest"
+TINY_PNG_DATA_URL = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg=="
+)
+TEST_PDF_DATA_URL = (
+    "data:application/pdf;base64,"
+    "JVBERi0xLjAKMSAwIG9iago8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiAwIFI+PmVuZG9iagoyIDAgb2JqCjw8L1R5cGUvUGFnZXMvS2lkc1szIDAgUl0vQ291bnQgMT4+ZW5kb2JqCjMgMCBvYmoKPDwvVHlwZS9QYWdlL01lZGlhQm94WzAgMCA2MTIgNzkyXT4+ZW5kb2JqCnhyZWYKMCA0CjAwMDAwMDAwMDAgNjU1MzUgZg0KMDAwMDAwMDAxMCAwMDAwMCBuDQowMDAwMDAwMDUzIDAwMDAwIG4NCjAwMDAwMDAxMDIgMDAwMDAgbg0KdHJhaWxlcgo8PC9TaXplIDQvUm9vdCAxIDAgUj4+CnN0YXJ0eHJlZgoxNDkKJUVPRg=="
+)
 
 
 @pytest.fixture(scope="module")
@@ -61,6 +72,13 @@ def memory_logger():
 
 def _get_client():
     return Mistral(api_key=os.environ.get("MISTRAL_API_KEY"))
+
+
+def _assert_ocr_metrics_are_valid(metrics, start, end):
+    assert metrics["duration"] >= 0
+    assert metrics["pages_processed"] >= 1
+    assert metrics["doc_size_bytes"] > 0
+    assert start <= metrics["start"] <= metrics["end"] <= end
 
 
 @contextmanager
@@ -285,6 +303,76 @@ async def test_wrap_mistral_agents_stream_async(memory_logger):
 
 
 @pytest.mark.vcr
+def test_wrap_mistral_ocr_process_sync(memory_logger):
+    assert not memory_logger.pop()
+
+    client = wrap_mistral(_get_client())
+    start = time.time()
+    response = client.ocr.process(
+        model=OCR_MODEL,
+        document={
+            "type": "document_url",
+            "document_url": TEST_PDF_DATA_URL,
+            "document_name": "test.pdf",
+        },
+    )
+    end = time.time()
+
+    assert response.pages
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span["metadata"]["provider"] == "mistral"
+    assert span["metadata"]["model"] == OCR_MODEL
+    assert span["metadata"]["document_type"] == "document_url"
+    assert span["metadata"]["page_count"] == len(response.pages)
+    assert span["output"]["pages"]
+    file_data_value = span["input"]["document"]["file"]["file_data"]
+    assert isinstance(file_data_value, Attachment)
+    assert file_data_value.reference["type"] == "braintrust_attachment"
+    assert file_data_value.reference["content_type"] == "application/pdf"
+    assert file_data_value.reference["filename"] == "test.pdf"
+    assert file_data_value.reference["key"]
+    _assert_ocr_metrics_are_valid(span["metrics"], start, end)
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_wrap_mistral_ocr_process_async(memory_logger):
+    assert not memory_logger.pop()
+
+    client = wrap_mistral(_get_client())
+    start = time.time()
+    response = await client.ocr.process_async(
+        model=OCR_MODEL,
+        document={
+            "type": "image_url",
+            "image_url": TINY_PNG_DATA_URL,
+        },
+    )
+    end = time.time()
+
+    assert response.pages
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span["metadata"]["provider"] == "mistral"
+    assert span["metadata"]["model"] == OCR_MODEL
+    assert span["metadata"]["document_type"] == "image_url"
+    assert span["metadata"]["page_count"] == len(response.pages)
+    assert span["output"]["pages"]
+    image_url_value = span["input"]["document"]["image_url"]["url"]
+    assert isinstance(image_url_value, Attachment)
+    assert image_url_value.reference["type"] == "braintrust_attachment"
+    assert image_url_value.reference["content_type"] == "image/png"
+    assert image_url_value.reference["filename"] == "image.png"
+    assert image_url_value.reference["key"]
+    _assert_ocr_metrics_are_valid(span["metrics"], start, end)
+
+
+@pytest.mark.vcr
 def test_wrap_mistral_embeddings_create(memory_logger):
     assert not memory_logger.pop()
 
@@ -452,6 +540,8 @@ def test_mistral_integration_setup_creates_spans(memory_logger, monkeypatch):
     original_agents_complete_async = inspect.getattr_static(Agents, "complete_async")
     original_agents_stream = inspect.getattr_static(Agents, "stream")
     original_agents_stream_async = inspect.getattr_static(Agents, "stream_async")
+    original_ocr_process = inspect.getattr_static(Ocr, "process")
+    original_ocr_process_async = inspect.getattr_static(Ocr, "process_async")
 
     assert MistralIntegration.setup()
     client = _get_client()
@@ -477,6 +567,8 @@ def test_mistral_integration_setup_creates_spans(memory_logger, monkeypatch):
     monkeypatch.setattr(Agents, "complete_async", original_agents_complete_async)
     monkeypatch.setattr(Agents, "stream", original_agents_stream)
     monkeypatch.setattr(Agents, "stream_async", original_agents_stream_async)
+    monkeypatch.setattr(Ocr, "process", original_ocr_process)
+    monkeypatch.setattr(Ocr, "process_async", original_ocr_process_async)
 
     assert "4" in str(response.choices[0].message.content)
 
@@ -504,6 +596,8 @@ def test_mistral_integration_setup_is_idempotent(monkeypatch):
     first_agents_complete_async = inspect.getattr_static(Agents, "complete_async")
     first_agents_stream = inspect.getattr_static(Agents, "stream")
     first_agents_stream_async = inspect.getattr_static(Agents, "stream_async")
+    first_ocr_process = inspect.getattr_static(Ocr, "process")
+    first_ocr_process_async = inspect.getattr_static(Ocr, "process_async")
 
     assert MistralIntegration.setup()
     patched_complete = inspect.getattr_static(Chat, "complete")
@@ -520,6 +614,8 @@ def test_mistral_integration_setup_is_idempotent(monkeypatch):
     patched_agents_complete_async = inspect.getattr_static(Agents, "complete_async")
     patched_agents_stream = inspect.getattr_static(Agents, "stream")
     patched_agents_stream_async = inspect.getattr_static(Agents, "stream_async")
+    patched_ocr_process = inspect.getattr_static(Ocr, "process")
+    patched_ocr_process_async = inspect.getattr_static(Ocr, "process_async")
 
     assert MistralIntegration.setup()
     assert inspect.getattr_static(Chat, "complete") is patched_complete
@@ -536,6 +632,8 @@ def test_mistral_integration_setup_is_idempotent(monkeypatch):
     assert inspect.getattr_static(Agents, "complete_async") is patched_agents_complete_async
     assert inspect.getattr_static(Agents, "stream") is patched_agents_stream
     assert inspect.getattr_static(Agents, "stream_async") is patched_agents_stream_async
+    assert inspect.getattr_static(Ocr, "process") is patched_ocr_process
+    assert inspect.getattr_static(Ocr, "process_async") is patched_ocr_process_async
 
     monkeypatch.setattr(Chat, "complete", first_complete)
     monkeypatch.setattr(Chat, "complete_async", first_complete_async)
@@ -551,6 +649,8 @@ def test_mistral_integration_setup_is_idempotent(monkeypatch):
     monkeypatch.setattr(Agents, "complete_async", first_agents_complete_async)
     monkeypatch.setattr(Agents, "stream", first_agents_stream)
     monkeypatch.setattr(Agents, "stream_async", first_agents_stream_async)
+    monkeypatch.setattr(Ocr, "process", first_ocr_process)
+    monkeypatch.setattr(Ocr, "process_async", first_ocr_process_async)
 
 
 def test_chat_complete_wrapper_logs_errors(memory_logger):
@@ -616,6 +716,33 @@ def test_sanitize_mistral_logged_value_converts_image_url_data_uri_to_attachment
 
     assert isinstance(sanitized["image_url"]["url"], Attachment)
     assert sanitized["image_url"]["url"].reference["content_type"] == "image/png"
+
+
+def test_sanitize_mistral_logged_value_converts_image_url_string_data_uri_to_attachment():
+    sanitized = sanitize_mistral_logged_value(
+        {
+            "type": "image_url",
+            "image_url": "data:image/png;base64,aGVsbG8=",
+        }
+    )
+
+    assert isinstance(sanitized["image_url"]["url"], Attachment)
+    assert sanitized["image_url"]["url"].reference["content_type"] == "image/png"
+
+
+def test_sanitize_mistral_logged_value_converts_document_url_data_uri_to_attachment():
+    sanitized = sanitize_mistral_logged_value(
+        {
+            "type": "document_url",
+            "document_url": TEST_PDF_DATA_URL,
+            "document_name": "test.pdf",
+        }
+    )
+
+    assert sanitized["type"] == "file"
+    assert isinstance(sanitized["file"]["file_data"], Attachment)
+    assert sanitized["file"]["file_data"].reference["content_type"] == "application/pdf"
+    assert sanitized["file"]["filename"] == "test.pdf"
 
 
 def test_sanitize_mistral_logged_value_converts_large_base64_input_audio_to_attachment():

--- a/py/src/braintrust/integrations/mistral/tracing.py
+++ b/py/src/braintrust/integrations/mistral/tracing.py
@@ -129,22 +129,20 @@ def _normalize_special_payloads(value: Any) -> Any:
     if item_type == "image_url":
         image_url = value.get("image_url")
         if isinstance(image_url, str):
+            resolved = _materialize_attachment(image_url)
             return {
                 **value,
                 "image_url": {
-                    "url": resolved.attachment
-                    if (resolved := _materialize_attachment(image_url)) is not None
-                    else image_url,
+                    "url": resolved.attachment if resolved is not None else image_url,
                 },
             }
         if isinstance(image_url, dict) and isinstance(image_url.get("url"), str):
+            resolved = _materialize_attachment(image_url["url"])
             return {
                 **value,
                 "image_url": {
                     **image_url,
-                    "url": resolved.attachment
-                    if (resolved := _materialize_attachment(image_url["url"])) is not None
-                    else image_url["url"],
+                    "url": resolved.attachment if resolved is not None else image_url["url"],
                 },
             }
 

--- a/py/src/braintrust/integrations/mistral/tracing.py
+++ b/py/src/braintrust/integrations/mistral/tracing.py
@@ -75,6 +75,20 @@ _FIM_METADATA_KEYS = (
     "random_seed",
     "min_tokens",
 )
+_OCR_METADATA_KEYS = (
+    "model",
+    "id",
+    "pages",
+    "include_image_base64",
+    "image_limit",
+    "image_min_size",
+    "bbox_annotation_format",
+    "document_annotation_format",
+    "document_annotation_prompt",
+    "table_format",
+    "extract_header",
+    "extract_footer",
+)
 
 
 def _is_unset(value: Any) -> bool:
@@ -117,9 +131,11 @@ def _normalize_special_payloads(value: Any) -> Any:
         if isinstance(image_url, str):
             return {
                 **value,
-                "image_url": resolved.attachment
-                if (resolved := _materialize_attachment(image_url)) is not None
-                else image_url,
+                "image_url": {
+                    "url": resolved.attachment
+                    if (resolved := _materialize_attachment(image_url)) is not None
+                    else image_url,
+                },
             }
         if isinstance(image_url, dict) and isinstance(image_url.get("url"), str):
             return {
@@ -129,6 +145,21 @@ def _normalize_special_payloads(value: Any) -> Any:
                     "url": resolved.attachment
                     if (resolved := _materialize_attachment(image_url["url"])) is not None
                     else image_url["url"],
+                },
+            }
+
+    if item_type == "document_url" and isinstance(value.get("document_url"), str):
+        resolved = _materialize_attachment(
+            value["document_url"],
+            filename=value.get("document_name"),
+            prefix="document",
+        )
+        if resolved is not None:
+            return {
+                "type": "file",
+                "file": {
+                    "file_data": resolved.attachment,
+                    "filename": resolved.filename,
                 },
             }
 
@@ -207,12 +238,38 @@ def _build_fim_metadata(kwargs: dict[str, Any], *, stream: bool | None = None) -
     return _build_request_metadata(kwargs, _FIM_METADATA_KEYS, stream=stream)
 
 
+def _document_type(document: Any) -> str | None:
+    if _is_unset(document):
+        return None
+
+    document_type = getattr(document, "type", None)
+    if document_type is None and isinstance(document, dict):
+        document_type = document.get("type")
+
+    if isinstance(document_type, str) and document_type:
+        return document_type
+
+    return None
+
+
+def _build_ocr_metadata(kwargs: dict[str, Any]) -> dict[str, Any]:
+    metadata = _build_request_metadata(kwargs, _OCR_METADATA_KEYS)
+    document_type = _document_type(kwargs.get("document"))
+    if document_type is not None:
+        metadata["document_type"] = document_type
+    return metadata
+
+
 def _fim_input(kwargs: dict[str, Any]) -> dict[str, Any]:
     span_input = {"prompt": kwargs.get("prompt")}
     suffix = kwargs.get("suffix")
     if suffix is not None and not _is_unset(suffix):
         span_input["suffix"] = suffix
     return span_input
+
+
+def _ocr_input(kwargs: dict[str, Any]) -> dict[str, Any]:
+    return {"document": kwargs.get("document")}
 
 
 def _start_span(name: str, span_input: Any, metadata: dict[str, Any]):
@@ -250,6 +307,20 @@ def _merge_metrics(start_time: float, usage: Any, first_token_time: float | None
     )
 
 
+def _parse_ocr_usage_metrics(usage: Any) -> dict[str, float]:
+    usage_data = sanitize_mistral_logged_value(usage)
+    if not isinstance(usage_data, dict):
+        return {}
+
+    return {
+        _camel_to_snake(key): float(value) for key, value in usage_data.items() if _is_supported_metric_value(value)
+    }
+
+
+def _merge_ocr_metrics(start_time: float, usage: Any) -> dict[str, Any]:
+    return _merge_timing_and_usage_metrics(start_time, usage, _parse_ocr_usage_metrics)
+
+
 def _response_to_metadata(response: Any) -> dict[str, Any]:
     data = sanitize_mistral_logged_value(response)
     if not isinstance(data, dict):
@@ -282,6 +353,31 @@ def _embeddings_output(response: Any) -> dict[str, Any]:
     if first is not None and getattr(first, "index", None) is not None:
         output["first_index"] = first.index
     return output
+
+
+def _ocr_output(response: Any) -> dict[str, Any]:
+    data = sanitize_mistral_logged_value(response)
+    if not isinstance(data, dict):
+        return {"pages": []}
+
+    output = {
+        "pages": data.get("pages") or [],
+    }
+    document_annotation = data.get("document_annotation")
+    if document_annotation is not None:
+        output["document_annotation"] = document_annotation
+    return output
+
+
+def _ocr_response_to_metadata(response: Any) -> dict[str, Any]:
+    data = sanitize_mistral_logged_value(response)
+    if not isinstance(data, dict):
+        return {}
+
+    pages = data.get("pages")
+    return {
+        "page_count": len(pages) if isinstance(pages, list) else 0,
+    }
 
 
 def _call_with_error_logging(span: Any, wrapped: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
@@ -469,6 +565,16 @@ def _finalize_embeddings_response(span: Any, request_metadata: dict[str, Any], r
         span,
         output=_embeddings_output(response),
         metrics=_merge_metrics(start_time, getattr(response, "usage", None)),
+        metadata={**request_metadata, **response_metadata},
+    )
+
+
+def _finalize_ocr_response(span: Any, request_metadata: dict[str, Any], response: Any, start_time: float):
+    response_metadata = _ocr_response_to_metadata(response)
+    _log_and_end_span(
+        span,
+        output=_ocr_output(response),
+        metrics=_merge_ocr_metrics(start_time, getattr(response, "usage_info", None)),
         metadata={**request_metadata, **response_metadata},
     )
 
@@ -749,9 +855,29 @@ async def _fim_stream_async_wrapper(wrapped, instance, args, kwargs):
     return _TracedMistralAsyncStream(result, span, request_metadata, start_time)
 
 
+def _ocr_process_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_ocr_metadata(kwargs)
+    span = _start_span("mistral.ocr.process", _ocr_input(kwargs), request_metadata)
+    start_time = time.time()
+    result = _call_with_error_logging(span, wrapped, args, kwargs)
+
+    _finalize_ocr_response(span, request_metadata, result, start_time)
+    return result
+
+
+async def _ocr_process_async_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_ocr_metadata(kwargs)
+    span = _start_span("mistral.ocr.process", _ocr_input(kwargs), request_metadata)
+    start_time = time.time()
+    result = await _call_async_with_error_logging(span, wrapped, args, kwargs)
+
+    _finalize_ocr_response(span, request_metadata, result, start_time)
+    return result
+
+
 def wrap_mistral(client: Any) -> Any:
     """Wrap a single Mistral client instance for tracing."""
-    from .patchers import AgentsPatcher, ChatPatcher, EmbeddingsPatcher, FimPatcher
+    from .patchers import AgentsPatcher, ChatPatcher, EmbeddingsPatcher, FimPatcher, OcrPatcher
 
     chat = getattr(client, "chat", None)
     if chat is not None:
@@ -768,5 +894,9 @@ def wrap_mistral(client: Any) -> Any:
     agents = getattr(client, "agents", None)
     if agents is not None:
         AgentsPatcher.wrap_target(agents)
+
+    ocr = getattr(client, "ocr", None)
+    if ocr is not None:
+        OcrPatcher.wrap_target(ocr)
 
     return client


### PR DESCRIPTION
Add instrumentation for Mistral OCR process and process_async calls, including OCR-specific input/output shaping, metadata, and usage metrics.

The traced input materializes OCR image and document data URLs as Braintrust attachments, and the regression coverage uses focused VCR-backed sync and async tests.

resolves https://github.com/braintrustdata/braintrust-sdk-python/issues/222