### PR TITLE
fix: use Mapping for Metadata and ParametersSchema type aliases

### DIFF
--- a/py/src/braintrust/parameters.py
+++ b/py/src/braintrust/parameters.py
@@ -38,7 +38,7 @@ JSONValue = None | bool | int | float | str | list["JSONValue"] | dict[str, "JSO
 ValidatedParameters = dict[str, object]
 ParameterSchema = PromptParameter | ModelParameter | type[object] | None
 EvalParameters = Mapping[str, ParameterSchema]
-ParametersSchema = dict[str, Any]
+ParametersSchema = Mapping[str, Any]
 
 
 @dataclass

--- a/py/src/braintrust/types/__init__.py
+++ b/py/src/braintrust/types/__init__.py
@@ -1,4 +1,5 @@
+from collections.abc import Mapping
 from typing import Any
 
 
-Metadata = dict[str, Any]
+Metadata = Mapping[str, Any]


### PR DESCRIPTION
## Summary

- Changes `Metadata` (`types/__init__.py`) and `ParametersSchema` (`parameters.py`) from `dict[str, Any]` to `Mapping[str, Any]`.
- Both aliases are used exclusively in parameter positions across the SDK (`Eval()`, `EvalAsync()`, `init()`, `Logger.log()`, `Dataset.insert()`, `invoke()`, `validate_json_schema()`, etc.). No call site mutates values received through these types.
- Fixes dict invariance: a caller with `dict[str, str]` (valid metadata) was rejected by type checkers because `dict[str, str]` is not assignable to `dict[str, Any]` due to invariance. `Mapping` is covariant in its value type, so this works correctly.
- Follows the same pattern as PR #281 (`EvalParameters` → `Mapping`).

`Score.metadata` is typed as `Metadata` on a dataclass field — verified that no code mutates it after construction.

## Test plan

- [ ] Existing tests pass (annotation-only change, no runtime impact)
- [ ] `dict` subtype callers (e.g. `dict[str, str]`) are now accepted by type checkers