### PR TITLE
ci: bump peter-evans/create-pull-request to v8

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Open PR
         if: steps.labels.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b31e8c0e067c3b0d45ef # v7.0.8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           title: "chore(deps): daily dependency update"
           body: |

--- a/.github/workflows/update-session-weights.yaml
+++ b/.github/workflows/update-session-weights.yaml
@@ -67,7 +67,7 @@ jobs:
         run: rm -f measured-durations-*.json
       - name: Create pull request
         if: steps.check.outputs.drifted == 'true'
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "ci: update nox session weights"
           branch: auto/update-session-weights


### PR DESCRIPTION
This fixes https://github.com/braintrustdata/braintrust-sdk-python/actions/runs/24496114527