### PR TITLE
Remove @dataclasses.dataclass from TaskProgressEvent

### DIFF
--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -109,7 +109,6 @@ class EvalResult(SerializableDataClass, Generic[Input, Output, Expected]):
     exc_info: str | None = None
 
 
-@dataclasses.dataclass
 class TaskProgressEvent(TypedDict):
     """Progress event that can be reported during task execution."""
 


### PR DESCRIPTION
## Summary

Fixes #293.

`TaskProgressEvent` was decorated with both `@dataclasses.dataclass` and inherited from `TypedDict`. These use incompatible metaclass mechanisms — `TypedDict` uses its own metaclass to build the class dict, while `@dataclasses.dataclass` expects a regular class and transforms its annotations into dataclass fields. The combination works accidentally at runtime but confuses static type checkers and is unnecessary.

The maintainer [confirmed](https://github.com/braintrustdata/braintrust-sdk-python/issues/293#issuecomment-4248459296) that `TypedDict` is the intended form. This PR removes the `@dataclasses.dataclass` decorator, leaving `class TaskProgressEvent(TypedDict):` unchanged.

## Test plan

- [x] Verify no other `@dataclasses.dataclass` decorators are affected (only `TaskProgressEvent`'s was removed)
- [x] Confirm `TaskProgressEvent` and its subclass `SSEProgressEvent` continue to work as plain `TypedDict` classes