### PR TITLE
fix(google_genai): serialize Content objects with nested binary Parts as attachments

### DIFF
--- a/py/src/braintrust/integrations/google_genai/cassettes/test_image_input_wrapped_in_content.yaml
+++ b/py/src/braintrust/integrations/google_genai/cassettes/test_image_input_wrapped_in_content.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"inlineData": {"data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==",
+      "mimeType": "image/png"}}, {"text": "What color is this image?"}], "role": "user"}],
+      "generationConfig": {"maxOutputTokens": 150}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2611607'
+      Content-Type:
+      - application/json
+      Host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.70.0 gl-python/3.13.3
+      x-goog-api-client:
+      - google-genai-sdk/1.70.0 gl-python/3.13.3
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-001:generateContent
+  response:
+    body:
+      string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
+        [\n          {\n            \"text\": \"The image is predominantly blue.\"\n
+        \         }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
+        \"STOP\",\n      \"avgLogprobs\": -0.39939455191294354\n    }\n  ],\n  \"usageMetadata\":
+        {\n    \"promptTokenCount\": 1296,\n    \"candidatesTokenCount\": 6,\n    \"totalTokenCount\":
+        1302,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"IMAGE\",\n
+        \       \"tokenCount\": 1290\n      },\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 6\n      }\n    ],\n    \"candidatesTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 6\n      }\n
+        \   ]\n  },\n  \"modelVersion\": \"gemini-2.0-flash-001\",\n  \"responseId\":
+        \"4qzNaamuO7Gx1MkPtOGkwQU\"\n}\n"
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 01 Apr 2026 23:40:19 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=2700
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gemini-Service-Tier:
+      - standard
+      X-XSS-Protection:
+      - '0'
+      content-length:
+      - '756'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/google_genai/test_google_genai.py
+++ b/py/src/braintrust/integrations/google_genai/test_google_genai.py
@@ -406,6 +406,60 @@ def test_document_input(memory_logger):
     _assert_metrics_are_valid(span["metrics"], start, end)
 
 
+@pytest.mark.vcr
+def test_image_input_wrapped_in_content(memory_logger):
+    """Verify binary Parts inside a Content wrapper are traced as attachments.
+
+    This is a regression test for the case where the user passes a
+    ``types.Content(parts=[Part.from_bytes(...), ...])`` instead of a flat
+    list of Part objects.  Previously the Content object was returned
+    un-serialized, leaking raw bytes into the logged span.
+    """
+    assert not memory_logger.pop()
+
+    image_data = (FIXTURES_DIR / "test-image.png").read_bytes()
+
+    client = Client()
+    start = time.time()
+    response = client.models.generate_content(
+        model=MODEL,
+        contents=[
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part.from_bytes(data=image_data, mime_type="image/png"),
+                    types.Part.from_text(text="What color is this image?"),
+                ],
+            ),
+        ],
+        config=types.GenerateContentConfig(
+            max_output_tokens=150,
+        ),
+    )
+    end = time.time()
+
+    assert response.text
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span["metadata"]["model"] == MODEL
+
+    # The contents list should contain one serialized Content dict.
+    contents = span["input"]["contents"]
+    assert len(contents) == 1
+    content = contents[0]
+    assert content["role"] == "user"
+    assert len(content["parts"]) == 2
+
+    # Binary part must be an attachment, not raw bytes.
+    _assert_attachment_part(content["parts"][0], content_type="image/png", filename="file.png")
+    assert content["parts"][1] == {"text": "What color is this image?"}
+    _assert_binary_not_logged(span, image_data)
+    assert span["output"]
+    _assert_metrics_are_valid(span["metrics"], start, end)
+
+
 # Test 3: Tool Use (Sync)
 @pytest.mark.vcr
 @pytest.mark.parametrize(
@@ -1071,6 +1125,47 @@ def test_interaction_materialization_only_converts_multimodal_payloads():
     assert materialized["media"]["caption"] is None
     assert isinstance(materialized["media"]["data"], Attachment)
     assert materialized["media"]["image_url"]["url"] is materialized["media"]["data"]
+
+
+def test_serialize_content_item_with_content_and_binary_part():
+    """Content objects wrapping binary Parts must produce Attachment objects.
+
+    _serialize_content_item only replaces binary inline_data with Attachments;
+    non-binary parts are left as-is for bt_safe_deep_copy to serialise later.
+    """
+    from braintrust.integrations.google_genai.tracing import _serialize_content_item
+    from braintrust.logger import Attachment
+
+    image_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64  # small fake PNG bytes
+    content = types.Content(
+        role="user",
+        parts=[
+            types.Part.from_bytes(data=image_data, mime_type="image/png"),
+            types.Part.from_text(text="What color is this image?"),
+        ],
+    )
+
+    serialized = _serialize_content_item(content)
+
+    # The Content wrapper must be preserved with role + serialized parts.
+    assert isinstance(serialized, dict), f"Expected dict, got {type(serialized)}"
+    assert serialized["role"] == "user"
+    assert isinstance(serialized.get("parts"), list)
+    assert len(serialized["parts"]) == 2
+
+    # The binary part must have been converted to an attachment – not left as
+    # raw bytes or a model_dump of inline_data.
+    binary_part = serialized["parts"][0]
+    assert "image_url" in binary_part, f"Expected image_url key in binary part, got keys: {list(binary_part.keys())}"
+    attachment = binary_part["image_url"]["url"]
+    assert isinstance(attachment, Attachment), f"Expected Attachment, got {type(attachment)}"
+    assert attachment.reference["content_type"] == "image/png"
+    assert attachment.reference["filename"] == "file.png"
+
+    # The text part is left as the original Part object — bt_safe_deep_copy
+    # will serialise it downstream.
+    text_part = serialized["parts"][1]
+    assert getattr(text_part, "text", None) == "What color is this image?"
 
 
 GROUNDING_MODEL = "gemini-2.0-flash-001"

--- a/py/src/braintrust/integrations/google_genai/tracing.py
+++ b/py/src/braintrust/integrations/google_genai/tracing.py
@@ -78,53 +78,89 @@ def _serialize_input(api_client: Any, input: dict[str, Any]) -> dict[str, Any]:
 
 
 def _serialize_contents(contents: Any) -> Any:
-    """Serialize contents, converting binary data to base64-encoded data URLs."""
+    """Serialize contents, converting binary inline_data into attachments.
+
+    Most of the heavy lifting (Pydantic model_dump, deep-copy, etc.) is
+    handled downstream by ``bt_safe_deep_copy``.  This pass only needs to
+    walk the Content/Part tree and replace binary ``inline_data`` with
+    :class:`Attachment` objects so the background logger can upload them.
+    """
     if contents is None:
         return None
 
-    # Handle list of contents
     if isinstance(contents, list):
         return [_serialize_content_item(item) for item in contents]
 
-    # Handle single content item
     return _serialize_content_item(contents)
 
 
 def _serialize_content_item(item: Any) -> Any:
-    """Serialize a single content item, handling binary data."""
-    # If it's already a dict, return as-is
-    if isinstance(item, dict):
+    """Replace binary inline_data inside a content item with Attachments.
+
+    Content-like objects (with ``parts``) are recursed into so nested
+    binary data is converted.  Everything else is returned as-is for
+    ``bt_safe_deep_copy`` to serialise later.
+    """
+    if item is None or isinstance(item, (str, int, float, bool)):
         return item
 
-    # Handle Part objects from google.genai
-    if hasattr(item, "__class__") and item.__class__.__name__ == "Part":
-        # Try to extract the data from the Part
-        if hasattr(item, "text") and item.text is not None:
-            return {"text": item.text}
-        elif hasattr(item, "inline_data"):
-            # Handle binary data (e.g., images)
-            inline_data = item.inline_data
-            if hasattr(inline_data, "data") and hasattr(inline_data, "mime_type"):
-                # Convert bytes to Attachment
-                data = inline_data.data
-                mime_type = inline_data.mime_type
+    # Content-like wrapper (has "parts") — recurse into each part.
+    parts = _get_parts(item)
+    if parts is not None:
+        serialized_parts = [_serialize_content_item(p) for p in parts]
+        if isinstance(item, dict):
+            return {**item, "parts": serialized_parts}
+        # Object form (e.g. types.Content): build a minimal dict so that
+        # the replaced Attachment parts survive bt_safe_deep_copy.
+        result: dict[str, Any] = {"parts": serialized_parts}
+        role = getattr(item, "role", None)
+        if role is not None:
+            result["role"] = role
+        return result
 
-                # Ensure data is bytes
-                if isinstance(data, bytes):
-                    resolved_attachment = _materialize_attachment(data, mime_type=mime_type, prefix="file")
-                    if resolved_attachment is not None:
-                        return resolved_attachment.multimodal_part_payload
+    # Leaf part — replace binary inline_data with an Attachment if present.
+    resolved = _try_materialize_inline_data(item)
+    if resolved is not None:
+        return resolved
 
-        # Try to use built-in serialization if available
-        if hasattr(item, "model_dump"):
-            return item.model_dump()
-        elif hasattr(item, "dump"):
-            return item.dump()
-        elif hasattr(item, "to_dict"):
-            return item.to_dict()
-
-    # Return the item as-is if we can't serialize it
+    # No binary data — return as-is; bt_safe_deep_copy handles the rest.
     return item
+
+
+def _get_parts(item: Any) -> list[Any] | None:
+    """Extract the ``parts`` list from a Content-like object or dict, or None."""
+    if isinstance(item, dict):
+        parts = item.get("parts")
+        return parts if isinstance(parts, list) else None
+    # Object with .parts that is not itself a Part.
+    if getattr(getattr(item, "__class__", None), "__name__", None) == "Part":
+        return None
+    parts = getattr(item, "parts", None)
+    return parts if isinstance(parts, list) else None
+
+
+def _try_materialize_inline_data(item: Any) -> Any | None:
+    """If *item* carries binary ``inline_data``, convert it to an attachment payload."""
+    if isinstance(item, dict):
+        inline_data = item.get("inline_data") or item.get("inlineData")
+    else:
+        inline_data = getattr(item, "inline_data", None)
+
+    if inline_data is None:
+        return None
+
+    if isinstance(inline_data, dict):
+        data = inline_data.get("data")
+        mime_type = inline_data.get("mime_type") or inline_data.get("mimeType")
+    else:
+        data = getattr(inline_data, "data", None)
+        mime_type = getattr(inline_data, "mime_type", None)
+
+    if not isinstance(data, bytes) or not isinstance(mime_type, str):
+        return None
+
+    resolved = _materialize_attachment(data, mime_type=mime_type, prefix="file")
+    return resolved.multimodal_part_payload if resolved is not None else None
 
 
 def _serialize_tools(api_client: Any, input: Any | None) -> Any | None:


### PR DESCRIPTION
Content objects wrapping binary Parts (e.g.
types.Content(parts=[Part.from_bytes(...), ...])) were returned un-serialized by _serialize_content_item, leaking raw bytes into logged spans instead of converting inline_data to Attachment objects.

Refactored the serialization pass to only do what bt_safe_deep_copy cannot: walk the Content/Part tree and replace binary inline_data with Attachments. All other serialization (text parts, Pydantic model_dump, etc.) is left to bt_safe_deep_copy downstream, removing the redundant model_dump/dump/to_dict fallback chain.

Adds a unit test for _serialize_content_item with a Content wrapper and a VCR-backed integration test for generate_content with Content-wrapped binary+text parts.

supercedes https://github.com/braintrustdata/braintrust-sdk-python/pull/167