### PR TITLE
chore(mise): point venv path to py/.venv

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ experimental = true
 
 [env]
 # Automatically activate our virtual environment
-_.python.venv = { path = "venv", create = true, uv_create_args = ['--seed']}
+_.python.venv = { path = "py/.venv", create = true, uv_create_args = ['--seed']}
 
 # See env.example to configure API keys.
 _.file = ".env"


### PR DESCRIPTION
## Summary

- Updates the mise venv path from `venv` to `py/.venv` to match the SDK workspace layout under `py/`

## Test plan

- [ ] Verify `mise install` activates the virtualenv at `py/.venv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fixes this warning when running mise install 

```
     + wrapt==1.17.3
    uv sync --group dev
    warning: `VIRTUAL_ENV=/Users/matt/code/braintrustdata/braintrust-sdk-python/venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
    Resolved 299 packages in 3ms
```