### PR TITLE
fix(openai): re-export NamedWrapper from braintrust.oai for back-compat

### DIFF
--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -1,4 +1,5 @@
 from braintrust.integrations.openai import OpenAIIntegration, wrap_openai
+from braintrust.integrations.openai.tracing import NamedWrapper
 
 
 def patch_openai() -> bool:
@@ -7,6 +8,7 @@ def patch_openai() -> bool:
 
 
 __all__ = [
+    "NamedWrapper",
     "patch_openai",
     "wrap_openai",
 ]

--- a/py/src/braintrust/oai.py
+++ b/py/src/braintrust/oai.py
@@ -1,4 +1,10 @@
 from braintrust.integrations.openai import OpenAIIntegration, wrap_openai
+
+# NamedWrapper is re-exported here for back-compat. autoevals imports it from
+# `braintrust.oai` to detect OpenAI clients that the Braintrust SDK has already
+# wrapped (see autoevals/oai.py); if the import fails, autoevals falls back to
+# an internal stub and its isinstance check misses real wrapped clients,
+# causing scorer LLM calls to be re-wrapped without tracing.
 from braintrust.integrations.openai.tracing import NamedWrapper
 
 


### PR DESCRIPTION
autoevals imports NamedWrapper from braintrust.oai to detect whether an
OpenAI client has already been wrapped by the Braintrust SDK. After the
0.15.0 refactor moved the class to braintrust.integrations.openai.tracing,
the import silently fell back to an internal stub, so isinstance checks
no longer matched braintrust-wrapped clients. autoevals then re-wrapped
with its own non-tracing shim, dropping scorer spans (openai.responses.create
and Embedding calls with purpose="scorer") across a number of expect tests.

Re-export NamedWrapper from braintrust.oai so autoevals' existing detection
path keeps working.