### PR TITLE
fix: use Mapping for dict params, Any for ValidatedParameters

### DIFF
--- a/py/src/braintrust/framework2.py
+++ b/py/src/braintrust/framework2.py
@@ -1,6 +1,6 @@
 import dataclasses
 import json
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any, overload
 
 import slugify
@@ -127,7 +127,7 @@ class CodeParameters:
     description: str | None
     schema: EvalParameters
     if_exists: IfExists | None
-    metadata: dict[str, Any] | None = None
+    metadata: Mapping[str, Any] | None = None
 
     def to_function_definition(self, if_exists: IfExists | None, project_ids: ProjectIdCache) -> dict[str, Any]:
         schema = parameters_to_json_schema(self.schema)
@@ -352,7 +352,7 @@ class ParametersBuilder:
         slug: str | None = None,
         description: str | None = None,
         if_exists: IfExists | None = None,
-        metadata: dict[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
     ) -> EvalParameters:
         if slug is None or len(slug) == 0:
             slug = slugify.slugify(name)
@@ -408,7 +408,7 @@ class ScorerBuilder:
         model: str,
         params: ModelParams | None = None,
         use_cot: bool,
-        choice_scores: dict[str, float],
+        choice_scores: Mapping[str, float],
     ) -> CodePrompt: ...
 
     # LLM scorer with messages.
@@ -426,7 +426,7 @@ class ScorerBuilder:
         model: str,
         params: ModelParams | None = None,
         use_cot: bool,
-        choice_scores: dict[str, float],
+        choice_scores: Mapping[str, float],
     ) -> CodePrompt: ...
 
     def create(
@@ -448,7 +448,7 @@ class ScorerBuilder:
         model: str | None = None,
         params: ModelParams | None = None,
         use_cot: bool | None = None,
-        choice_scores: dict[str, float] | None = None,
+        choice_scores: Mapping[str, float] | None = None,
     ) -> CodeFunction | CodePrompt:
         """Creates a scorer.
 

--- a/py/src/braintrust/parameters.py
+++ b/py/src/braintrust/parameters.py
@@ -35,7 +35,7 @@ class ModelParameter(TypedDict):
 
 
 JSONValue = None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
-ValidatedParameters = dict[str, object]
+ValidatedParameters = dict[str, Any]
 ParameterSchema = PromptParameter | ModelParameter | type[object] | None
 EvalParameters = Mapping[str, ParameterSchema]
 ParametersSchema = dict[str, Any]


### PR DESCRIPTION
## Summary

Three type annotation fixes in `framework2.py` and `parameters.py`:

- **`choice_scores: dict[str, float]` → `Mapping[str, float]`** in `ScorerBuilder.create()` (all 3 overloads). Input parameter — dict invariance means `dict[str, int]` was rejected even though `int` is compatible with `float`.
- **`metadata: dict[str, Any]` → `Mapping[str, Any]`** in `CodeParameters` dataclass field and `ParametersBuilder.create()`. Input parameter — same invariance class as the `Metadata` alias change in PR #285. Other metadata params in this file already use the `Metadata` alias.
- **`ValidatedParameters = dict[str, object]` → `dict[str, Any]`**. Values are Pydantic models, strings, `Prompt` objects, etc. Using `object` forces every caller to narrow; `Any` is the practical type for this heterogeneous container.

## Test plan

- [ ] Existing tests pass (annotation-only changes, no runtime impact)
- [ ] `dict[str, int]` is now accepted for `choice_scores` by type checkers
- [ ] Retrieved `ValidatedParameters` values no longer require narrowing from `object`