### PR TITLE
fix: use Sequence instead of Iterable for report_failures parameter

### DIFF
--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -593,7 +593,7 @@ def pluralize(n, singular, plural):
         return plural
 
 
-def report_failures(evaluator: Evaluator, failing_results: Iterable[EvalResult], verbose: bool, jsonl: bool) -> None:
+def report_failures(evaluator: Evaluator, failing_results: Sequence[EvalResult], verbose: bool, jsonl: bool) -> None:
     eprint(
         f"{bcolors.FAIL}Evaluator {evaluator.eval_name} failed with {len(failing_results)} {pluralize(len(failing_results), 'error', 'errors')}{bcolors.ENDC}"
     )


### PR DESCRIPTION
## Summary

- `report_failures` calls `len(failing_results)` but the parameter is typed as `Iterable[EvalResult]`, which has no `__len__`. Changed to `Sequence[EvalResult]` to match the actual contract.
- `Sequence` is already imported in the file; no new imports needed.
- The sole call site (`report_evaluator_result`) already passes a `list`, so this is annotation-only — no behavioral change.

## Test plan

- [ ] Existing tests pass (annotation-only change, no runtime impact)
- [ ] Type checkers no longer allow passing a non-sized iterable to `report_failures`