### PR TITLE
fix: use `Mapping` instead of `dict` for `EvalParameters` type alias

### DIFF
--- a/py/src/braintrust/parameters.py
+++ b/py/src/braintrust/parameters.py
@@ -1,5 +1,6 @@
 """Evaluation parameters support for Python SDK."""
 
+from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
@@ -36,7 +37,7 @@ class ModelParameter(TypedDict):
 JSONValue = None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
 ValidatedParameters = dict[str, object]
 ParameterSchema = PromptParameter | ModelParameter | type[object] | None
-EvalParameters = dict[str, ParameterSchema]
+EvalParameters = Mapping[str, ParameterSchema]
 ParametersSchema = dict[str, Any]
 
 
@@ -172,7 +173,7 @@ def _pydantic_field_required(field: Any) -> bool:
 def is_eval_parameter_schema(schema: Any) -> bool:
     if isinstance(schema, RemoteEvalParameters):
         return True
-    if not isinstance(schema, dict):
+    if not isinstance(schema, Mapping):
         return False
     if len(schema) == 0:
         return True


### PR DESCRIPTION
## Summary

`EvalParameters` is typed as `dict[str, ParameterSchema]`, but `dict` is invariant in its value type. This means callers who construct a homogeneous parameter dict (e.g. `dict[str, ModelParameter]`) get a mypy error when passing it to `Eval(parameters=...)`, even though `ModelParameter` is a member of the `ParameterSchema` union.

This PR changes the `EvalParameters` type alias from `dict` to `Mapping` (from `collections.abc`), which is covariant in its value type. It also widens the `isinstance` check in `is_eval_parameter_schema` from `dict` to `Mapping` so the runtime guard matches the type.

The SDK only reads the parameter dict (via `.items()`, `.values()`, `.get()`) — it never mutates it after being passed in. `_validate_local_parameters`, `is_eval_parameter_schema`, and `serialize_eval_parameters` all build new result dicts. So `Mapping` is the correct abstraction.

Fixes #280