### PR TITLE
feat(framework): add classifier support to Eval

### DIFF
--- a/py/src/braintrust/cassettes/test_classifier_spans_are_logged.yaml
+++ b/py/src/braintrust/cassettes/test_classifier_spans_are_logged.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: '{"id": "test-classifier-span"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '30'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://www.braintrust.dev/api/base_experiment/get_id
+  response:
+    body:
+      string: "[\n  {\n    \"validation\": \"uuid\",\n    \"code\": \"invalid_string\",\n
+        \   \"message\": \"Invalid uuid\",\n    \"path\": [\n      \"id\"\n    ]\n
+        \ }\n] [user_email=___braintrust_anon_user___@braintrustdata.com] [timestamp=1776185951.284]
+        [request_id=yul1::rlkb8-1776185950926-a394af342bfa]"
+    headers:
+      Cache-Control:
+      - public, max-age=0, must-revalidate
+      Content-Length:
+      - '267'
+      Content-Security-Policy:
+      - 'script-src ''self'' ''unsafe-eval'' ''wasm-unsafe-eval'' ''strict-dynamic''
+        ''nonce-NGNlMGVjNTUtNmE2MC00ZDA3LWE3OGMtMDQ3NWExNWVkZGUz''  *.js.stripe.com
+        js.stripe.com maps.googleapis.com ; style-src ''self'' ''unsafe-inline'' *.braintrust.dev
+        btcm6qilbbhv4yi1.public.blob.vercel-storage.com fonts.googleapis.com www.gstatic.com
+        d4tuoctqmanu0.cloudfront.net; font-src ''self'' data: fonts.gstatic.com btcm6qilbbhv4yi1.public.blob.vercel-storage.com
+        cdn.jsdelivr.net d4tuoctqmanu0.cloudfront.net fonts.googleapis.com mintlify-assets.b-cdn.net
+        fonts.cdnfonts.com; object-src ''none''; base-uri ''self''; form-action ''self'';
+        frame-ancestors ''self''; worker-src ''self'' blob:; report-uri https://o4507221741076480.ingest.us.sentry.io/api/4507221754380288/security/?sentry_key=27fa5ac907cf7c6ce4a1ab2a03f805b4&sentry_environment=production&sentry_release=16;
+        report-to csp-endpoint-0'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 14 Apr 2026 16:59:11 GMT
+      Etag:
+      - '"ox95rpt6sr7f"'
+      Reporting-Endpoints:
+      - csp-endpoint-0="https://o4507221741076480.ingest.us.sentry.io/api/4507221754380288/security/?sentry_key=27fa5ac907cf7c6ce4a1ab2a03f805b4&sentry_environment=production&sentry_release=16"
+      Server:
+      - Vercel
+      Set-Cookie:
+      - __Host-authjs.csrf-token=29800db0ea46edba4ca7714d00cba09854ccf08e98f28666bd7a8f816dc260ea%7C4f5ce689e487bc9972f79ed54f75a99deeb00baec720e82e1efa5e58f551d316;
+        Path=/; HttpOnly; Secure; SameSite=Lax
+      - __Secure-authjs.callback-url=https%3A%2F%2Fwww.braintrustdata.com; Path=/;
+        HttpOnly; Secure; SameSite=Lax
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Clerk-Auth-Reason:
+      - session-token-and-uat-missing
+      X-Clerk-Auth-Status:
+      - signed-out
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Matched-Path:
+      - /api/base_experiment/get_id
+      X-Nonce:
+      - NGNlMGVjNTUtNmE2MC00ZDA3LWE3OGMtMDQ3NWExNWVkZGUz
+      X-Vercel-Cache:
+      - MISS
+      X-Vercel-Id:
+      - yul1::iad1::rlkb8-1776185950926-a394af342bfa
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/py/src/braintrust/cli/push.py
+++ b/py/src/braintrust/cli/push.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import requests
 import slugify
-from braintrust.framework import _evals, _scorer_name, _set_lazy_load
+from braintrust.framework import _classifier_name, _evals, _scorer_name, _set_lazy_load
 
 from .. import api_conn, login, org_id, proxy_conn
 from ..framework2 import ProjectIdCache, global_
@@ -303,8 +303,11 @@ def _collect_evaluator_defs(
         evaluator = eval_instance.evaluator
         project_id = project_ids.get_by_name(evaluator.project_name)
 
-        scores = [{"name": _scorer_name(scorer, i)} for i, scorer in enumerate(evaluator.scores)]
-        evaluator_definition: dict[str, Any] = {"scores": scores}
+        scores = [{"name": _scorer_name(scorer, i)} for i, scorer in enumerate(evaluator.scores or [])]
+        classifiers = [
+            {"name": _classifier_name(classifier, i)} for i, classifier in enumerate(evaluator.classifiers or [])
+        ]
+        evaluator_definition: dict[str, Any] = {"scores": scores, "classifiers": classifiers}
         if evaluator.parameters is not None:
             evaluator_definition["parameters"] = serialize_remote_eval_parameters_container(evaluator.parameters)
 

--- a/py/src/braintrust/cli/test_push_evaluator.py
+++ b/py/src/braintrust/cli/test_push_evaluator.py
@@ -15,10 +15,11 @@ def _make_scorer(name):
     return scorer
 
 
-def _make_evaluator(project_name, scorer_names, parameters=None):
+def _make_evaluator(project_name, scorer_names, parameters=None, classifier_names=None):
     evaluator = MagicMock()
     evaluator.project_name = project_name
     evaluator.scores = [_make_scorer(n) for n in scorer_names]
+    evaluator.classifiers = [_make_scorer(n) for n in (classifier_names or [])]
     evaluator.parameters = parameters
 
     instance = MagicMock()
@@ -50,7 +51,10 @@ class TestCollectEvaluatorDefs:
                             "sandbox_spec": {"provider": "lambda"},
                             "entrypoints": ["evals/my_eval.py"],
                             "eval_name": "my_eval",
-                            "evaluator_definition": {"scores": [{"name": "accuracy"}]},
+                            "evaluator_definition": {
+                                "scores": [{"name": "accuracy"}],
+                                "classifiers": [],
+                            },
                         },
                         "bundle_id": "bundle-abc",
                     },
@@ -97,6 +101,16 @@ class TestCollectEvaluatorDefs:
         assert parameters["type"] == "braintrust.staticParameters"
         assert parameters["source"] is None
         assert parameters["schema"]["prompt"]["type"] == "prompt"
+
+    def test_evaluator_with_classifiers(self, mock_project_ids):
+        evaluators = {"eval1": _make_evaluator("test-project", ["accuracy"], classifier_names=["category"])}
+
+        functions = []
+        _collect_evaluator_defs(mock_project_ids, functions, "bundle-1", "replace", "eval.py", evaluators)
+
+        eval_def = functions[0]["function_data"]["data"]["location"]["evaluator_definition"]
+        assert eval_def["scores"] == [{"name": "accuracy"}]
+        assert eval_def["classifiers"] == [{"name": "category"}]
 
     def test_slug_from_source_file(self, mock_project_ids):
         evaluators = {"Test Eval": _make_evaluator("test-project", ["accuracy"])}

--- a/py/src/braintrust/devserver/server.py
+++ b/py/src/braintrust/devserver/server.py
@@ -32,6 +32,8 @@ from ..framework import (
     Evaluator,
     ExperimentSummary,
     SSEProgressEvent,
+    _classifier_name,
+    _scorer_name,
 )
 from ..generated_types import FunctionId
 from ..logger import BraintrustState, bt_iscoroutinefunction
@@ -123,7 +125,10 @@ async def list_evaluators(request: Request) -> JSONResponse:
             "parameters": (
                 serialize_remote_eval_parameters_container(evaluator.parameters) if evaluator.parameters else None
             ),
-            "scores": [{"name": getattr(score, "name", f"score_{i}")} for i, score in enumerate(evaluator.scores)],
+            "scores": [{"name": _scorer_name(score, i)} for i, score in enumerate(evaluator.scores or [])],
+            "classifiers": [
+                {"name": _classifier_name(classifier, i)} for i, classifier in enumerate(evaluator.classifiers or [])
+            ],
         }
 
     return JSONResponse(evaluator_list)
@@ -227,7 +232,7 @@ async def run_eval(request: Request) -> JSONResponse | StreamingResponse:
                 **{
                     **eval_kwargs,
                     "state": state,
-                    "scores": evaluator.scores
+                    "scores": (evaluator.scores or [])
                     + [
                         make_scorer(state, score["name"], score["function_id"], ctx.project_id)
                         for score in eval_data.get("scores", [])

--- a/py/src/braintrust/devserver/test_server_integration.py
+++ b/py/src/braintrust/devserver/test_server_integration.py
@@ -49,6 +49,9 @@ def client():
         """Simple exact match scorer."""
         return 1.0 if output == expected else 0.0
 
+    def classifier(input: str, output: str, expected: str) -> dict[str, str]:
+        return {"id": "correct" if output == expected else "incorrect", "name": "answer_type"}
+
     evaluator = Evaluator(
         project_name="test-math-eval",
         eval_name="simple-math-eval",
@@ -59,6 +62,7 @@ def client():
         ],
         task=task,
         scores=[scorer],
+        classifiers=[classifier],
         experiment_name=None,
         metadata=None,
     )
@@ -114,6 +118,8 @@ def test_devserver_list_evaluators(client, api_key, org_name):
     assert response.status_code == 200
     evaluators = response.json()
     assert "simple-math-eval" in evaluators
+    assert evaluators["simple-math-eval"]["scores"] == [{"name": "scorer"}]
+    assert evaluators["simple-math-eval"]["classifiers"] == [{"name": "classifier"}]
 
 
 def parse_sse_events(response_text: str) -> list[dict[str, Any]]:

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -49,7 +49,7 @@ from .parameters import (
     validate_parameters,
 )
 from .resource_manager import ResourceManager
-from .score import Score, is_score, is_scorer
+from .score import Classification, ClassificationItem, Score, is_classification, is_score, is_scorer
 from .serializable_data_class import SerializableDataClass
 from .span_types import SpanTypeAttribute
 from .types._eval import EvalCaseDict, EvalCaseDictNoOutput, ExperimentDatasetEvent
@@ -102,6 +102,7 @@ class EvalResult(SerializableDataClass, Generic[Input, Output, Expected]):
     input: Input
     output: Output
     scores: dict[str, float | None]
+    classifications: dict[str, list[ClassificationItem]] | None = None
     expected: Expected | None = None
     metadata: Metadata | None = None
     tags: list[str] | None = None
@@ -218,6 +219,12 @@ class EvalScorerArgs(SerializableDataClass, Generic[Input, Output, Expected]):
 
 
 OneOrMoreScores = Union[float, int, bool, None, Score, list[Score]]
+OneOrMoreClassifications = Union[
+    None,
+    Classification,
+    Mapping[str, Any],
+    list[Classification | Mapping[str, Any]],
+]
 
 
 # Synchronous scorer interface - implements callable
@@ -250,6 +257,11 @@ EvalScorer = Union[
     type[ScorerLike[Input, Output, Expected]],
     Callable[[Input, Output, Expected], OneOrMoreScores],
     Callable[[Input, Output, Expected], Awaitable[OneOrMoreScores]],
+]
+
+EvalClassifier = Union[
+    Callable[[Input, Output, Expected], OneOrMoreClassifications],
+    Callable[[Input, Output, Expected], Awaitable[OneOrMoreClassifications]],
 ]
 
 
@@ -427,6 +439,12 @@ class Evaluator(Generic[Input, Output, Expected]):
     """
     A set of parameters that will be passed to the evaluator.
     Can be used to define prompts or other configurable values.
+    """
+
+    classifiers: list[EvalClassifier[Input, Output, Expected]] | None = None
+    """
+    Optional list of classifiers to evaluate the task output. Classifier results are
+    recorded under the `classifications` field instead of `scores`.
     """
 
     parameter_values: dict[str, Any] | None = None
@@ -647,7 +665,8 @@ def _EvalCommon(
     name: str,
     data: EvalData[Input, Expected],
     task: EvalTask[Input, Output, Expected],
-    scores: Sequence[EvalScorer[Input, Output, Expected]],
+    scores: Sequence[EvalScorer[Input, Output, Expected]] | None,
+    classifiers: Sequence[EvalClassifier[Input, Output, Expected]] | None,
     experiment_name: str | None,
     trial_count: int,
     metadata: Metadata | None,
@@ -678,6 +697,9 @@ def _EvalCommon(
     the `_evals` global immediately instead of whenever the coroutine is
     awaited.
     """
+    if scores is None and classifiers is None:
+        raise ValueError("At least one of `scores` or `classifiers` must be provided.")
+
     eval_name = _make_eval_name(name, experiment_name)
 
     global _evals
@@ -689,7 +711,8 @@ def _EvalCommon(
         project_name=name,
         data=data,
         task=task,
-        scores=scores,
+        scores=list(scores or []),
+        classifiers=list(classifiers) if classifiers is not None else None,
         experiment_name=experiment_name,
         trial_count=trial_count,
         metadata=metadata,
@@ -783,7 +806,8 @@ async def EvalAsync(
     name: str,
     data: EvalData[Input, Expected],
     task: EvalTask[Input, Output, Expected],
-    scores: Sequence[EvalScorer[Input, Output, Expected]],
+    scores: Sequence[EvalScorer[Input, Output, Expected]] | None = None,
+    classifiers: Sequence[EvalClassifier[Input, Output, Expected]] | None = None,
     experiment_name: str | None = None,
     trial_count: int = 1,
     metadata: Metadata | None = None,
@@ -875,6 +899,7 @@ async def EvalAsync(
         data=data,
         task=task,
         scores=scores,
+        classifiers=classifiers,
         experiment_name=experiment_name,
         trial_count=trial_count,
         metadata=metadata,
@@ -899,7 +924,6 @@ async def EvalAsync(
         state=state,
         enable_cache=enable_cache,
     )
-
     return await f()
 
 
@@ -910,7 +934,8 @@ def Eval(
     name: str,
     data: EvalData[Input, Expected],
     task: EvalTask[Input, Output, Expected],
-    scores: Sequence[EvalScorer[Input, Output, Expected]],
+    scores: Sequence[EvalScorer[Input, Output, Expected]] | None = None,
+    classifiers: Sequence[EvalClassifier[Input, Output, Expected]] | None = None,
     experiment_name: str | None = None,
     trial_count: int = 1,
     metadata: Metadata | None = None,
@@ -1003,6 +1028,7 @@ def Eval(
         data=data,
         task=task,
         scores=scores,
+        classifiers=classifiers,
         experiment_name=experiment_name,
         trial_count=trial_count,
         metadata=metadata,
@@ -1028,7 +1054,6 @@ def Eval(
         state=state,
         enable_cache=enable_cache,
     )
-
     # https://stackoverflow.com/questions/55409641/asyncio-run-cannot-be-called-from-a-running-event-loop-when-using-jupyter-no
     try:
         loop = asyncio.get_running_loop()
@@ -1252,19 +1277,89 @@ def set_thread_pool_max_workers(max_workers):
         obj.set_max_workers(max_workers)
 
 
-def _scorer_name(scorer, scorer_idx):
-    def helper():
-        if hasattr(scorer, "_name"):
-            return scorer._name()
-        elif hasattr(scorer, "__name__"):
-            return scorer.__name__
-        else:
-            return type(scorer).__name__
+def _callable_name(obj: Any, idx: int, fallback_prefix: str) -> str:
+    if hasattr(obj, "_name"):
+        ret = obj._name()
+    elif hasattr(obj, "__name__"):
+        ret = obj.__name__
+    else:
+        ret = type(obj).__name__
 
-    ret = helper()
     if ret == "<lambda>":
-        ret = f"scorer_{scorer_idx}"
+        ret = f"{fallback_prefix}_{idx}"
     return ret
+
+
+def _scorer_name(scorer, scorer_idx):
+    return _callable_name(scorer, scorer_idx, "scorer")
+
+
+def _classifier_name(classifier, classifier_idx):
+    return _callable_name(classifier, classifier_idx, "classifier")
+
+
+def _build_span_metadata(results: list[Score] | list[Classification]) -> Metadata | None:
+    if not results:
+        return None
+    if len(results) == 1:
+        return results[0].metadata
+
+    grouped_metadata: Metadata = {}
+    for result in results:
+        assert result.name is not None, f"Expected result to have a name, but got {result!r}"
+        if result.name not in grouped_metadata:
+            grouped_metadata[result.name] = result.metadata
+        elif isinstance(grouped_metadata[result.name], list):
+            grouped_metadata[result.name].append(result.metadata)
+        else:
+            grouped_metadata[result.name] = [grouped_metadata[result.name], result.metadata]
+    return grouped_metadata
+
+
+def _build_classification_span_output(
+    classifications: list[Classification],
+) -> dict[str, ClassificationItem | list[ClassificationItem]] | ClassificationItem:
+    assert classifications, "_build_classification_span_output requires a non-empty list"
+    if len(classifications) == 1:
+        return classifications[0].as_item()
+
+    grouped_output: dict[str, ClassificationItem | list[ClassificationItem]] = {}
+    for classification in classifications:
+        item = classification.as_item()
+        if classification.name not in grouped_output:
+            grouped_output[classification.name] = item
+        elif isinstance(grouped_output[classification.name], list):
+            grouped_output[classification.name].append(item)
+        else:
+            grouped_output[classification.name] = [grouped_output[classification.name], item]
+    return grouped_output
+
+
+def _validate_classification_result(value: Any, classifier_name: str) -> Classification:
+    if isinstance(value, Mapping):
+        if not value:
+            raise ValueError(
+                "When returning structured classifier results, each classification must be a non-empty object. "
+                f"Got: {value}"
+            )
+        try:
+            classification = Classification.from_dict(value)
+        except Exception as e:
+            raise ValueError(
+                "When returning structured classifier results, each classification must be a valid "
+                f"Classification object. Got: {value}"
+            ) from e
+    elif is_classification(value):
+        classification = value
+    else:
+        raise ValueError(
+            "When returning structured classifier results, each classification must be a non-empty object. "
+            f"Got: {value}"
+        )
+
+    if not classification.name:
+        classification = dataclasses.replace(classification, name=classifier_name)
+    return classification
 
 
 async def run_evaluator(
@@ -1355,16 +1450,14 @@ async def _run_evaluator_internal_impl(
             if hasattr(scorer, "eval_async"):
                 score = scorer.eval_async
 
-            scorer_args = kwargs
-
-            result = await call_user_fn(event_loop, score, **scorer_args)
+            result = await call_user_fn(event_loop, score, **kwargs)
             if isinstance(result, dict):
                 try:
                     result = Score.from_dict(result)
                 except Exception as e:
                     raise ValueError(f"When returning a dict, it must be a valid Score object. Got: {result}") from e
 
-            if isinstance(result, Iterable):
+            if isinstance(result, Iterable) and not isinstance(result, (str, bytes, Mapping)):
                 for s in result:
                     if not is_score(s):
                         raise ValueError(
@@ -1379,7 +1472,7 @@ async def _run_evaluator_internal_impl(
             def get_other_fields(s):
                 return {k: v for k, v in s.as_dict().items() if k not in ["metadata", "name"]}
 
-            result_metadata = {r.name: r.metadata for r in result} if len(result) != 1 else result[0].metadata
+            result_metadata = _build_span_metadata(result)
             result_output = (
                 {r.name: get_other_fields(r) for r in result} if len(result) != 1 else get_other_fields(result[0])
             )
@@ -1388,9 +1481,45 @@ async def _run_evaluator_internal_impl(
             span.log(output=result_output, metadata=result_metadata, scores=scores)
             return result
 
+    async def await_or_run_classifier(root_span, classifier, name, **kwargs):
+        parent_propagated = root_span.propagated_event or {}
+        merged_propagated = merge_dicts(
+            {**parent_propagated},
+            {"span_attributes": {"purpose": "scorer"}},
+        )
+        logged_input = {k: v for k, v in kwargs.items() if k != "trace"}
+        with root_span.start_span(
+            name=name,
+            span_attributes={"type": SpanTypeAttribute.CLASSIFIER, "purpose": "scorer"},
+            propagated_event=merged_propagated,
+            input=logged_input,
+        ) as span:
+            result = await call_user_fn(event_loop, classifier, **kwargs)
+            if result is None:
+                return None
+
+            if isinstance(result, Iterable) and not isinstance(result, (str, bytes, Mapping)):
+                raw_results = list(result)
+            else:
+                raw_results = [result]
+
+            classifications = [_validate_classification_result(r, name) for r in raw_results]
+            if not classifications:
+                span.log(output={}, metadata=None)
+                return classifications
+
+            result_metadata = _build_span_metadata(classifications)
+            result_output = _build_classification_span_output(classifications)
+            span.log(output=result_output, metadata=result_metadata)
+            return classifications
+
     # First, resolve the scorers if they are classes
-    scorers = [scorer() if inspect.isclass(scorer) and is_scorer(scorer) else scorer for scorer in evaluator.scores]
+    scorers = [
+        scorer() if inspect.isclass(scorer) and is_scorer(scorer) else scorer for scorer in (evaluator.scores or [])
+    ]
     scorer_names = [_scorer_name(scorer, i) for i, scorer in enumerate(scorers)]
+    classifiers = list(evaluator.classifiers or [])
+    classifier_names = [_classifier_name(classifier, i) for i, classifier in enumerate(classifiers)]
     unhandled_scores = scorer_names
 
     if evaluator.parameter_values is not None:
@@ -1411,6 +1540,7 @@ async def _run_evaluator_internal_impl(
         error = None
         exc_info = None
         scores = {}
+        classifications = {}
         tags = datum.tags
 
         event_dataset = (
@@ -1548,34 +1678,47 @@ async def _run_evaluator_internal_impl(
                         state=trace_state,
                     )
 
+                scorer_kwargs = {
+                    "input": datum.input,
+                    "expected": datum.expected,
+                    "metadata": metadata,
+                    "output": output,
+                    "trace": trace,
+                }
                 score_promises = [
-                    asyncio.create_task(
-                        await_or_run_scorer(
-                            root_span,
-                            score,
-                            name,
-                            **{
-                                "input": datum.input,
-                                "expected": datum.expected,
-                                "metadata": metadata,
-                                "output": output,
-                                "trace": trace,
-                            },
-                        )
-                    )
+                    asyncio.create_task(await_or_run_scorer(root_span, score, name, **scorer_kwargs))
                     for score, name in zip(scorers, scorer_names)
                 ]
-                passing_scorers_and_results = []
+                classifier_promises = [
+                    asyncio.create_task(await_or_run_classifier(root_span, classifier, name, **scorer_kwargs))
+                    for classifier, name in zip(classifiers, classifier_names)
+                ]
+
                 failing_scorers_and_exceptions = []
                 for name, p in zip(scorer_names, score_promises):
                     try:
                         score_results = await p
                         for score in score_results:
-                            passing_scorers_and_results.append((score.name, score))
                             scores[score.name] = score.score
                     except Exception as e:
-                        exc_info = traceback.format_exc()
-                        failing_scorers_and_exceptions.append((name, e, exc_info))
+                        failing_scorers_and_exceptions.append((name, e, traceback.format_exc()))
+
+                failing_classifiers_and_exceptions = []
+                for name, p in zip(classifier_names, classifier_promises):
+                    try:
+                        classifier_results = await p
+                        if classifier_results is None:
+                            continue
+                        for classification in classifier_results:
+                            item = classification.as_item()
+                            if classification.name not in classifications:
+                                classifications[classification.name] = []
+                            classifications[classification.name].append(item)
+                    except Exception as e:
+                        failing_classifiers_and_exceptions.append((name, e, traceback.format_exc()))
+
+                if classifications:
+                    root_span.log(classifications=classifications)
 
                 nonlocal unhandled_scores
                 unhandled_scores = None
@@ -1584,14 +1727,25 @@ async def _run_evaluator_internal_impl(
                         scorer_name: exc_info for scorer_name, _, exc_info in failing_scorers_and_exceptions
                     }
                     metadata["scorer_errors"] = scorer_errors
-                    root_span.log(metadata=metadata, tags=tags)
-                    names = ", ".join(scorer_errors.keys())
-                    exceptions = [x[1] for x in failing_scorers_and_exceptions]
                     unhandled_scores = list(scorer_errors.keys())
                     eprint(
-                        f"Found exceptions for the following scorers: {names}",
-                        exceptions,
+                        f"Found exceptions for the following scorers: {', '.join(scorer_errors.keys())}",
+                        [x[1] for x in failing_scorers_and_exceptions],
                     )
+
+                if failing_classifiers_and_exceptions:
+                    classifier_errors = {
+                        classifier_name: exc_info
+                        for classifier_name, _, exc_info in failing_classifiers_and_exceptions
+                    }
+                    metadata["classifier_errors"] = classifier_errors
+                    eprint(
+                        f"Found exceptions for the following classifiers: {', '.join(classifier_errors.keys())}",
+                        [x[1] for x in failing_classifiers_and_exceptions],
+                    )
+
+                if failing_scorers_and_exceptions or failing_classifiers_and_exceptions:
+                    root_span.log(metadata=metadata, tags=tags)
             except Exception as e:
                 exc_type, exc_value, tb = sys.exc_info()
                 root_span.log(error=stringify_exception(exc_type, exc_value, tb))
@@ -1615,6 +1769,7 @@ async def _run_evaluator_internal_impl(
                 ),
                 **scores,
             },
+            classifications=classifications or None,
             error=error,
             exc_info=exc_info,
         )
@@ -1732,4 +1887,14 @@ def build_local_summary(
     )
 
 
-__all__ = ["Evaluator", "Eval", "EvalAsync", "Score", "EvalCase", "EvalHooks", "BaseExperiment", "Reporter"]
+__all__ = [
+    "BaseExperiment",
+    "Classification",
+    "Eval",
+    "EvalAsync",
+    "EvalCase",
+    "EvalHooks",
+    "Evaluator",
+    "Reporter",
+    "Score",
+]

--- a/py/src/braintrust/score.py
+++ b/py/src/braintrust/score.py
@@ -2,7 +2,9 @@ import dataclasses
 import inspect
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, TypedDict
+
+from typing_extensions import NotRequired
 
 from .serializable_data_class import SerializableDataClass
 from .types import Metadata
@@ -51,6 +53,56 @@ class Score(SerializableDataClass):
             )
 
 
+class ClassificationItem(TypedDict):
+    id: str
+    label: str
+    metadata: NotRequired[Metadata]
+
+
+@dataclasses.dataclass
+class Classification(SerializableDataClass):
+    """A classification result for an evaluation."""
+
+    id: str
+    """A machine-readable identifier for the classification outcome."""
+
+    name: str | None = None
+    """The name of this classification result. Defaults to the classifier function name when omitted."""
+
+    label: str | None = None
+    """Optional human-readable label. Defaults to ``id`` when omitted."""
+
+    metadata: Metadata | None = None
+    """Optional metadata attached to the classification result."""
+
+    def as_dict(self):
+        result = {"id": self.id}
+        if self.name is not None:
+            result["name"] = self.name
+        if self.label is not None:
+            result["label"] = self.label
+        if self.metadata is not None:
+            result["metadata"] = self.metadata
+        return result
+
+    def as_item(self) -> ClassificationItem:
+        result: ClassificationItem = {
+            "id": self.id,
+            "label": self.label or self.id,
+        }
+        if self.metadata is not None:
+            result["metadata"] = self.metadata
+        return result
+
+    def __post_init__(self):
+        if not isinstance(self.id, str) or not self.id:
+            raise ValueError("classification id must be a non-empty string")
+        if self.name is not None and (not isinstance(self.name, str) or not self.name):
+            raise ValueError("classification name must be a non-empty string when provided")
+        if self.label is not None and not isinstance(self.label, str):
+            raise ValueError("classification label must be a string when provided")
+
+
 def is_score(obj):
     return hasattr(obj, "name") and hasattr(obj, "score") and hasattr(obj, "metadata") and hasattr(obj, "as_dict")
 
@@ -76,6 +128,10 @@ class Scorer(ABC):
     def _run_eval_sync(self, output: Any, expected: Any = None, **kwargs: Any) -> Score: ...
 
 
+def is_classification(obj):
+    return hasattr(obj, "id") and hasattr(obj, "metadata") and hasattr(obj, "as_dict")
+
+
 def is_scorer(obj):
     # For class objects, check for appropriate methods
     if inspect.isclass(obj):
@@ -92,4 +148,12 @@ def is_scorer(obj):
     return callable(obj)
 
 
-__all__ = ["Score", "Scorer", "is_score", "is_scorer"]
+__all__ = [
+    "Classification",
+    "ClassificationItem",
+    "Score",
+    "Scorer",
+    "is_classification",
+    "is_score",
+    "is_scorer",
+]

--- a/py/src/braintrust/span_types.py
+++ b/py/src/braintrust/span_types.py
@@ -16,6 +16,7 @@ class SpanTypeAttribute(str, Enum):
     AUTOMATION = "automation"
     FACET = "facet"
     PREPROCESSOR = "preprocessor"
+    CLASSIFIER = "classifier"
     REVIEW = "review"
 
 

--- a/py/src/braintrust/test_framework.py
+++ b/py/src/braintrust/test_framework.py
@@ -18,7 +18,7 @@ from .framework import (
     parse_filters,
     run_evaluator,
 )
-from .score import Score, Scorer
+from .score import Classification, Score, Scorer
 from .test_helpers import init_test_exp, with_memory_logger, with_simulate_login  # noqa: F401
 
 
@@ -466,6 +466,133 @@ def simple_scorer():
         return {"name": "simple_scorer", "score": 0.8}
 
     return simple_scorer_function
+
+
+@pytest.mark.asyncio
+async def test_eval_classifier_only_populates_classifications():
+    result = await Eval(
+        "test-classifier-only",
+        data=[{"input": "hello", "expected": "greeting"}],
+        task=lambda input_value: input_value,
+        classifiers=[
+            lambda input_value, output, expected: Classification(
+                id="greeting",
+                name="category",
+                label="Greeting",
+                metadata={"source": "unit-test"},
+            )
+        ],
+        no_send_logs=True,
+    )
+
+    assert len(result.results) == 1
+    assert result.results[0].scores == {}
+    assert result.results[0].classifications == {
+        "category": [
+            {
+                "id": "greeting",
+                "label": "Greeting",
+                "metadata": {"source": "unit-test"},
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_eval_multiple_classifications_append_same_name():
+    def category(input_value, output, expected):
+        return [
+            {"id": "greeting", "name": "category", "label": "Greeting"},
+            {"id": "informal", "name": "category", "label": "Informal"},
+        ]
+
+    result = await Eval(
+        "test-classifier-append",
+        data=[{"input": "hello"}],
+        task=lambda input_value: input_value,
+        classifiers=[category],
+        no_send_logs=True,
+    )
+
+    assert len(result.results) == 1
+    assert result.results[0].classifications == {
+        "category": [
+            {"id": "greeting", "label": "Greeting"},
+            {"id": "informal", "label": "Informal"},
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_eval_populates_scores_and_classifications(simple_scorer):
+    def category(input_value, output, expected):
+        return {"id": "greeting", "label": "Greeting"}
+
+    result = await Eval(
+        "test-score-and-classify",
+        data=[{"input": "hello", "expected": "hello"}],
+        task=lambda input_value: input_value,
+        scores=[simple_scorer],
+        classifiers=[category],
+        no_send_logs=True,
+    )
+
+    assert len(result.results) == 1
+    assert result.results[0].scores == {"simple_scorer": 0.8}
+    assert result.results[0].classifications == {"category": [{"id": "greeting", "label": "Greeting"}]}
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_classifier_spans_are_logged(with_memory_logger, with_simulate_login):
+    evaluator = Evaluator(
+        project_name="test-project",
+        eval_name="test-classifier-span",
+        data=[EvalCase(input="hello", expected="greeting")],
+        task=lambda input_value: input_value,
+        scores=[],
+        classifiers=[
+            lambda input_value, output, expected: [
+                {
+                    "id": "greeting",
+                    "name": "category",
+                    "label": "Greeting",
+                    "metadata": {"source": "greeting"},
+                },
+                {
+                    "id": "informal",
+                    "name": "category",
+                    "label": "Informal",
+                    "metadata": {"source": "style"},
+                },
+            ]
+        ],
+        experiment_name="test-classifier-span",
+        metadata=None,
+    )
+
+    exp = init_test_exp("test-classifier-span", "test-project")
+    result = await run_evaluator(experiment=exp, evaluator=evaluator, position=None, filters=[])
+
+    assert len(result.results) == 1
+    expected_classifications = {
+        "category": [
+            {"id": "greeting", "label": "Greeting", "metadata": {"source": "greeting"}},
+            {"id": "informal", "label": "Informal", "metadata": {"source": "style"}},
+        ]
+    }
+    assert result.results[0].classifications == expected_classifications
+
+    logs = with_memory_logger.pop()
+    classifier_spans = [log for log in logs if log.get("span_attributes", {}).get("type") == "classifier"]
+    assert len(classifier_spans) == 1
+    assert classifier_spans[0]["span_attributes"].get("purpose") == "scorer"
+    assert classifier_spans[0].get("output") == expected_classifications
+    assert classifier_spans[0].get("metadata") == {"category": [{"source": "greeting"}, {"source": "style"}]}
+
+    root_spans = [log for log in logs if not log["span_parents"]]
+    assert len(root_spans) == 1
+    assert root_spans[0].get("classifications") == expected_classifications
 
 
 @pytest.mark.asyncio

--- a/py/src/braintrust/test_score.py
+++ b/py/src/braintrust/test_score.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-from .score import Score
+from .score import Classification, Score
 
 
 class TestScore(unittest.TestCase):
@@ -149,6 +149,36 @@ class TestScore(unittest.TestCase):
         result_with_error = score_with_error.as_dict()
 
         self.assertNotIn("error", result_with_error)
+
+
+class TestClassification(unittest.TestCase):
+    def test_as_dict_omits_unset_optional_fields(self):
+        classification = Classification(id="greeting")
+        self.assertEqual(classification.as_dict(), {"id": "greeting"})
+
+    def test_as_item_defaults_label_to_id(self):
+        classification = Classification(id="greeting")
+        self.assertEqual(classification.as_item(), {"id": "greeting", "label": "greeting"})
+
+    def test_as_item_includes_metadata(self):
+        classification = Classification(
+            id="greeting",
+            name="category",
+            label="Greeting",
+            metadata={"source": "unit-test"},
+        )
+        self.assertEqual(
+            classification.as_item(),
+            {
+                "id": "greeting",
+                "label": "Greeting",
+                "metadata": {"source": "unit-test"},
+            },
+        )
+
+    def test_validation_requires_non_empty_id(self):
+        with self.assertRaises(ValueError):
+            Classification(id="")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a new `classifiers` parameter to `Eval`/`EvalAsync`/`Evaluator` that runs classification functions alongside scorers. Classifier results are recorded under a dedicated `classifications` field on `EvalResult` and logged to classifier-typed spans.

Based on JS PR: https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1553
and the spec: https://github.com/braintrustdata/braintrust-spec/blob/main/docs/telemetry/classifier.md