### PR TITLE
ci(deps): run dependency updates on weekdays and tidy workflow

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -1,7 +1,7 @@
 name: Dependency updates
 on:
   schedule:
-    - cron: "0 6 * * *" # daily 6am UTC
+    - cron: "0 6 * * 1-5" # weekdays 6am UTC
   workflow_dispatch:
 
 permissions:
@@ -21,7 +21,7 @@ jobs:
 
       - name: Update matrix latest pins
         working-directory: py
-        run: python3 scripts/update-matrix-latest.py
+        run: python scripts/update-matrix-latest.py
 
       - name: Upgrade lockfile
         working-directory: py
@@ -30,54 +30,26 @@ jobs:
       - name: Determine labels
         id: labels
         working-directory: py
-        run: |
-          python3 << 'PYEOF' >> "$GITHUB_OUTPUT"
-          import subprocess, sys
-
-          if sys.version_info >= (3, 11):
-              import tomllib
-          else:
-              try:
-                  import tomllib
-              except ModuleNotFoundError:
-                  import tomli as tomllib
-
-          diff = subprocess.check_output(["git", "diff", "--", "pyproject.toml", "uv.lock"], text=True)
-          if not diff:
-              print("changed=false")
-              raise SystemExit(0)
-
-          # Read pyproject.toml to find provider SDK packages from the matrix table
-          with open("pyproject.toml", "rb") as f:
-              pyproject = tomllib.load(f)
-
-          matrix = pyproject.get("tool", {}).get("braintrust", {}).get("matrix", {})
-
-          # Extract the base package name from provider-related matrix requirement strings.
-          # Exclude pure test/infra pins that do not affect cassette coverage.
-          provider_matrix = {
-              key: versions
-              for key, versions in matrix.items()
-              if key not in {"pytest-matrix", "braintrust-core"}
-          }
-
-          provider_pkgs = set()
-          for _prefix, versions in provider_matrix.items():
-              for req in versions.values():
-                  # req looks like "openai==1.92.0" or "pydantic-ai==1.82.0"
-                  pkg = req.split("==")[0].split(">=")[0].split("<=")[0].strip()
-                  provider_pkgs.add(pkg)
-
-          # Check if any provider package changed in the lockfile diff
-          needs_rerecord = any(pkg in diff for pkg in provider_pkgs)
-
-          print("changed=true")
-          print(f"needs_rerecord={str(needs_rerecord).lower()}")
-          PYEOF
+        run: python scripts/determine-dependency-update-labels.py >> "$GITHUB_OUTPUT"
 
       - name: Get date
         id: date
         run: echo "date=$(date +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Close stale daily dependency update PRs
+        if: steps.labels.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_BRANCH: deps/daily-update-${{ steps.date.outputs.date }}
+        run: |
+          gh pr list \
+            --state open \
+            --json number,title,headRefName \
+            --jq ".[] | select(.title == \"chore(deps): daily dependency update\") | select(.headRefName != \"$CURRENT_BRANCH\") | .number" \
+          | while read -r pr; do
+              echo "Closing stale dependency update PR #$pr"
+              gh pr close "$pr" --comment "Superseded by a newer automated dependency update." --delete-branch
+            done
 
       - name: Open PR
         if: steps.labels.outputs.changed == 'true'

--- a/py/scripts/check-stale-cassettes.py
+++ b/py/scripts/check-stale-cassettes.py
@@ -19,14 +19,7 @@ import pathlib
 import shutil
 import sys
 
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    try:
-        import tomllib
-    except ModuleNotFoundError:
-        import tomli as tomllib  # type: ignore[no-redef]
+import tomllib
 
 
 _PROJECT_DIR = pathlib.Path(__file__).resolve().parent.parent

--- a/py/scripts/determine-dependency-update-labels.py
+++ b/py/scripts/determine-dependency-update-labels.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Determine GitHub Actions outputs for the daily dependency update workflow.
+
+Inspects the working-tree diff of ``py/pyproject.toml`` and ``py/uv.lock`` to
+decide whether anything changed and, if so, whether any provider SDK pins
+shifted (which requires cassette re-recording).
+
+Writes ``key=value`` lines to stdout in the format expected by
+``$GITHUB_OUTPUT``:
+
+    changed=true|false
+    needs_rerecord=true|false   # only when changed=true
+
+Run from ``py/`` (same working directory as the workflow step):
+
+    python scripts/determine-dependency-update-labels.py >> "$GITHUB_OUTPUT"
+"""
+
+import subprocess
+import sys
+
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+
+def main() -> int:
+    diff = subprocess.check_output(["git", "diff", "--", "pyproject.toml", "uv.lock"], text=True)
+    if not diff:
+        print("changed=false")
+        return 0
+
+    # Read pyproject.toml to find provider SDK packages from the matrix table.
+    with open("pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
+
+    matrix = pyproject.get("tool", {}).get("braintrust", {}).get("matrix", {})
+
+    # Exclude pure test/infra pins that do not affect cassette coverage.
+    provider_matrix = {
+        key: versions for key, versions in matrix.items() if key not in {"pytest-matrix", "braintrust-core"}
+    }
+
+    provider_pkgs = set()
+    for versions in provider_matrix.values():
+        for req in versions.values():
+            # req looks like "openai==1.92.0" or "pydantic-ai==1.82.0"
+            pkg = req.split("==")[0].split(">=")[0].split("<=")[0].strip()
+            provider_pkgs.add(pkg)
+
+    # Check if any provider package changed in the lockfile diff.
+    needs_rerecord = any(pkg in diff for pkg in provider_pkgs)
+
+    print("changed=true")
+    print(f"needs_rerecord={str(needs_rerecord).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/py/scripts/determine-dependency-update-labels.py
+++ b/py/scripts/determine-dependency-update-labels.py
@@ -19,14 +19,7 @@ Run from ``py/`` (same working directory as the workflow step):
 import subprocess
 import sys
 
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    try:
-        import tomllib  # type: ignore[no-redef]
-    except ModuleNotFoundError:
-        import tomli as tomllib  # type: ignore[no-redef]
+import tomllib
 
 
 def main() -> int:

--- a/py/scripts/update-matrix-latest.py
+++ b/py/scripts/update-matrix-latest.py
@@ -14,19 +14,11 @@ import argparse
 import json
 import pathlib
 import re
-import sys
 import urllib.error
 import urllib.parse
 import urllib.request
 
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    try:
-        import tomllib
-    except ModuleNotFoundError:
-        import tomli as tomllib  # type: ignore[no-redef]
+import tomllib
 
 
 _PROJECT_DIR = pathlib.Path(__file__).resolve().parent.parent


### PR DESCRIPTION
- Switch the dependency-updates cron from daily to Monday-Friday at
  6am UTC. Manual runs via workflow_dispatch remain available.
- Close any stale open `chore(deps): daily dependency update` PRs
  before opening a new one, skipping the current-day branch so same-day
  re-runs update in place.