### PR TITLE
Widen BraintrustStreamChunk and annotate BraintrustStream.stream

### DIFF
--- a/py/src/braintrust/functions/stream.py
+++ b/py/src/braintrust/functions/stream.py
@@ -7,7 +7,7 @@ with utility methods to make them easy to log and convert into various formats.
 
 import dataclasses
 import json
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from itertools import tee
 from typing import Literal, Union
 
@@ -79,7 +79,13 @@ class BraintrustInvokeError(ValueError):
     pass
 
 
-BraintrustStreamChunk = Union[BraintrustTextChunk, BraintrustJsonChunk, BraintrustErrorChunk]
+BraintrustStreamChunk = Union[
+    BraintrustTextChunk,
+    BraintrustJsonChunk,
+    BraintrustErrorChunk,
+    BraintrustConsoleChunk,
+    BraintrustProgressChunk,
+]
 
 
 class BraintrustStream:
@@ -96,7 +102,7 @@ class BraintrustStream:
             base_stream: Either an SSEClient or a list of BraintrustStreamChunks.
         """
         if isinstance(base_stream, SSEClient):
-            self.stream = self._parse_sse_stream(base_stream)
+            self.stream: Iterable[BraintrustStreamChunk] = self._parse_sse_stream(base_stream)
         else:
             self.stream = base_stream
         self._memoized_final_value = None


### PR DESCRIPTION
## Summary

Fixes #294.

Two entangled type fixes in `functions/stream.py`:

1. **Widen `BraintrustStreamChunk`** — `_parse_sse_stream` yields `BraintrustConsoleChunk` and `BraintrustProgressChunk` in addition to the three types in the union. The union now includes all five chunk types so the declared type matches actual stream output.

2. **Annotate `self.stream`** — previously untyped. Annotated as `Iterable[BraintrustStreamChunk]` to cover the generator from `_parse_sse_stream`, `list` inputs, and iterators produced by `tee` in `copy()`.

Per [maintainer guidance](https://github.com/braintrustdata/braintrust-sdk-python/issues/294#issuecomment-4248464526), widening the public type is preferred over an internal union — the types should reflect the actual API.

## Test plan

- [x] Verify `_parse_sse_stream` yield types are all members of the widened `BraintrustStreamChunk`
- [x] Verify `parse_stream` handles all five chunk types (lines 191-199)
- [x] Verify `self.stream` annotation is compatible with all assignment sites (`__init__`, `copy`)