### PR TITLE
fix(framework): make classifier labels optional

### DIFF
--- a/py/src/braintrust/score.py
+++ b/py/src/braintrust/score.py
@@ -55,7 +55,7 @@ class Score(SerializableDataClass):
 
 class ClassificationItem(TypedDict):
     id: str
-    label: str
+    label: NotRequired[str]
     metadata: NotRequired[Metadata]
 
 
@@ -70,7 +70,7 @@ class Classification(SerializableDataClass):
     """The name of this classification result. Defaults to the classifier function name when omitted."""
 
     label: str | None = None
-    """Optional human-readable label. Defaults to ``id`` when omitted."""
+    """Optional human-readable label."""
 
     metadata: Metadata | None = None
     """Optional metadata attached to the classification result."""
@@ -86,10 +86,9 @@ class Classification(SerializableDataClass):
         return result
 
     def as_item(self) -> ClassificationItem:
-        result: ClassificationItem = {
-            "id": self.id,
-            "label": self.label or self.id,
-        }
+        result: ClassificationItem = {"id": self.id}
+        if self.label is not None:
+            result["label"] = self.label
         if self.metadata is not None:
             result["metadata"] = self.metadata
         return result

--- a/py/src/braintrust/test_framework.py
+++ b/py/src/braintrust/test_framework.py
@@ -499,6 +499,23 @@ async def test_eval_classifier_only_populates_classifications():
 
 
 @pytest.mark.asyncio
+async def test_eval_classifier_without_label_omits_label():
+    def category(input_value, output, expected):
+        return {"id": "greeting"}
+
+    result = await Eval(
+        "test-classifier-without-label",
+        data=[{"input": "hello"}],
+        task=lambda input_value: input_value,
+        classifiers=[category],
+        no_send_logs=True,
+    )
+
+    assert len(result.results) == 1
+    assert result.results[0].classifications == {"category": [{"id": "greeting"}]}
+
+
+@pytest.mark.asyncio
 async def test_eval_multiple_classifications_append_same_name():
     def category(input_value, output, expected):
         return [

--- a/py/src/braintrust/test_score.py
+++ b/py/src/braintrust/test_score.py
@@ -156,9 +156,9 @@ class TestClassification(unittest.TestCase):
         classification = Classification(id="greeting")
         self.assertEqual(classification.as_dict(), {"id": "greeting"})
 
-    def test_as_item_defaults_label_to_id(self):
+    def test_as_item_omits_label_when_unset(self):
         classification = Classification(id="greeting")
-        self.assertEqual(classification.as_item(), {"id": "greeting", "label": "greeting"})
+        self.assertEqual(classification.as_item(), {"id": "greeting"})
 
     def test_as_item_includes_metadata(self):
         classification = Classification(


### PR DESCRIPTION
Stop defaulting unlabeled classifier results to their id when building classification items. This keeps the Python SDK aligned with the JavaScript fix and preserves payloads where `label` is omitted.

Add regression coverage for bare classifier ids in both the score helpers and Eval output.

Aligns with https://github.com/braintrustdata/braintrust-sdk-javascript/pull/1842