### PR TITLE
fix(claude_agent_sdk): preserve tool span output across back-to-back tool_use messages

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -266,7 +266,7 @@ latest = "litellm==1.83.9"
 "1.74.0" = "litellm==1.74.0"
 
 [tool.braintrust.matrix.claude-agent-sdk]
-latest = "claude-agent-sdk==0.1.60"
+latest = "claude-agent-sdk==0.1.61"
 "0.1.10" = "claude-agent-sdk==0.1.10"
 
 [tool.braintrust.matrix.agno]

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_auto_claude_agent_sdk.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_auto_claude_agent_sdk.json
@@ -10,7 +10,7 @@
             "hooks": null,
             "subtype": "initialize"
           },
-          "request_id": "req_1_c18c0151",
+          "request_id": "req_1_74e31761",
           "type": "control_request"
         }
       }
@@ -19,7 +19,7 @@
       "op": "read",
       "payload": {
         "response": {
-          "request_id": "req_1_c18c0151",
+          "request_id": "req_1_74e31761",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
@@ -61,7 +61,7 @@
           "statusline-setup"
         ],
         "apiKeySource": "ANTHROPIC_API_KEY",
-        "claude_code_version": "2.1.111",
+        "claude_code_version": "2.1.112",
         "cwd": "<REDACTED_CWD>",
         "fast_mode_state": "off",
         "mcp_servers": [
@@ -87,7 +87,7 @@
             "source": "rust-analyzer-lsp@claude-plugins-official"
           }
         ],
-        "session_id": "b4d0c5e6-fe8f-468d-834d-7aa9308fb670",
+        "session_id": "2f2fb67d-d508-4f58-9f48-551b133d70f8",
         "skills": [
           "update-config",
           "debug",
@@ -214,7 +214,7 @@
           "mcp__linear-server__update_document"
         ],
         "type": "system",
-        "uuid": "f4136e46-3351-45a5-8c82-6979d9792b4f"
+        "uuid": "71551199-f881-4abd-bafc-deb6392925db"
       }
     },
     {
@@ -230,7 +230,7 @@
             }
           ],
           "context_management": null,
-          "id": "095526d8-ef05-4ca6-b321-3f01dd2f6e43",
+          "id": "e2d89271-1454-4fb9-80ac-9487ea1d1bd1",
           "model": "<synthetic>",
           "role": "assistant",
           "stop_reason": "stop_sequence",
@@ -256,9 +256,9 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "b4d0c5e6-fe8f-468d-834d-7aa9308fb670",
+        "session_id": "2f2fb67d-d508-4f58-9f48-551b133d70f8",
         "type": "assistant",
-        "uuid": "ba47c73f-65b6-4eae-8f5d-15932b8b2fb2"
+        "uuid": "1e886de5-b6e9-46ac-bb3a-6fa5151858fe"
       }
     },
     {
@@ -266,14 +266,14 @@
       "payload": {
         "api_error_status": 404,
         "duration_api_ms": 0,
-        "duration_ms": 388,
+        "duration_ms": 883,
         "fast_mode_state": "off",
         "is_error": true,
         "modelUsage": {},
         "num_turns": 1,
         "permission_denials": [],
         "result": "There's an issue with the selected model (claude-3-5-haiku-20241022). It may not exist or you may not have access to it. Run --model to pick a different model.",
-        "session_id": "b4d0c5e6-fe8f-468d-834d-7aa9308fb670",
+        "session_id": "2f2fb67d-d508-4f58-9f48-551b133d70f8",
         "stop_reason": "stop_sequence",
         "subtype": "success",
         "terminal_reason": "completed",
@@ -297,9 +297,9 @@
           "service_tier": "standard",
           "speed": "standard"
         },
-        "uuid": "cf09ab01-6bb8-4682-bad3-568e35b897d7"
+        "uuid": "7f82d01b-549c-4ca8-a2e5-abf9a2484127"
       }
     }
   ],
-  "sdk_version": "0.1.60"
+  "sdk_version": "0.1.61"
 }

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_bundled_subagent_creates_task_span.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_bundled_subagent_creates_task_span.json
@@ -10,7 +10,7 @@
             "hooks": null,
             "subtype": "initialize"
           },
-          "request_id": "req_1_a58e72af",
+          "request_id": "req_1_9d990cf3",
           "type": "control_request"
         }
       }
@@ -19,7 +19,7 @@
       "op": "read",
       "payload": {
         "response": {
-          "request_id": "req_1_a58e72af",
+          "request_id": "req_1_9d990cf3",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
@@ -61,7 +61,7 @@
           "statusline-setup"
         ],
         "apiKeySource": "ANTHROPIC_API_KEY",
-        "claude_code_version": "2.1.111",
+        "claude_code_version": "2.1.112",
         "cwd": "<REDACTED_CWD>",
         "fast_mode_state": "off",
         "mcp_servers": [
@@ -83,7 +83,7 @@
             "source": "rust-analyzer-lsp@claude-plugins-official"
           }
         ],
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
         "skills": [
           "update-config",
           "debug",
@@ -201,7 +201,7 @@
           "mcp__linear-server__update_document"
         ],
         "type": "system",
-        "uuid": "197d70eb-40d8-4a71-8737-4da44c963460"
+        "uuid": "cb0f8a34-1eff-4a71-ab0d-611f2f651b54"
       }
     },
     {
@@ -211,12 +211,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The user is asking me to delegate this task to a general-purpose agent to inspect the current repository and reply with only the repository name. They explicitly state I should not answer directly without using the subagent.\n\nI need to use the Agent tool with subagent_type \"general-purpose\" to:\n1. Inspect the current repository\n2. Determine the repository name\n3. Report back with only the repository name\n\nLet me create an appropriate prompt for the general-purpose agent to do this task.",
+              "thinking": "The user is asking me to delegate a task to a general-purpose agent to inspect the current repository and reply with only the repository name. I should use the Agent tool with the general-purpose subagent type.\n\nLet me create an agent that will inspect the repository and tell me the repository name.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01QAwjeD9Piu9QGVaCVzh3yE",
+          "id": "msg_01V9wGYEBRwdorVdnc2S9zMf",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -226,20 +226,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 37579
+              "ephemeral_5m_input_tokens": 37691
             },
-            "cache_creation_input_tokens": 37579,
+            "cache_creation_input_tokens": 37691,
             "cache_read_input_tokens": 0,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 8,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
         "type": "assistant",
-        "uuid": "d13a5dbc-6829-4526-b2c0-7aef6fef0221"
+        "uuid": "8ca993c0-6814-4d42-a881-7bab954e9ed0"
       }
     },
     {
@@ -251,10 +251,10 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01Y4DoFs9XchCM46sY2vgLQB",
+              "id": "toolu_015CpBQLq1C2DjkN3pSjYmg7",
               "input": {
-                "description": "Inspect repository and identify its name",
-                "prompt": "Inspect the current repository by examining files like README.md, pyproject.toml, package.json, .git/config, or any other configuration files that would identify the repository name. Then reply with ONLY the repository name, nothing else.",
+                "description": "Inspect repository and report name",
+                "prompt": "Inspect the current repository to determine its name. Look at the directory structure, git configuration, package metadata, or any other relevant files to identify the repository name. Reply with ONLY the repository name, nothing else.",
                 "subagent_type": "general-purpose"
               },
               "name": "Agent",
@@ -262,7 +262,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01QAwjeD9Piu9QGVaCVzh3yE",
+          "id": "msg_01V9wGYEBRwdorVdnc2S9zMf",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -272,34 +272,34 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 37579
+              "ephemeral_5m_input_tokens": 37691
             },
-            "cache_creation_input_tokens": 37579,
+            "cache_creation_input_tokens": 37691,
             "cache_read_input_tokens": 0,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 8,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
         "type": "assistant",
-        "uuid": "1576f5f6-5e4b-49b3-a2c8-44fe99ba797c"
+        "uuid": "f1bf5129-c71c-4f09-a0f1-ee918698edde"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Inspect repository and identify its name",
-        "prompt": "Inspect the current repository by examining files like README.md, pyproject.toml, package.json, .git/config, or any other configuration files that would identify the repository name. Then reply with ONLY the repository name, nothing else.",
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
+        "description": "Inspect repository and report name",
+        "prompt": "Inspect the current repository to determine its name. Look at the directory structure, git configuration, package metadata, or any other relevant files to identify the repository name. Reply with ONLY the repository name, nothing else.",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
         "subtype": "task_started",
-        "task_id": "ab799669e465ba288",
+        "task_id": "ae78d4ad25a910a76",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01Y4DoFs9XchCM46sY2vgLQB",
+        "tool_use_id": "toolu_015CpBQLq1C2DjkN3pSjYmg7",
         "type": "system",
-        "uuid": "38b8bd4e-a99e-459a-b62f-6cf0ef6816b6"
+        "uuid": "593bf60c-297b-4f98-8532-48463021f5c7"
       }
     },
     {
@@ -308,35 +308,35 @@
         "message": {
           "content": [
             {
-              "text": "Inspect the current repository by examining files like README.md, pyproject.toml, package.json, .git/config, or any other configuration files that would identify the repository name. Then reply with ONLY the repository name, nothing else.",
+              "text": "Inspect the current repository to determine its name. Look at the directory structure, git configuration, package metadata, or any other relevant files to identify the repository name. Reply with ONLY the repository name, nothing else.",
               "type": "text"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01Y4DoFs9XchCM46sY2vgLQB",
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
-        "timestamp": "2026-04-16T16:48:53.922Z",
+        "parent_tool_use_id": "toolu_015CpBQLq1C2DjkN3pSjYmg7",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
+        "timestamp": "2026-04-17T16:17:42.496Z",
         "type": "user",
-        "uuid": "117df2f4-1d37-494d-bd17-1b87557ec010"
+        "uuid": "144d4816-2687-42fc-bd6f-1aea42926f5b"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Reading pyproject.toml",
+        "description": "Reading py/pyproject.toml",
         "last_tool_name": "Read",
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
         "subtype": "task_progress",
-        "task_id": "ab799669e465ba288",
-        "tool_use_id": "toolu_01Y4DoFs9XchCM46sY2vgLQB",
+        "task_id": "ae78d4ad25a910a76",
+        "tool_use_id": "toolu_015CpBQLq1C2DjkN3pSjYmg7",
         "type": "system",
         "usage": {
-          "duration_ms": 1827,
+          "duration_ms": 1814,
           "tool_uses": 1,
-          "total_tokens": 32210
+          "total_tokens": 32090
         },
-        "uuid": "9a231290-a03c-470a-9e57-a585133e47bd"
+        "uuid": "c1a99b96-3099-4e87-8f2a-fc908d3f96d7"
       }
     },
     {
@@ -348,7 +348,7 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01BQ5yemRfBgq6CiV4SuHtj2",
+              "id": "toolu_01LqMG3Ef6WYSJjLcM22UURE",
               "input": {
                 "file_path": "<REDACTED_PATH>",
                 "limit": 50
@@ -358,7 +358,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01VqSgvwBTxBBcbGFgNc5biR",
+          "id": "msg_01AshKPBC3qL7CJVeBJCnEG4",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -368,9 +368,9 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 32205
+              "ephemeral_5m_input_tokens": 32085
             },
-            "cache_creation_input_tokens": 32205,
+            "cache_creation_input_tokens": 32085,
             "cache_read_input_tokens": 0,
             "inference_geo": "not_available",
             "input_tokens": 3,
@@ -378,10 +378,10 @@
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01Y4DoFs9XchCM46sY2vgLQB",
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
+        "parent_tool_use_id": "toolu_015CpBQLq1C2DjkN3pSjYmg7",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
         "type": "assistant",
-        "uuid": "9204d543-f124-4d29-a51b-bd28076561d2"
+        "uuid": "e55a002f-0139-4221-a659-c8d4a26ed871"
       }
     },
     {
@@ -390,36 +390,36 @@
         "message": {
           "content": [
             {
-              "content": "1\t[tool.ruff]\n2\tline-length = 119\n3\tforce-exclude = true\n4\textend-exclude = [\n5\t    \"py/src/braintrust/_generated_types.py\",\n6\t    \"py/src/braintrust/generated_types.py\",\n7\t]\n8\t\n9\t[tool.ruff.lint]\n10\tselect = [\n11\t    \"I\",    # isort\n12\t    \"F401\", # unused imports\n13\t]\n14\t[tool.ruff.lint.isort]\n15\tknown-third-party = [\"braintrust\", \"braintrust_local\", \"autoevals\"]\n16\tlines-after-imports = 2\n17\tsplit-on-trailing-comma = true\n18\t\n19\t[tool.pytest.ini_options]\n20\tasyncio_mode = \"strict\"\n21\tasyncio_default_fixture_loop_scope = \"function\"\n22\taddopts = \"--durations=3 --durations-min=0.1\"\n23\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_01BQ5yemRfBgq6CiV4SuHtj2",
+              "content": "1\t[build-system]\n2\trequires = [\"setuptools>=82.0.1\"]\n3\tbuild-backend = \"setuptools.build_meta\"\n4\t\n5\t[project]\n6\tname = \"braintrust\"\n7\tdynamic = [\"version\"]\n8\tdescription = \"SDK for integrating Braintrust\"\n9\treadme = \"README.md\"\n10\tlicense = \"MIT\"\n11\trequires-python = \">=3.10.0\"\n12\tauthors = [\n13\t    { name = \"Braintrust\", email = \"sdk@braintrustdata.com\" },\n14\t]\n15\tclassifiers = [\n16\t    \"Programming Language :: Python :: 3\",\n17\t    \"Programming Language :: Python :: 3.10\",\n18\t    \"Operating System :: OS Independent\",\n19\t]\n20\tdependencies = [\n21\t    \"GitPython\",\n22\t    \"requests\",\n23\t    \"chevron\",\n24\t    \"tqdm\",\n25\t    \"exceptiongroup>=1.2.0\",\n26\t    \"jsonschema\",\n27\t    \"packaging\",\n28\t    \"sseclient-py\",\n29\t    \"python-slugify\",\n30\t    \"typing_extensions>=4.1.0\",\n31\t    \"wrapt\",\n32\t]\n33\t\n34\t[project.urls]\n35\tHomepage = \"https://www.braintrust.dev\"\n36\t\"Source Code\" = \"https://github.com/braintrustdata/braintrust-sdk-python\"\n37\t\"Bug Tracker\" = \"https://github.com/braintrustdata/braintrust-sdk-python/issues\"\n38\t\n39\t[project.scripts]\n40\tbraintrust = \"braintrust.cli.__main__:main\"\n41\t\n42\t[project.entry-points.pytest11]\n43\tbraintrust = \"braintrust.wrappers.pytest_plugin.plugin\"\n44\t\n45\t[project.optional-dependencies]\n46\tcli = [\"boto3\", \"python-dotenv\", \"uv\", \"starlette\", \"uvicorn\"]\n47\t# TODO: remove the doc extra in the next major version.\n48\tdoc = []\n49\topenai-agents = [\"openai-agents\"]\n50\totel = [\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
+              "tool_use_id": "toolu_01LqMG3Ef6WYSJjLcM22UURE",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01Y4DoFs9XchCM46sY2vgLQB",
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
-        "timestamp": "2026-04-16T16:48:55.756Z",
+        "parent_tool_use_id": "toolu_015CpBQLq1C2DjkN3pSjYmg7",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
+        "timestamp": "2026-04-17T16:17:44.313Z",
         "type": "user",
-        "uuid": "2b5aa7bc-7123-41f8-a4bc-36f6a140e76c"
+        "uuid": "1f94c0b0-b903-4e63-937f-3210074d7c62"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Reading .git/config",
-        "last_tool_name": "Read",
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
+        "description": "Running git config --get remote.origin.url",
+        "last_tool_name": "Bash",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
         "subtype": "task_progress",
-        "task_id": "ab799669e465ba288",
-        "tool_use_id": "toolu_01Y4DoFs9XchCM46sY2vgLQB",
+        "task_id": "ae78d4ad25a910a76",
+        "tool_use_id": "toolu_015CpBQLq1C2DjkN3pSjYmg7",
         "type": "system",
         "usage": {
-          "duration_ms": 2052,
+          "duration_ms": 2029,
           "tool_uses": 2,
-          "total_tokens": 32211
+          "total_tokens": 32091
         },
-        "uuid": "4b885e8f-d269-4682-b3d7-7f0b1b3fe35f"
+        "uuid": "1ab70f6e-b197-4272-9c19-bc16dd4c14a5"
       }
     },
     {
@@ -431,16 +431,16 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_015heiehE78dQ4xhSLU3RipF",
+              "id": "toolu_01Xy8xzLyeSTjNBoFWgzZf4b",
               "input": {
-                "file_path": "<REDACTED_PATH>"
+                "command": "git config --get remote.origin.url"
               },
-              "name": "Read",
+              "name": "Bash",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01VqSgvwBTxBBcbGFgNc5biR",
+          "id": "msg_01AshKPBC3qL7CJVeBJCnEG4",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -450,9 +450,9 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 32205
+              "ephemeral_5m_input_tokens": 32085
             },
-            "cache_creation_input_tokens": 32205,
+            "cache_creation_input_tokens": 32085,
             "cache_read_input_tokens": 0,
             "inference_geo": "not_available",
             "input_tokens": 3,
@@ -460,10 +460,10 @@
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01Y4DoFs9XchCM46sY2vgLQB",
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
+        "parent_tool_use_id": "toolu_015CpBQLq1C2DjkN3pSjYmg7",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
         "type": "assistant",
-        "uuid": "52e0a467-e22a-468f-86e5-c51b1b6aec09"
+        "uuid": "f462ca70-eaa8-46d9-a43e-d562e44c0ad0"
       }
     },
     {
@@ -472,37 +472,38 @@
         "message": {
           "content": [
             {
-              "content": "1\t[core]\n2\t\trepositoryformatversion = 0\n3\t\tfilemode = true\n4\t\tbare = false\n5\t\tlogallrefupdates = true\n6\t\tignorecase = true\n7\t\tprecomposeunicode = true\n8\t[remote \"origin\"]\n9\t\turl = git@github.com:braintrustdata/braintrust-sdk-python.git\n10\t\tfetch = +refs/heads/*:refs/remotes/origin/*\n11\t[branch \"abhi-remove-js\"]\n12\t\tvscode-merge-base = origin/main\n13\t[branch \"abhi-pydantic-ai-tool-calls\"]\n14\t\tvscode-merge-base = upstream/main\n15\t[branch \"abhi-0.5.6-test-release\"]\n16\t\tvscode-merge-base = upstream/main\n17\t[branch \"abhi-bump-0.6.0\"]\n18\t\tvscode-merge-base = upstream/main\n19\t[branch \"abhi-unbound-local-error-git-metadata\"]\n20\t\tvscode-merge-base = upstream/main\n21\t[branch \"abhi-release-script-correct-repo\"]\n22\t\tvscode-merge-base = origin/main\n23\t[branch \"abhi-release-script-changelog\"]\n24\t\tvscode-merge-base = origin/main\n25\t[branch \"abhi-move-adk-integration\"]\n26\t\tvscode-merge-base = origin/main\n27\t[branch \"abhi-repo-cleanup-rename\"]\n28\t\tvscode-merge-base = origin/main\n29\t[branch \"feat/eval-tags\"]\n30\t\tremote = git@github.com:Mahhheshh/braintrust-sdk-python.git\n31\t\tpushRemote = git@github.com:Mahhheshh/braintrust-sdk-python.git\n32\t\tmerge = refs/heads/feat/eval-tags\n33\t[branch \"abhi-evals-py-tags\"]\n34\t\tvscode-merge-base = origin/main\n35\t[branch \"abhi-bump-0.7.0\"]\n36\t\tvscode-merge-base = origin/main\n37\t[branch \"abhi-fix-repo-url\"]\n38\t\tvscode-merge-base = origin/main\n39\t[branch \"abhi-chmod-release-script\"]\n40\t\tvscode-merge-base = origin/main\n41\t[branch \"abhi-sub-exceptions-traceback\"]\n42\t\tvscode-merge-base = origin/main\n43\t[branch \"ci/label-gated-fork-pr-tests\"]\n44\t\tvscode-merge-base = origin/main\n45\t\tremote = origin\n46\t\tmerge = refs/heads/ci/label-gated-fork-pr-tests\n47\t[branch \"abhi-pytest-integration\"]\n48\t\tvscode-merge-base = origin/main\n49\t[branch \"abhi-sdk-builder-tags\"]\n50\t\tvscode-merge-base = origin/main\n51\t[branch \"clean-redundant-imports\"]\n52\t\tremote = origin\n53\t\tvscode-merge-base = origin/main\n54\t\tmerge = refs/heads/clean-redundant-imports\n55\t[branch \"abhi-improve-changelog\"]\n56\t\tvscode-merge-base = origin/main\n57\t[branch \"ibolmo/bra-3897--thread-safe-integrations-wrappers\"]\n58\t\tremote = origin\n59\t\tmerge = refs/heads/ibolmo/bra-3897--thread-safe-integrations-wrappers\n60\t\tvscode-merge-base = origin/ibolmo/bra-3897--thread-safe-integrations-wrappers\n61\t[branch \"abhi-no-api-keys-ci\"]\n62\t\tvscode-merge-base = origin/main\n63\t[branch \"main\"]\n64\t\tremote = origin\n65\t\tmerge = refs/heads/main\n66\t\tvscode-merge-base = origin/main\n67\t[branch \"abhi-argo-integration-improvements\"]\n68\t\tvscode-merge-base = origin/main\n69\t[branch \"phil/agno-workflow\"]\n70\t\tremote = origin\n71\t\tmerge = refs/heads/phil/agno-workflow\n72\t\tvscode-merge-base = origin/phil/agno-workflow\n73\t[branch \"codex/update-adk-workflow\"]\n74\t\tvscode-merge-base = origin/main\n75\t\tremote = origin\n76\t\tmerge = refs/heads/codex/update-adk-workflow\n77\t[branch \"abhi-python-3.14\"]\n78\t\tvscode-merge-base = origin/main\n79\t[branch \"abhi-sdk-0.8.0\"]\n80\t\tvscode-merge-base = origin/main\n81\t[branch \"abhi-cleanup-readmes\"]\n82\t\tvscode-merge-base = origin/main\n83\t[branch \"abhi-actually-add-performance-extra\"]\n84\t\tvscode-merge-base = origin/main\n85\t[branch \"abhi-use-mise-everywhere\"]\n86\t\tvscode-merge-base = origin/main\n87\t[branch \"abhi-test-increase-windows-shards\"]\n88\t\tvscode-merge-base = origin/main\n89\t[branch \"abhi-0.8.0-test-pypi\"]\n90\t\tvscode-merge-base = origin/main\n91\t[branch \"abhi-openai-with-raw-response\"]\n92\t\tvscode-merge-base = origin/main\n93\t[branch \"fix/31\"]\n94\t\tremote = git@github.com:Mahhheshh/braintrust-sdk-python.git\n95\t\tpushRemote = git@github.com:Mahhheshh/braintrust-sdk-python.git\n96\t\tmerge = refs/heads/fix/31\n97\t\tvscode-merge-base = origin/main\n98\t[branch \"abhi-fix-nox-file-flags\"]\n99\t\tvscode-merge-base = origin/main\n100\t[branch \"abhi-wrap-agent-to_cli_sync\"]\n101\t\tvscode-merge-base = origin/main\n102\t[branch \"abhi-cross-context-cleanup\"]\n103\t\tvscode-merge-base = origin/main\n104\t[branch \"abhi-use-python-3.14-locally\"]\n105\t\tvscode-merge-base = origin/main\n106\t[branch \"alex/handle-classifiers\"]\n107\t\tremote = origin\n108\t\tmerge = refs/heads/alex/handle-classifiers\n109\t[branch \"cedric/json-serialization-error-multi-turn-evaluation\"]\n110\t\tremote = origin\n111\t\tmerge = refs/heads/cedric/json-serialization-error-multi-turn-evaluation\n112\t\tvscode-merge-base = origin/cedric/json-serialization-error-multi-turn-evaluation\n113\t[branch \"abhi-claude-agent-sdk-improvements\"]\n114\t\tvscode-merge-base = origin/main\n115\t[branch \"abhi-better-claude-agent-sdk-spans\"]\n116\t\tvscode-merge-base = origin/main\n117\t[branch \"abhi-claude-agent-sdk-test-pypi\"]\n118\t\tvscode-merge-base = origin/main\n119\t[branch \"abhi-claude-agent-sdk\"]\n120\t\tvscode-merge-base = origin/main\n121\t[branch \"abhi-claude-agent-sdk-record-ci\"]\n122\t\tvscode-merge-base = origin/main\n123\t[branch \"abhi-pin-gha\"]\n124\t\tvscode-merge-base = origin/main\n125\t[branch \"abhi-release-via-gha-trigger\"]\n126\t\tvscode-merge-base = origin/main\n127\t[branch \"abhi-claude-agent-hooks\"]\n128\t\tvscode-merge-base = origin/main\n129\t[branch \"sandbox-registration\"]\n130\t\tremote = origin\n131\t\tmerge = refs/heads/sandbox-registration\n132\t\tvscode-merge-base = origin/sandbox-registration\n133\t[branch \"abhi-fix-parallel-sub-agents-claude-agent-sdk\"]\n134\t\tvscode-merge-base = origin/main\n135\t[branch \"abhi-canary-nightly\"]\n136\t\tvscode-merge-base = origin/main\n137\t[branch \"abhi-create-release-tag-locally-dry-run\"]\n138\t\tvscode-merge-base = origin/main\n139\t[branch \"abhi-metadata-types\"]\n140\t\tvscode-merge-base = origin/main\n141\t[branch \"fix/28\"]\n142\t\tremote = git@github.com:Mahhheshh/braintrust-sdk-python.git\n143\t\tpushRemote = git@github.com:Mahhheshh/braintrust-sdk-python.git\n144\t\tmerge = refs/heads/fix/28\n145\t\tvscode-merge-base = origin/main\n146\t[branch \"chore/regenerate-sdk-python-types\"]\n147\t\tremote = origin\n148\t\tmerge = refs/heads/chore/regenerate-sdk-python-types\n149\t\tvscode-merge-base = origin/chore/regenerate-sdk-python-types\n150\t[branch \"abhi-fix-agno-ci\"]\n151\t\tvscode-merge-base = origin/main\n152\t[branch \"py-sdk-saved-parameters\"]\n153\t\tremote = origin\n154\t\tmerge = refs/heads/py-sdk-saved-parameters\n155\t\tvscode-merge-base = origin/py-sdk-saved-parameters\n156\t[branch \"abhi-pydantic-warning-serialize\"]\n157\t\tvscode-merge-base = origin/main\n158\t[branch \"abhi-ref-claude-agent-sdk\"]\n159\t\tvscode-merge-base = origin/main\n160\t[branch \"abhi-sdk-0.10.0\"]\n161\t\tvscode-merge-base = origin/main\n162\t[branch \"abhi-fix-integration-pr-workflow\"]\n163\t\tvscode-merge-base = origin/main\n164\t[branch \"abhi-provider-gap-action\"]\n165\t\tvscode-merge-base = origin/main\n166\t[branch \"abhi-google-genai-embed-instrumentation\"]\n167\t\tvscode-merge-base = origin/main\n168\t[branch \"chore/label-bot-automation-issues\"]\n169\t\tvscode-merge-base = origin/main\n170\t[branch \"abhi-new-integrations-api\"]\n171\t\tvscode-merge-base = origin/main\n172\t[branch \"abhi-fix-openai-stream-context-manager-http2\"]\n173\t\tvscode-merge-base = origin/main\n174\t[branch \"abhi-fix-broken-lint\"]\n175\t\tvscode-merge-base = origin/main\n176\t[branch \"abhi-refactor-adk-to-integrations-api\"]\n177\t\tvscode-merge-base = origin/main\n178\t[branch \"abhi-test-anthropic-cleanup-vcr-mocks\"]\n179\t\tvscode-merge-base = origin/main\n180\t[branch \"abhi-pin-optional-deps\"]\n181\t\tvscode-merge-base = origin/main\n182\t[branch \"abhi-validate-auto-instrument-adk\"]\n183\t\tvscode-merge-base = origin/main\n184\t[branch \"abhi-adk-nested-subagent-tools\"]\n185\t\tvscode-merge-base = origin/main\n186\t[branch \"abhi-agno-migrate\"]\n187\t\tvscode-merge-base = origin/main\n188\t[branch \"abhi-re-org-ci\"]\n189\t\tvscode-merge-base = origin/main\n190\t[branch \"abhi-benchmarks\"]\n191\t\tvscode-merge-base = origin/main\n192\t[branch \"abhi-delete-adk-golden-test\"]\n193\t\tvscode-merge-base = origin/main\n194\t[branch \"abhi-claude-agent-sdk-migrate\"]\n195\t\tvscode-merge-base = origin/main\n196\t[branch \"claude-agent-sdk-hooks\"]\n197\t\tvscode-merge-base = origin/main\n198\t[branch \"abhi-hard-pin-dev-deps\"]\n199\t\tvscode-merge-base = origin/main\n200\t[branch \"abhi-perf-optimize-bt-json-hot-paths\"]\n201\t\tvscode-merge-base = origin/main\n202\t[branch \"abhi-claude-agent-sdk-hooks\"]\n203\t\tvscode-merge-base = origin/main\n204\t[branch \"abhi-ref-google-genai\"]\n205\t\tvscode-merge-base = origin/main\n206\t[branch \"abhi-google-genai-multimodal\"]\n207\t\tvscode-merge-base = origin/main\n208\t[branch \"abhi-agentscope-integration\"]\n209\t\tvscode-merge-base = origin/main\n210\t[branch \"abhi-agentscope-eval-integration\"]\n211\t\tvscode-merge-base = origin/main\n212\t[branch \"abhi-openrouter-integration\"]\n213\t\tvscode-merge-base = origin/main\n214\t[branch \"auto-instrument-bttraceprocessor\"]\n215\t\tremote = git@github.com:Mahhheshh/braintrust-sdk-python.git\n216\t\tpushRemote = git@github.com:Mahhheshh/braintrust-sdk-python.git\n217\t\tmerge = refs/heads/auto-instrument-bttraceprocessor\n218\t[branch \"abhi-feat-google-genai-generate-images-tracing\"]\n219\t\tvscode-merge-base = origin/main\n220\t[branch \"josh/rehydrate-remote-prompt-parameters\"]\n221\t\tremote = origin\n222\t\tmerge = refs/heads/josh/rehydrate-remote-prompt-parameters\n223\t[branch \"fix/172\"]\n224\t\tremote = git@github.com:Mahhheshh/braintrust-sdk-python.git\n225\t\tpushRemote = git@github.com:Mahhheshh/braintrust-sdk-python.git\n226\t\tmerge = refs/heads/fix/172\n227\t[branch \"abhi-refactor-migrate-pydantic-ai-integration\"]\n228\t\tvscode-merge-base = origin/main\n229\t[branch \"cedric/migrate-langchain-into-braintrust-pkg-without-auto-instrumentation\"]\n230\t\tremote = origin\n231\t\tmerge = refs/heads/cedric/migrate-langchain-into-braintrust-pkg-without-auto-instrumentation\n232\t\tvscode-merge-base = origin/cedric/migrate-langchain-into-braintrust-pkg-without-auto-instrumentation\n233\t[branch \"abhi-feat-litellm-integrations-api-migration\"]\n234\t\tvscode-merge-base = origin/main\n235\t[branch \"abhi-fix-176-dspy-adapter-callbacks\"]\n236\t\tvscode-merge-base = origin/main\n237\t[branch \"abhi-deprecate-old-langchain-package\"]\n238\t\tvscode-merge-base = origin/main\n239\t[branch \"abhi-refactor-migrate-openai-wrapper-to-integrations\"]\n240\t\tvscode-merge-base = origin/main\n241\t[branch \"abhi-fix-149-thinking-block-type\"]\n242\t\tvscode-merge-base = origin/main\n243\t[branch \"abhi-set-min-deps-nox\"]\n244\t\tvscode-merge-base = origin/main\n245\t[branch \"abhi-fix-pydantic-ai-toolmanager-move\"]\n246\t\tvscode-merge-base = origin/main\n247\t[branch \"abhi-feat-198-google-genai-interactions\"]\n248\t\tremote = origin\n249\t\tmerge = refs/heads/abhi-feat-198-google-genai-interactions\n250\t[branch \"abhi-ref-integration-utils\"]\n251\t\tvscode-merge-base = origin/main\n252\t[branch \"migrate-langchain-golden-tests\"]\n253\t\tremote = origin\n254\t\tmerge = refs/heads/migrate-langchain-golden-tests\n255\t\tvscode-merge-base = origin/migrate-langchain-golden-tests\n256\t[branch \"feat/responses-retrieve-cancel-instrumentation\"]\n257\t\tremote = origin\n258\t\tmerge = refs/heads/feat/responses-retrieve-cancel-instrumentation\n259\t[branch \"feat/audio-api-instrumentation\"]\n260\t\tremote = origin\n261\t\tmerge = refs/heads/feat/audio-api-instrumentation\n262\t[branch \"bt-4702-text-stream-ttft\"]\n263\t\tremote = origin\n264\t\tmerge = refs/heads/bt-4702-text-stream-ttft\n265\t[branch \"abhi-feat-add-openai-images-tracing\"]\n266\t\tvscode-merge-base = origin/main\n267\t[branch \"abhi-refactor-integration-attachment-utils\"]\n268\t\tvscode-merge-base = origin/main\n269\t\tremote = origin\n270\t\tmerge = refs/heads/abhi-refactor-integration-attachment-utils\n271\t[branch \"abhi-0.14.0-version-bump\"]\n272\t\tvscode-merge-base = origin/main\n273\t[branch \"abhi-fix-adk-sync-runner-spans\"]\n274\t\tvscode-merge-base = origin/main\n275\t[branch \"abhi-ci-extract-static-checks\"]\n276\t\tvscode-merge-base = origin/main\n277\t[branch \"abhi-feat-222-trace-mistral-ocr\"]\n278\t\tremote = origin\n279\t\tmerge = refs/heads/abhi-feat-222-trace-mistral-ocr\n280\t[branch \"curtis/cached_span_fetcher_fix\"]\n281\t\tremote = origin\n282\t\tmerge = refs/heads/curtis/cached_span_fetcher_fix\n283\t[branch \"auto/update-session-weights\"]\n284\t\tremote = origin\n285\t\tmerge = refs/heads/auto/update-session-weights\n286\t[branch \"ci/speed-up-python-env-setup\"]\n287\t\tvscode-merge-base = origin/main\n288\t[branch \"abhi-test-replace-pytest-forked-with-subprocess\"]\n289\t\tvscode-merge-base = origin/main\n290\t[branch \"abhi-refactor-migrate-wrappers-cassettes-and-test-utils\"]\n291\t\tvscode-merge-base = origin/main\n292\t[branch \"abhi-feat-per-version-vcr-cassettes\"]\n293\t\tvscode-merge-base = origin/main\n294\t[branch \"chore/noxfile-dep-pinning\"]\n295\t\tvscode-merge-base = origin/main\n296\t[branch \"abhi-bump-dep-update\"]\n297\t\tvscode-merge-base = origin/main\n298\t[branch \"deps/daily-update-2026-04-16\"]\n299\t\tremote = origin\n300\t\tmerge = refs/heads/deps/daily-update-2026-04-16\n301\t\tvscode-merge-base = origin/deps/daily-update-2026-04-16\n302\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_015heiehE78dQ4xhSLU3RipF",
+              "content": "git@github.com:braintrustdata/braintrust-sdk-python.git",
+              "is_error": false,
+              "tool_use_id": "toolu_01Xy8xzLyeSTjNBoFWgzZf4b",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01Y4DoFs9XchCM46sY2vgLQB",
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
-        "timestamp": "2026-04-16T16:48:55.977Z",
+        "parent_tool_use_id": "toolu_015CpBQLq1C2DjkN3pSjYmg7",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
+        "timestamp": "2026-04-17T16:17:44.772Z",
         "type": "user",
-        "uuid": "3f013a99-0762-441a-9865-268bd57149b6"
+        "uuid": "71fe533a-67ac-44f5-8794-157b5a37a87b"
       }
     },
     {
       "op": "read",
       "payload": {
         "output_file": "",
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
         "status": "completed",
         "subtype": "task_notification",
-        "summary": "Inspect repository and identify its name",
-        "task_id": "ab799669e465ba288",
-        "tool_use_id": "toolu_01Y4DoFs9XchCM46sY2vgLQB",
+        "summary": "Inspect repository and report name",
+        "task_id": "ae78d4ad25a910a76",
+        "tool_use_id": "toolu_015CpBQLq1C2DjkN3pSjYmg7",
         "type": "system",
         "usage": {
-          "duration_ms": 3254,
+          "duration_ms": 3099,
           "tool_uses": 2,
-          "total_tokens": 38825
+          "total_tokens": 34359
         },
-        "uuid": "29d5766c-646e-4290-b588-f2cb0d291b8b"
+        "uuid": "4bfb9b4a-fd8e-41d1-8f67-accd9727ff17"
       }
     },
     {
@@ -517,21 +518,21 @@
                   "type": "text"
                 },
                 {
-                  "text": "agentId: ab799669e465ba288 (use SendMessage with to: 'ab799669e465ba288' to continue this agent)\n<usage>total_tokens: 38831\ntool_uses: 2\nduration_ms: 3256</usage>",
+                  "text": "agentId: ae78d4ad25a910a76 (use SendMessage with to: 'ae78d4ad25a910a76' to continue this agent)\n<usage>total_tokens: 34365\ntool_uses: 2\nduration_ms: 3099</usage>",
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01Y4DoFs9XchCM46sY2vgLQB",
+              "tool_use_id": "toolu_015CpBQLq1C2DjkN3pSjYmg7",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
-        "timestamp": "2026-04-16T16:48:57.178Z",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
+        "timestamp": "2026-04-17T16:17:45.595Z",
         "tool_use_result": {
-          "agentId": "ab799669e465ba288",
+          "agentId": "ae78d4ad25a910a76",
           "agentType": "general-purpose",
           "content": [
             {
@@ -539,42 +540,30 @@
               "type": "text"
             }
           ],
-          "prompt": "Inspect the current repository by examining files like README.md, pyproject.toml, package.json, .git/config, or any other configuration files that would identify the repository name. Then reply with ONLY the repository name, nothing else.",
+          "prompt": "Inspect the current repository to determine its name. Look at the directory structure, git configuration, package metadata, or any other relevant files to identify the repository name. Reply with ONLY the repository name, nothing else.",
           "status": "completed",
           "toolStats": {
-            "bashCount": 0,
+            "bashCount": 1,
             "editFileCount": 0,
             "linesAdded": 0,
             "linesRemoved": 0,
             "otherToolCount": 0,
-            "readCount": 2,
+            "readCount": 1,
             "searchCount": 0
           },
-          "totalDurationMs": 3256,
-          "totalTokens": 38831,
+          "totalDurationMs": 3099,
+          "totalTokens": 34365,
           "totalToolUseCount": 2,
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 6609
+              "ephemeral_5m_input_tokens": 2263
             },
-            "cache_creation_input_tokens": 6609,
-            "cache_read_input_tokens": 32205,
+            "cache_creation_input_tokens": 2263,
+            "cache_read_input_tokens": 32085,
             "inference_geo": "",
             "input_tokens": 7,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 6609
-                },
-                "cache_creation_input_tokens": 6609,
-                "cache_read_input_tokens": 32205,
-                "input_tokens": 7,
-                "output_tokens": 10,
-                "type": "message"
-              }
-            ],
+            "iterations": [],
             "output_tokens": 10,
             "server_tool_use": {
               "web_fetch_requests": 0,
@@ -585,7 +574,7 @@
           }
         },
         "type": "user",
-        "uuid": "3452c768-1ad3-4602-875f-e96a0d0e3747"
+        "uuid": "29dc0ba1-d4dd-418e-8c24-9dc6b1a517e3"
       }
     },
     {
@@ -595,12 +584,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The agent has returned \"braintrust-sdk-python\" as the repository name. This matches what I can see from the CLAUDE.md context in the system reminder which indicates this is a Python SDK for Braintrust, and the file path `<REDACTED_PATH> also confirms this.\n\nThe agent did what was asked - it inspected the repository and returned only the repository name.",
+              "thinking": "The agent has returned the repository name: `braintrust-sdk-python`\n\nThe user asked me to have the agent reply with only the repository name and to not answer directly without using the subagent. The agent has done that, so I should just pass along the result.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01Dzvc5EXubRCk3VAYJ9L44P",
+          "id": "msg_014gWMrEwYMN32Bf9V4pMKMX",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -610,10 +599,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 354
+              "ephemeral_5m_input_tokens": 305
             },
-            "cache_creation_input_tokens": 354,
-            "cache_read_input_tokens": 37579,
+            "cache_creation_input_tokens": 305,
+            "cache_read_input_tokens": 37691,
             "inference_geo": "not_available",
             "input_tokens": 8,
             "output_tokens": 1,
@@ -621,9 +610,9 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
         "type": "assistant",
-        "uuid": "7ebc76cf-01f1-4265-9611-51daec519cf5"
+        "uuid": "b50f943c-9033-4131-8d47-45846d1cd9f2"
       }
     },
     {
@@ -637,7 +626,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01Dzvc5EXubRCk3VAYJ9L44P",
+          "id": "msg_014gWMrEwYMN32Bf9V4pMKMX",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -647,10 +636,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 354
+              "ephemeral_5m_input_tokens": 305
             },
-            "cache_creation_input_tokens": 354,
-            "cache_read_input_tokens": 37579,
+            "cache_creation_input_tokens": 305,
+            "cache_read_input_tokens": 37691,
             "inference_geo": "not_available",
             "input_tokens": 8,
             "output_tokens": 1,
@@ -658,63 +647,51 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
         "type": "assistant",
-        "uuid": "95a8be15-d1f1-40b8-9dc4-5f9d74867659"
+        "uuid": "9f965402-708e-48ea-904c-b77bce2dd584"
       }
     },
     {
       "op": "read",
       "payload": {
         "api_error_status": null,
-        "duration_api_ms": 10100,
-        "duration_ms": 8505,
+        "duration_api_ms": 7974,
+        "duration_ms": 7109,
         "fast_mode_state": "off",
         "is_error": false,
         "modelUsage": {
           "claude-haiku-4-5-20251001": {
-            "cacheCreationInputTokens": 76747,
-            "cacheReadInputTokens": 69784,
+            "cacheCreationInputTokens": 72344,
+            "cacheReadInputTokens": 69776,
             "contextWindow": 200000,
-            "costUSD": 0.10617815,
+            "costUSD": 0.1002186,
             "inputTokens": 406,
             "maxOutputTokens": 32000,
-            "outputTokens": 572,
+            "outputTokens": 481,
             "webSearchRequests": 0
           }
         },
         "num_turns": 2,
         "permission_denials": [],
         "result": "braintrust-sdk-python",
-        "session_id": "1918114c-c1d5-4f90-ad87-7c3312ccb889",
+        "session_id": "2ef1d545-f6ea-4427-b093-4afcf2a91ddb",
         "stop_reason": "end_turn",
         "subtype": "success",
         "terminal_reason": "completed",
-        "total_cost_usd": 0.10617815,
+        "total_cost_usd": 0.1002186,
         "type": "result",
         "usage": {
           "cache_creation": {
             "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 37933
+            "ephemeral_5m_input_tokens": 37996
           },
-          "cache_creation_input_tokens": 37933,
-          "cache_read_input_tokens": 37579,
+          "cache_creation_input_tokens": 37996,
+          "cache_read_input_tokens": 37691,
           "inference_geo": "",
           "input_tokens": 18,
-          "iterations": [
-            {
-              "cache_creation": {
-                "ephemeral_1h_input_tokens": 0,
-                "ephemeral_5m_input_tokens": 354
-              },
-              "cache_creation_input_tokens": 354,
-              "cache_read_input_tokens": 37579,
-              "input_tokens": 8,
-              "output_tokens": 119,
-              "type": "message"
-            }
-          ],
-          "output_tokens": 382,
+          "iterations": [],
+          "output_tokens": 285,
           "server_tool_use": {
             "web_fetch_requests": 0,
             "web_search_requests": 0
@@ -722,9 +699,9 @@
           "service_tier": "standard",
           "speed": "standard"
         },
-        "uuid": "a125dcf0-d150-4c58-a39b-fadbd5d80ab4"
+        "uuid": "39022cdf-72d1-4c71-b614-b94b1979d2b4"
       }
     }
   ],
-  "sdk_version": "0.1.60"
+  "sdk_version": "0.1.61"
 }

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_calculator_with_multiple_operations.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_calculator_with_multiple_operations.json
@@ -10,7 +10,7 @@
             "hooks": null,
             "subtype": "initialize"
           },
-          "request_id": "req_1_6febc072",
+          "request_id": "req_1_9ad732c2",
           "type": "control_request"
         }
       }
@@ -29,7 +29,7 @@
                 "description": "Anthropic's agentic coding tool",
                 "name": "claude-code",
                 "title": "Claude Code",
-                "version": "2.1.111",
+                "version": "2.1.112",
                 "websiteUrl": "https://claude.com/claude-code"
               },
               "protocolVersion": "2025-11-25"
@@ -38,7 +38,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "3b210dfc-299b-452a-86c1-2d8c79a3404c",
+        "request_id": "8338d555-2dc1-4f67-a38d-b66ddb9d420f",
         "type": "control_request"
       }
     },
@@ -48,7 +48,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "3b210dfc-299b-452a-86c1-2d8c79a3404c",
+            "request_id": "8338d555-2dc1-4f67-a38d-b66ddb9d420f",
             "response": {
               "mcp_response": {
                 "id": 0,
@@ -75,7 +75,7 @@
       "op": "read",
       "payload": {
         "response": {
-          "request_id": "req_1_6febc072",
+          "request_id": "req_1_9ad732c2",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
@@ -90,6 +90,21 @@
           "subtype": "success"
         },
         "type": "control_response"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "request": {
+          "message": {
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "38146cb0-a9ba-4869-b2f5-e29ff3364e37",
+        "type": "control_request"
       }
     },
     {
@@ -108,27 +123,12 @@
       }
     },
     {
-      "op": "read",
-      "payload": {
-        "request": {
-          "message": {
-            "jsonrpc": "2.0",
-            "method": "notifications/initialized"
-          },
-          "server_name": "calculator",
-          "subtype": "mcp_message"
-        },
-        "request_id": "900275fa-8944-426c-9cc0-d1299e35732b",
-        "type": "control_request"
-      }
-    },
-    {
       "op": "write",
       "payload": {
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "900275fa-8944-426c-9cc0-d1299e35732b",
+            "request_id": "38146cb0-a9ba-4869-b2f5-e29ff3364e37",
             "response": {
               "mcp_response": {
                 "jsonrpc": "2.0",
@@ -155,7 +155,7 @@
                 "description": "Anthropic's agentic coding tool",
                 "name": "claude-code",
                 "title": "Claude Code",
-                "version": "2.1.111",
+                "version": "2.1.112",
                 "websiteUrl": "https://claude.com/claude-code"
               },
               "protocolVersion": "2025-11-25"
@@ -164,7 +164,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "ae7d87a5-d593-4489-b90f-f124044e3bf1",
+        "request_id": "a4fa6fab-50f6-4db1-b906-c99c1a7e958a",
         "type": "control_request"
       }
     },
@@ -174,7 +174,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "ae7d87a5-d593-4489-b90f-f124044e3bf1",
+            "request_id": "a4fa6fab-50f6-4db1-b906-c99c1a7e958a",
             "response": {
               "mcp_response": {
                 "id": 0,
@@ -202,40 +202,6 @@
       "payload": {
         "request": {
           "message": {
-            "jsonrpc": "2.0",
-            "method": "notifications/initialized"
-          },
-          "server_name": "calculator",
-          "subtype": "mcp_message"
-        },
-        "request_id": "60d455e9-db88-43ca-9a21-eee49ef66e39",
-        "type": "control_request"
-      }
-    },
-    {
-      "op": "write",
-      "payload": {
-        "kind": "json",
-        "value": {
-          "response": {
-            "request_id": "60d455e9-db88-43ca-9a21-eee49ef66e39",
-            "response": {
-              "mcp_response": {
-                "jsonrpc": "2.0",
-                "result": {}
-              }
-            },
-            "subtype": "success"
-          },
-          "type": "control_response"
-        }
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "request": {
-          "message": {
             "id": 1,
             "jsonrpc": "2.0",
             "method": "tools/list"
@@ -243,7 +209,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "3e5453bb-1450-4810-a70c-71a623df401b",
+        "request_id": "a787f677-b542-4e54-b91e-65b16625aac7",
         "type": "control_request"
       }
     },
@@ -253,7 +219,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "3e5453bb-1450-4810-a70c-71a623df401b",
+            "request_id": "a787f677-b542-4e54-b91e-65b16625aac7",
             "response": {
               "mcp_response": {
                 "id": 1,
@@ -305,6 +271,40 @@
     {
       "op": "read",
       "payload": {
+        "request": {
+          "message": {
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+          },
+          "server_name": "calculator",
+          "subtype": "mcp_message"
+        },
+        "request_id": "7e5da956-6452-4565-a1cc-d1c0651c7e8e",
+        "type": "control_request"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "response": {
+            "request_id": "7e5da956-6452-4565-a1cc-d1c0651c7e8e",
+            "response": {
+              "mcp_response": {
+                "jsonrpc": "2.0",
+                "result": {}
+              }
+            },
+            "subtype": "success"
+          },
+          "type": "control_response"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
         "agents": [
           "Explore",
           "general-purpose",
@@ -312,7 +312,7 @@
           "statusline-setup"
         ],
         "apiKeySource": "ANTHROPIC_API_KEY",
-        "claude_code_version": "2.1.111",
+        "claude_code_version": "2.1.112",
         "cwd": "<REDACTED_CWD>",
         "fast_mode_state": "off",
         "mcp_servers": [
@@ -342,7 +342,7 @@
             "source": "rust-analyzer-lsp@claude-plugins-official"
           }
         ],
-        "session_id": "c6d57ba9-36c9-4ba8-9d21-4d192a51d90c",
+        "session_id": "4cb634d4-1dfd-4e4e-80a3-c5318dca8932",
         "skills": [
           "update-config",
           "debug",
@@ -470,7 +470,7 @@
           "mcp__linear-server__update_document"
         ],
         "type": "system",
-        "uuid": "b4f72777-4a71-464e-a585-755a4da34f6c"
+        "uuid": "00d68539-4c6e-48d7-bde9-4337ecf0c353"
       }
     },
     {
@@ -480,12 +480,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The user is asking me to:\n1. Calculate 15 multiplied by 7\n2. Subtract 5 from the result\n\nI can use the calculator tool to do this. Let me do the multiplication first (15 * 7), then subtract 5 from the result.\n\nActually, I could do this in two steps:\n1. First call: 15 * 7 = 105\n2. Second call: 105 - 5 = 100\n\nOr I could just do the math myself since it's simple, but the user has provided me with a calculator tool, so I should use it. Let me use the calculator tool.",
+              "thinking": "The user is asking me to:\n1. Calculate 15 \u00d7 7\n2. Then subtract 5 from the result\n\nI can use the calculator tool to do this. Let me break it down:\n1. First, 15 \u00d7 7 = 105\n2. Then 105 - 5 = 100\n\nI'll use the calculator tool to perform these operations.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01HbvamgsWGinhuzA9bD2urB",
+          "id": "msg_01WAKZ3rwJJUhNo2RgwBZ8Cn",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -495,9 +495,9 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 41495
+              "ephemeral_5m_input_tokens": 41607
             },
-            "cache_creation_input_tokens": 41495,
+            "cache_creation_input_tokens": 41607,
             "cache_read_input_tokens": 0,
             "inference_geo": "not_available",
             "input_tokens": 10,
@@ -506,46 +506,9 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "c6d57ba9-36c9-4ba8-9d21-4d192a51d90c",
+        "session_id": "4cb634d4-1dfd-4e4e-80a3-c5318dca8932",
         "type": "assistant",
-        "uuid": "1544026d-3b22-4443-bf30-85ed4af3b27c"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "text": "I'll calculate that for you using the calculator.",
-              "type": "text"
-            }
-          ],
-          "context_management": null,
-          "id": "msg_01HbvamgsWGinhuzA9bD2urB",
-          "model": "claude-haiku-4-5-20251001",
-          "role": "assistant",
-          "stop_details": null,
-          "stop_reason": null,
-          "stop_sequence": null,
-          "type": "message",
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 41495
-            },
-            "cache_creation_input_tokens": 41495,
-            "cache_read_input_tokens": 0,
-            "inference_geo": "not_available",
-            "input_tokens": 10,
-            "output_tokens": 7,
-            "service_tier": "standard"
-          }
-        },
-        "parent_tool_use_id": null,
-        "session_id": "c6d57ba9-36c9-4ba8-9d21-4d192a51d90c",
-        "type": "assistant",
-        "uuid": "d68bd9ef-b4ab-4921-9899-0c59ebcbdabd"
+        "uuid": "16c85e70-3d48-44d6-a589-8e45d7f05ce1"
       }
     },
     {
@@ -557,7 +520,7 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01M2iNYdx2WB1Dbj1T3wtJQd",
+              "id": "toolu_01NthQ3WD27NUNrKoy92UePu",
               "input": {
                 "a": 15,
                 "b": 7,
@@ -568,7 +531,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01HbvamgsWGinhuzA9bD2urB",
+          "id": "msg_01WAKZ3rwJJUhNo2RgwBZ8Cn",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -578,9 +541,9 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 41495
+              "ephemeral_5m_input_tokens": 41607
             },
-            "cache_creation_input_tokens": 41495,
+            "cache_creation_input_tokens": 41607,
             "cache_read_input_tokens": 0,
             "inference_geo": "not_available",
             "input_tokens": 10,
@@ -589,9 +552,9 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "c6d57ba9-36c9-4ba8-9d21-4d192a51d90c",
+        "session_id": "4cb634d4-1dfd-4e4e-80a3-c5318dca8932",
         "type": "assistant",
-        "uuid": "acf8978d-6833-40c5-a184-f893b823e91d"
+        "uuid": "0f1fffe9-cb8a-418a-b23f-3ad5be4d5e72"
       }
     },
     {
@@ -604,7 +567,7 @@
             "method": "tools/call",
             "params": {
               "_meta": {
-                "claudecode/toolUseId": "toolu_01M2iNYdx2WB1Dbj1T3wtJQd",
+                "claudecode/toolUseId": "toolu_01NthQ3WD27NUNrKoy92UePu",
                 "progressToken": 2
               },
               "arguments": {
@@ -618,7 +581,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "16b2fff9-ad3f-4b93-91f6-448b4083d1f3",
+        "request_id": "e0191585-82a7-4f1f-9220-776ad6b3a918",
         "type": "control_request"
       }
     },
@@ -628,7 +591,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "16b2fff9-ad3f-4b93-91f6-448b4083d1f3",
+            "request_id": "e0191585-82a7-4f1f-9220-776ad6b3a918",
             "response": {
               "mcp_response": {
                 "id": 2,
@@ -661,15 +624,15 @@
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01M2iNYdx2WB1Dbj1T3wtJQd",
+              "tool_use_id": "toolu_01NthQ3WD27NUNrKoy92UePu",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "c6d57ba9-36c9-4ba8-9d21-4d192a51d90c",
-        "timestamp": "2026-04-16T16:47:04.190Z",
+        "session_id": "4cb634d4-1dfd-4e4e-80a3-c5318dca8932",
+        "timestamp": "2026-04-17T16:15:00.857Z",
         "tool_use_result": [
           {
             "text": "The result of multiply(15, 7) is 105",
@@ -677,7 +640,45 @@
           }
         ],
         "type": "user",
-        "uuid": "f4980ee5-1976-4e07-83d3-fa399b56f522"
+        "uuid": "ff4e0a0a-5360-4424-8e4e-2b3802d2837c"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "Great, 15 \u00d7 7 = 105. Now I need to subtract 5 from that result.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01HqNtumzNBtn8M6kJKLY7fB",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 217
+            },
+            "cache_creation_input_tokens": 217,
+            "cache_read_input_tokens": 41607,
+            "inference_geo": "not_available",
+            "input_tokens": 8,
+            "output_tokens": 1,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "4cb634d4-1dfd-4e4e-80a3-c5318dca8932",
+        "type": "assistant",
+        "uuid": "f2fe2d62-b212-4129-b6a9-c528517cc4f2"
       }
     },
     {
@@ -689,7 +690,7 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01UsMUsTuMZcwB5r6FNQx6md",
+              "id": "toolu_01AWL8CQDc8u9Hxou4Gexbi2",
               "input": {
                 "a": 105,
                 "b": 5,
@@ -700,7 +701,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01HbvamgsWGinhuzA9bD2urB",
+          "id": "msg_01HqNtumzNBtn8M6kJKLY7fB",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -710,20 +711,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 41495
+              "ephemeral_5m_input_tokens": 217
             },
-            "cache_creation_input_tokens": 41495,
-            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 217,
+            "cache_read_input_tokens": 41607,
             "inference_geo": "not_available",
-            "input_tokens": 10,
-            "output_tokens": 7,
+            "input_tokens": 8,
+            "output_tokens": 1,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "c6d57ba9-36c9-4ba8-9d21-4d192a51d90c",
+        "session_id": "4cb634d4-1dfd-4e4e-80a3-c5318dca8932",
         "type": "assistant",
-        "uuid": "dda8ee18-8a10-44d9-9f7e-153091b51d98"
+        "uuid": "2ac3bd96-a2ad-4ae8-aa71-80ae293eeb1d"
       }
     },
     {
@@ -736,7 +737,7 @@
             "method": "tools/call",
             "params": {
               "_meta": {
-                "claudecode/toolUseId": "toolu_01UsMUsTuMZcwB5r6FNQx6md",
+                "claudecode/toolUseId": "toolu_01AWL8CQDc8u9Hxou4Gexbi2",
                 "progressToken": 3
               },
               "arguments": {
@@ -750,7 +751,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "0e60a808-64a2-43c9-bded-3d0878c461dd",
+        "request_id": "a18ee913-3630-470a-a574-1ae2e65d09f3",
         "type": "control_request"
       }
     },
@@ -760,7 +761,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "0e60a808-64a2-43c9-bded-3d0878c461dd",
+            "request_id": "a18ee913-3630-470a-a574-1ae2e65d09f3",
             "response": {
               "mcp_response": {
                 "id": 3,
@@ -793,15 +794,15 @@
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01UsMUsTuMZcwB5r6FNQx6md",
+              "tool_use_id": "toolu_01AWL8CQDc8u9Hxou4Gexbi2",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "c6d57ba9-36c9-4ba8-9d21-4d192a51d90c",
-        "timestamp": "2026-04-16T16:47:04.245Z",
+        "session_id": "4cb634d4-1dfd-4e4e-80a3-c5318dca8932",
+        "timestamp": "2026-04-17T16:15:02.265Z",
         "tool_use_result": [
           {
             "text": "The result of subtract(105, 5) is 100",
@@ -809,7 +810,7 @@
           }
         ],
         "type": "user",
-        "uuid": "bcb691ac-fa75-484e-9c3d-f90a4f4ad8dc"
+        "uuid": "97050552-632b-4e8c-9750-9d27c6a44830"
       }
     },
     {
@@ -819,12 +820,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "Perfect! The calculations are done:\n- 15 \u00d7 7 = 105\n- 105 - 5 = 100\n\nThe answer is 100.",
+              "thinking": "Perfect! The calculations are:\n1. 15 \u00d7 7 = 105\n2. 105 - 5 = 100\n\nSo the final answer is 100.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01SoS62WtkZwZ4LWyiHica4T",
+          "id": "msg_01DevJ18r2eUuKLCvmRPgBzs",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -834,20 +835,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 429
+              "ephemeral_5m_input_tokens": 155
             },
-            "cache_creation_input_tokens": 429,
-            "cache_read_input_tokens": 41495,
+            "cache_creation_input_tokens": 155,
+            "cache_read_input_tokens": 41824,
             "inference_geo": "not_available",
             "input_tokens": 8,
-            "output_tokens": 3,
+            "output_tokens": 4,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "c6d57ba9-36c9-4ba8-9d21-4d192a51d90c",
+        "session_id": "4cb634d4-1dfd-4e4e-80a3-c5318dca8932",
         "type": "assistant",
-        "uuid": "94aedf9b-104e-4349-b73a-a6595be6e8a3"
+        "uuid": "4c396159-84eb-417a-af22-35c82445f7d5"
       }
     },
     {
@@ -856,12 +857,12 @@
         "message": {
           "content": [
             {
-              "text": "**The answer is 100.**\n\nHere's the breakdown:\n- 15 \u00d7 7 = 105\n- 105 - 5 = **100**",
+              "text": "The answer is **100**.\n\nHere's the breakdown:\n1. 15 \u00d7 7 = 105\n2. 105 \u2212 5 = 100",
               "type": "text"
             }
           ],
           "context_management": null,
-          "id": "msg_01SoS62WtkZwZ4LWyiHica4T",
+          "id": "msg_01DevJ18r2eUuKLCvmRPgBzs",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -871,74 +872,62 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 429
+              "ephemeral_5m_input_tokens": 155
             },
-            "cache_creation_input_tokens": 429,
-            "cache_read_input_tokens": 41495,
+            "cache_creation_input_tokens": 155,
+            "cache_read_input_tokens": 41824,
             "inference_geo": "not_available",
             "input_tokens": 8,
-            "output_tokens": 3,
+            "output_tokens": 4,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "c6d57ba9-36c9-4ba8-9d21-4d192a51d90c",
+        "session_id": "4cb634d4-1dfd-4e4e-80a3-c5318dca8932",
         "type": "assistant",
-        "uuid": "424baa61-8519-490f-98d2-409b343ab9c4"
+        "uuid": "e4aa110a-7aba-4601-af03-d0634bdaa40c"
       }
     },
     {
       "op": "read",
       "payload": {
         "api_error_status": null,
-        "duration_api_ms": 5527,
-        "duration_ms": 4395,
+        "duration_api_ms": 6140,
+        "duration_ms": 4895,
         "fast_mode_state": "off",
         "is_error": false,
         "modelUsage": {
           "claude-haiku-4-5-20251001": {
-            "cacheCreationInputTokens": 41924,
-            "cacheReadInputTokens": 41495,
+            "cacheCreationInputTokens": 41979,
+            "cacheReadInputTokens": 83431,
             "contextWindow": 200000,
-            "costUSD": 0.0590505,
-            "inputTokens": 376,
+            "costUSD": 0.06324085,
+            "inputTokens": 384,
             "maxOutputTokens": 32000,
-            "outputTokens": 424,
+            "outputTokens": 408,
             "webSearchRequests": 0
           }
         },
         "num_turns": 3,
         "permission_denials": [],
-        "result": "**The answer is 100.**\n\nHere's the breakdown:\n- 15 \u00d7 7 = 105\n- 105 - 5 = **100**",
-        "session_id": "c6d57ba9-36c9-4ba8-9d21-4d192a51d90c",
+        "result": "The answer is **100**.\n\nHere's the breakdown:\n1. 15 \u00d7 7 = 105\n2. 105 \u2212 5 = 100",
+        "session_id": "4cb634d4-1dfd-4e4e-80a3-c5318dca8932",
         "stop_reason": "end_turn",
         "subtype": "success",
         "terminal_reason": "completed",
-        "total_cost_usd": 0.0590505,
+        "total_cost_usd": 0.06324085,
         "type": "result",
         "usage": {
           "cache_creation": {
             "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 41924
+            "ephemeral_5m_input_tokens": 41979
           },
-          "cache_creation_input_tokens": 41924,
-          "cache_read_input_tokens": 41495,
+          "cache_creation_input_tokens": 41979,
+          "cache_read_input_tokens": 83431,
           "inference_geo": "",
-          "input_tokens": 18,
-          "iterations": [
-            {
-              "cache_creation": {
-                "ephemeral_1h_input_tokens": 0,
-                "ephemeral_5m_input_tokens": 429
-              },
-              "cache_creation_input_tokens": 429,
-              "cache_read_input_tokens": 41495,
-              "input_tokens": 8,
-              "output_tokens": 87,
-              "type": "message"
-            }
-          ],
-          "output_tokens": 413,
+          "input_tokens": 26,
+          "iterations": [],
+          "output_tokens": 397,
           "server_tool_use": {
             "web_fetch_requests": 0,
             "web_search_requests": 0
@@ -946,9 +935,9 @@
           "service_tier": "standard",
           "speed": "standard"
         },
-        "uuid": "8fe592ca-3689-4de9-871d-86ff463e0b9b"
+        "uuid": "27cdc403-3ba1-4d80-96ae-af10ae289537"
       }
     }
   ],
-  "sdk_version": "0.1.60"
+  "sdk_version": "0.1.61"
 }

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_concurrent_subagents_produce_parallel_llm_spans_with_correct_parenting.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_concurrent_subagents_produce_parallel_llm_spans_with_correct_parenting.json
@@ -10,7 +10,7 @@
             "hooks": null,
             "subtype": "initialize"
           },
-          "request_id": "req_1_592e3e7e",
+          "request_id": "req_1_99ee9b02",
           "type": "control_request"
         }
       }
@@ -19,7 +19,7 @@
       "op": "read",
       "payload": {
         "response": {
-          "request_id": "req_1_592e3e7e",
+          "request_id": "req_1_99ee9b02",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
@@ -61,7 +61,7 @@
           "statusline-setup"
         ],
         "apiKeySource": "ANTHROPIC_API_KEY",
-        "claude_code_version": "2.1.111",
+        "claude_code_version": "2.1.112",
         "cwd": "<REDACTED_CWD>",
         "fast_mode_state": "off",
         "mcp_servers": [],
@@ -78,7 +78,7 @@
             "source": "rust-analyzer-lsp@claude-plugins-official"
           }
         ],
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "skills": [
           "update-config",
           "debug",
@@ -144,7 +144,7 @@
           "Write"
         ],
         "type": "system",
-        "uuid": "66782772-1f96-4bdc-9da5-d0763021da61"
+        "uuid": "5998de44-e790-4ef7-bac8-be227524e362"
       }
     },
     {
@@ -154,12 +154,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The user is asking me to use exactly three bundled general-purpose subagents (using the Agent tool) and start all three Agent tool calls before waiting for any results. Each subagent must:\n\n1. First use Bash to run `echo bash-a-output` (or b/c equivalent)\n2. Then use Read on task_a.txt (or task_b/c.txt)\n3. Return only the file contents after completing both tool calls\n\nAfter all three finish, I should reply with exactly three lines in order A, B, C.\n\nLet me structure this properly:\n\nSubagent A:\n- Run: `echo bash-a-output`\n- Read: task_a.txt\n- Return: file contents only\n\nSubagent B:\n- Run: `echo bash-b-output`\n- Read: task_b.txt\n- Return: file contents only\n\nSubagent C:\n- Run: `echo bash-c-output`\n- Read: task_c.txt\n- Return: file contents only\n\nI need to write the prompts for each agent clearly instructing them to do these tasks and return only the file contents.",
+              "thinking": "The user is asking me to:\n1. Use exactly three bundled general-purpose subagents\n2. Start all three Agent tool calls before waiting for any result\n3. Each subagent must:\n   - Subagent A: Run `echo bash-a-output` via Bash, then Read task_a.txt\n   - Subagent B: Run `echo bash-b-output` via Bash, then Read task_b.txt\n   - Subagent C: Run `echo bash-c-output` via Bash, then Read task_c.txt\n4. Each delegated subagent must return only its file contents after completing both tool calls\n5. After all three finish, reply with exactly three lines in order A, B, C\n6. Don't ask clarifying questions\n7. Don't answer directly without using all three subagents\n\nI need to create three Agent calls in parallel that will:\n- Execute Bash commands\n- Read file contents\n- Return the results\n\nLet me create three general-purpose agents with appropriate prompts.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01DcYnKg1NuruySZap12idRo",
+          "id": "msg_01DsKPNy8YsskGyxuj16FXoc",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -169,10 +169,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1580
+              "ephemeral_5m_input_tokens": 0
             },
-            "cache_creation_input_tokens": 1580,
-            "cache_read_input_tokens": 21780,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 23360,
             "inference_geo": "not_available",
             "input_tokens": 10,
             "output_tokens": 8,
@@ -180,46 +180,9 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "type": "assistant",
-        "uuid": "e9f0ac4b-b020-4a47-b3d4-e4e973984e44"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "text": "I'll launch three subagents in parallel to complete their respective tasks.",
-              "type": "text"
-            }
-          ],
-          "context_management": null,
-          "id": "msg_01DcYnKg1NuruySZap12idRo",
-          "model": "claude-haiku-4-5-20251001",
-          "role": "assistant",
-          "stop_details": null,
-          "stop_reason": null,
-          "stop_sequence": null,
-          "type": "message",
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1580
-            },
-            "cache_creation_input_tokens": 1580,
-            "cache_read_input_tokens": 21780,
-            "inference_geo": "not_available",
-            "input_tokens": 10,
-            "output_tokens": 8,
-            "service_tier": "standard"
-          }
-        },
-        "parent_tool_use_id": null,
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "type": "assistant",
-        "uuid": "21b41b5c-c56f-4731-8ed1-f1c9fc812dfe"
+        "uuid": "6dde3110-b98b-474e-aa5f-9b376a26d3d6"
       }
     },
     {
@@ -231,18 +194,17 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01Ae5YSMa19oDXWp6hNyRT7M",
+              "id": "toolu_01CdZ7e2eZqRGeYCmQhKcG7K",
               "input": {
-                "description": "Subagent A: Bash echo and read task_a.txt",
-                "prompt": "Run the bash command `echo bash-a-output` and then read the file task_a.txt. After completing both tool calls, return only the contents of task_a.txt and nothing else.",
-                "subagent_type": "general-purpose"
+                "description": "Subagent A: bash and read task",
+                "prompt": "Run `echo bash-a-output` using Bash, then read the contents of task_a.txt using the Read tool. Return only the contents of task_a.txt file."
               },
               "name": "Agent",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01DcYnKg1NuruySZap12idRo",
+          "id": "msg_01DsKPNy8YsskGyxuj16FXoc",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -252,10 +214,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1580
+              "ephemeral_5m_input_tokens": 0
             },
-            "cache_creation_input_tokens": 1580,
-            "cache_read_input_tokens": 21780,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 23360,
             "inference_geo": "not_available",
             "input_tokens": 10,
             "output_tokens": 8,
@@ -263,23 +225,23 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "type": "assistant",
-        "uuid": "9e3ce80f-82ca-4698-8c07-d57ee6eb4dd4"
+        "uuid": "2bdb4094-859f-488f-a9aa-a787adbda0dd"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Subagent A: Bash echo and read task_a.txt",
-        "prompt": "Run the bash command `echo bash-a-output` and then read the file task_a.txt. After completing both tool calls, return only the contents of task_a.txt and nothing else.",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "description": "Subagent A: bash and read task",
+        "prompt": "Run `echo bash-a-output` using Bash, then read the contents of task_a.txt using the Read tool. Return only the contents of task_a.txt file.",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "subtype": "task_started",
-        "task_id": "a5c14f2c1e2f33795",
+        "task_id": "a7252fc6493b55b42",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01Ae5YSMa19oDXWp6hNyRT7M",
+        "tool_use_id": "toolu_01CdZ7e2eZqRGeYCmQhKcG7K",
         "type": "system",
-        "uuid": "6529654d-e349-47cb-999a-535e7a30c3df"
+        "uuid": "22e17ce9-f574-451b-8ff1-3ace51458e39"
       }
     },
     {
@@ -288,17 +250,17 @@
         "message": {
           "content": [
             {
-              "text": "Run the bash command `echo bash-a-output` and then read the file task_a.txt. After completing both tool calls, return only the contents of task_a.txt and nothing else.",
+              "text": "Run `echo bash-a-output` using Bash, then read the contents of task_a.txt using the Read tool. Return only the contents of task_a.txt file.",
               "type": "text"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01Ae5YSMa19oDXWp6hNyRT7M",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "timestamp": "2026-04-16T16:49:28.676Z",
+        "parent_tool_use_id": "toolu_01CdZ7e2eZqRGeYCmQhKcG7K",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "timestamp": "2026-04-17T16:19:30.221Z",
         "type": "user",
-        "uuid": "5ac4e163-d318-41a4-a015-1b0d20fc492e"
+        "uuid": "67b56c67-8e47-49b1-9703-4448f33445f6"
       }
     },
     {
@@ -310,18 +272,17 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01KAaaThx9ECArF2DLk25Wb2",
+              "id": "toolu_017yFZ6fdc1YuFQs2kazZJgT",
               "input": {
-                "description": "Subagent B: Bash echo and read task_b.txt",
-                "prompt": "Run the bash command `echo bash-b-output` and then read the file task_b.txt. After completing both tool calls, return only the contents of task_b.txt and nothing else.",
-                "subagent_type": "general-purpose"
+                "description": "Subagent B: bash and read task",
+                "prompt": "Run `echo bash-b-output` using Bash, then read the contents of task_b.txt using the Read tool. Return only the contents of task_b.txt file."
               },
               "name": "Agent",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01DcYnKg1NuruySZap12idRo",
+          "id": "msg_01DsKPNy8YsskGyxuj16FXoc",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -331,10 +292,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1580
+              "ephemeral_5m_input_tokens": 0
             },
-            "cache_creation_input_tokens": 1580,
-            "cache_read_input_tokens": 21780,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 23360,
             "inference_geo": "not_available",
             "input_tokens": 10,
             "output_tokens": 8,
@@ -342,23 +303,23 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "type": "assistant",
-        "uuid": "cb8c60fd-e420-4df4-934a-db9ef25e08c2"
+        "uuid": "f8a7a44f-d0aa-486e-94cf-66a6818e7857"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Subagent B: Bash echo and read task_b.txt",
-        "prompt": "Run the bash command `echo bash-b-output` and then read the file task_b.txt. After completing both tool calls, return only the contents of task_b.txt and nothing else.",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "description": "Subagent B: bash and read task",
+        "prompt": "Run `echo bash-b-output` using Bash, then read the contents of task_b.txt using the Read tool. Return only the contents of task_b.txt file.",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "subtype": "task_started",
-        "task_id": "add47d812bc724d7f",
+        "task_id": "a9b2b0632eb62cc71",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01KAaaThx9ECArF2DLk25Wb2",
+        "tool_use_id": "toolu_017yFZ6fdc1YuFQs2kazZJgT",
         "type": "system",
-        "uuid": "7cfe7343-e16e-4a70-b323-cdbd7b1a2b7b"
+        "uuid": "de3d2de0-463b-421b-86df-af0052f27936"
       }
     },
     {
@@ -367,17 +328,17 @@
         "message": {
           "content": [
             {
-              "text": "Run the bash command `echo bash-b-output` and then read the file task_b.txt. After completing both tool calls, return only the contents of task_b.txt and nothing else.",
+              "text": "Run `echo bash-b-output` using Bash, then read the contents of task_b.txt using the Read tool. Return only the contents of task_b.txt file.",
               "type": "text"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01KAaaThx9ECArF2DLk25Wb2",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "timestamp": "2026-04-16T16:49:28.765Z",
+        "parent_tool_use_id": "toolu_017yFZ6fdc1YuFQs2kazZJgT",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "timestamp": "2026-04-17T16:19:30.432Z",
         "type": "user",
-        "uuid": "e9091fd0-b1d4-40c8-b974-6f1352c4f575"
+        "uuid": "c13593d1-c9ec-43f3-8ff3-724a8f06c436"
       }
     },
     {
@@ -389,18 +350,17 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01BJazP9dLcM1R7oxe9FpCBY",
+              "id": "toolu_01X1zCmGAowCxrH9vvrVvihb",
               "input": {
-                "description": "Subagent C: Bash echo and read task_c.txt",
-                "prompt": "Run the bash command `echo bash-c-output` and then read the file task_c.txt. After completing both tool calls, return only the contents of task_c.txt and nothing else.",
-                "subagent_type": "general-purpose"
+                "description": "Subagent C: bash and read task",
+                "prompt": "Run `echo bash-c-output` using Bash, then read the contents of task_c.txt using the Read tool. Return only the contents of task_c.txt file."
               },
               "name": "Agent",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01DcYnKg1NuruySZap12idRo",
+          "id": "msg_01DsKPNy8YsskGyxuj16FXoc",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -410,10 +370,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1580
+              "ephemeral_5m_input_tokens": 0
             },
-            "cache_creation_input_tokens": 1580,
-            "cache_read_input_tokens": 21780,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 23360,
             "inference_geo": "not_available",
             "input_tokens": 10,
             "output_tokens": 8,
@@ -421,23 +381,23 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "type": "assistant",
-        "uuid": "6321aa3d-e8c1-43bd-86be-1ca913bc4e9d"
+        "uuid": "8a8cdfac-009f-468e-a268-a5c2fa3c9fce"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Subagent C: Bash echo and read task_c.txt",
-        "prompt": "Run the bash command `echo bash-c-output` and then read the file task_c.txt. After completing both tool calls, return only the contents of task_c.txt and nothing else.",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "description": "Subagent C: bash and read task",
+        "prompt": "Run `echo bash-c-output` using Bash, then read the contents of task_c.txt using the Read tool. Return only the contents of task_c.txt file.",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "subtype": "task_started",
-        "task_id": "a5f236905d911563d",
+        "task_id": "a4c582314e0225673",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01BJazP9dLcM1R7oxe9FpCBY",
+        "tool_use_id": "toolu_01X1zCmGAowCxrH9vvrVvihb",
         "type": "system",
-        "uuid": "a83736a7-80f5-4211-9bc8-da487e0e9a36"
+        "uuid": "4333e1b2-a650-4a15-865e-f8574e7ff0b6"
       }
     },
     {
@@ -446,17 +406,17 @@
         "message": {
           "content": [
             {
-              "text": "Run the bash command `echo bash-c-output` and then read the file task_c.txt. After completing both tool calls, return only the contents of task_c.txt and nothing else.",
+              "text": "Run `echo bash-c-output` using Bash, then read the contents of task_c.txt using the Read tool. Return only the contents of task_c.txt file.",
               "type": "text"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01BJazP9dLcM1R7oxe9FpCBY",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "timestamp": "2026-04-16T16:49:28.933Z",
+        "parent_tool_use_id": "toolu_01X1zCmGAowCxrH9vvrVvihb",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "timestamp": "2026-04-17T16:19:30.729Z",
         "type": "user",
-        "uuid": "5a1390b2-6f7a-41e1-9d1c-f778807063e6"
+        "uuid": "dd0233ee-b2cf-4552-b55f-7ed3ee93d6ba"
       }
     },
     {
@@ -464,17 +424,17 @@
       "payload": {
         "description": "Running echo bash-b-output",
         "last_tool_name": "Bash",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "subtype": "task_progress",
-        "task_id": "add47d812bc724d7f",
-        "tool_use_id": "toolu_01KAaaThx9ECArF2DLk25Wb2",
+        "task_id": "a9b2b0632eb62cc71",
+        "tool_use_id": "toolu_017yFZ6fdc1YuFQs2kazZJgT",
         "type": "system",
         "usage": {
-          "duration_ms": 1330,
+          "duration_ms": 1058,
           "tool_uses": 1,
-          "total_tokens": 17500
+          "total_tokens": 17501
         },
-        "uuid": "27c89c9b-8539-404c-a3ab-cdef40075d43"
+        "uuid": "69b12f63-7302-4b7f-9a14-a8157fa04d3c"
       }
     },
     {
@@ -486,7 +446,7 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01Fs5jCcLLqTaWNc29HYvynx",
+              "id": "toolu_014J8Asf3FC9iXzEMoUg1TbQ",
               "input": {
                 "command": "echo bash-b-output"
               },
@@ -495,7 +455,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01Lb4PT9Qjn8uTXx2jdEh3j4",
+          "id": "msg_01TpELNuELTeQ2AVQWkvx6t2",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -505,82 +465,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1068
+              "ephemeral_5m_input_tokens": 1065
             },
-            "cache_creation_input_tokens": 1068,
+            "cache_creation_input_tokens": 1065,
             "cache_read_input_tokens": 16423,
             "inference_geo": "not_available",
             "input_tokens": 3,
-            "output_tokens": 3,
+            "output_tokens": 5,
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01KAaaThx9ECArF2DLk25Wb2",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "parent_tool_use_id": "toolu_017yFZ6fdc1YuFQs2kazZJgT",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "type": "assistant",
-        "uuid": "de959cf2-18c3-44a8-8c0a-3855da9a2f71"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "description": "Running echo bash-c-output",
-        "last_tool_name": "Bash",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "subtype": "task_progress",
-        "task_id": "a5f236905d911563d",
-        "tool_use_id": "toolu_01BJazP9dLcM1R7oxe9FpCBY",
-        "type": "system",
-        "usage": {
-          "duration_ms": 1223,
-          "tool_uses": 1,
-          "total_tokens": 17510
-        },
-        "uuid": "284e76f0-e946-4381-9bf5-d14975c0da76"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "caller": {
-                "type": "direct"
-              },
-              "id": "toolu_01JryftVjZfvmx6zb7gS79jA",
-              "input": {
-                "command": "echo bash-c-output"
-              },
-              "name": "Bash",
-              "type": "tool_use"
-            }
-          ],
-          "context_management": null,
-          "id": "msg_0135394SsGCQh6G3xUqdZQLq",
-          "model": "claude-haiku-4-5-20251001",
-          "role": "assistant",
-          "stop_details": null,
-          "stop_reason": null,
-          "stop_sequence": null,
-          "type": "message",
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1068
-            },
-            "cache_creation_input_tokens": 1068,
-            "cache_read_input_tokens": 16423,
-            "inference_geo": "not_available",
-            "input_tokens": 3,
-            "output_tokens": 8,
-            "service_tier": "standard"
-          }
-        },
-        "parent_tool_use_id": "toolu_01BJazP9dLcM1R7oxe9FpCBY",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "type": "assistant",
-        "uuid": "873659c4-efc0-4f0e-bc53-b80f510eba46"
+        "uuid": "81cd61b3-e9ed-492f-bffe-cb4d31274c10"
       }
     },
     {
@@ -588,17 +486,17 @@
       "payload": {
         "description": "Running echo bash-a-output",
         "last_tool_name": "Bash",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "subtype": "task_progress",
-        "task_id": "a5c14f2c1e2f33795",
-        "tool_use_id": "toolu_01Ae5YSMa19oDXWp6hNyRT7M",
+        "task_id": "a7252fc6493b55b42",
+        "tool_use_id": "toolu_01CdZ7e2eZqRGeYCmQhKcG7K",
         "type": "system",
         "usage": {
-          "duration_ms": 1662,
+          "duration_ms": 1487,
           "tool_uses": 1,
-          "total_tokens": 17504
+          "total_tokens": 17497
         },
-        "uuid": "32112d88-9668-4f03-9740-e9e9b76935fd"
+        "uuid": "9ddf367c-9a00-4227-bc99-4905548084b2"
       }
     },
     {
@@ -610,7 +508,7 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01L8KYMaByAkreocgAPqTwiH",
+              "id": "toolu_017NRTmuBTmTjt1X8DFFMvAw",
               "input": {
                 "command": "echo bash-a-output"
               },
@@ -619,7 +517,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01V1Qhf7aGMzwHB9qW2B7Ahy",
+          "id": "msg_01VJwMEsFfFt5d9oyqfcRXxX",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -629,38 +527,38 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1068
+              "ephemeral_5m_input_tokens": 1065
             },
-            "cache_creation_input_tokens": 1068,
+            "cache_creation_input_tokens": 1065,
             "cache_read_input_tokens": 16423,
             "inference_geo": "not_available",
             "input_tokens": 3,
-            "output_tokens": 5,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01Ae5YSMa19oDXWp6hNyRT7M",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "parent_tool_use_id": "toolu_01CdZ7e2eZqRGeYCmQhKcG7K",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "type": "assistant",
-        "uuid": "f7f11a34-589a-402e-845f-669f5297922c"
+        "uuid": "f5f7fc15-0af7-4e30-a0cc-8d4135b81242"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Reading task_b.txt",
+        "description": "Reading task_a.txt",
         "last_tool_name": "Read",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "subtype": "task_progress",
-        "task_id": "add47d812bc724d7f",
-        "tool_use_id": "toolu_01KAaaThx9ECArF2DLk25Wb2",
+        "task_id": "a7252fc6493b55b42",
+        "tool_use_id": "toolu_01CdZ7e2eZqRGeYCmQhKcG7K",
         "type": "system",
         "usage": {
-          "duration_ms": 1597,
+          "duration_ms": 1576,
           "tool_uses": 2,
-          "total_tokens": 17503
+          "total_tokens": 17500
         },
-        "uuid": "82c1ecd1-5586-427c-9d7f-92d210b28d33"
+        "uuid": "020edced-ecc6-4a52-a663-6bf7a1b9c901"
       }
     },
     {
@@ -672,16 +570,16 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01XEWAYqJcHhpcDqy2T1DSf3",
+              "id": "toolu_01KZ6vbBKbB5rTWsgvyPosg5",
               "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_concurrent_subagents_prod0/concurrent_subagent_workspace/task_b.txt"
+                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-580/test_concurrent_subagents_prod0/concurrent_subagent_workspace/task_a.txt"
               },
               "name": "Read",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01Lb4PT9Qjn8uTXx2jdEh3j4",
+          "id": "msg_01VJwMEsFfFt5d9oyqfcRXxX",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -691,9 +589,9 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1068
+              "ephemeral_5m_input_tokens": 1065
             },
-            "cache_creation_input_tokens": 1068,
+            "cache_creation_input_tokens": 1065,
             "cache_read_input_tokens": 16423,
             "inference_geo": "not_available",
             "input_tokens": 3,
@@ -701,10 +599,92 @@
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01KAaaThx9ECArF2DLk25Wb2",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "parent_tool_use_id": "toolu_01CdZ7e2eZqRGeYCmQhKcG7K",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "type": "assistant",
-        "uuid": "592cd0e7-865b-4dcc-8b5d-166475d7c359"
+        "uuid": "0f876c94-0390-4e75-9af8-60ee9c2160da"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "description": "Reading task_b.txt",
+        "last_tool_name": "Read",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "subtype": "task_progress",
+        "task_id": "a9b2b0632eb62cc71",
+        "tool_use_id": "toolu_017yFZ6fdc1YuFQs2kazZJgT",
+        "type": "system",
+        "usage": {
+          "duration_ms": 1372,
+          "tool_uses": 2,
+          "total_tokens": 17506
+        },
+        "uuid": "7456cd2b-a570-45d3-b657-81c5b2793dfe"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "caller": {
+                "type": "direct"
+              },
+              "id": "toolu_015WWH6WSynVLhnd3L6mjkxi",
+              "input": {
+                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-580/test_concurrent_subagents_prod0/concurrent_subagent_workspace/task_b.txt"
+              },
+              "name": "Read",
+              "type": "tool_use"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01TpELNuELTeQ2AVQWkvx6t2",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 1065
+            },
+            "cache_creation_input_tokens": 1065,
+            "cache_read_input_tokens": 16423,
+            "inference_geo": "not_available",
+            "input_tokens": 3,
+            "output_tokens": 5,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": "toolu_017yFZ6fdc1YuFQs2kazZJgT",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "type": "assistant",
+        "uuid": "ed0c45c0-da1e-4d77-9ab9-ed94a9c13e95"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": "1\ttask_label=A\n2\towner=alpha\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
+              "tool_use_id": "toolu_01KZ6vbBKbB5rTWsgvyPosg5",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": "toolu_01CdZ7e2eZqRGeYCmQhKcG7K",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "timestamp": "2026-04-17T16:19:31.801Z",
+        "type": "user",
+        "uuid": "9bd14fae-4ec1-458b-8f5f-4d39f736f026"
       }
     },
     {
@@ -714,141 +694,17 @@
           "content": [
             {
               "content": "1\ttask_label=B\n2\towner=beta\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_01XEWAYqJcHhpcDqy2T1DSf3",
+              "tool_use_id": "toolu_015WWH6WSynVLhnd3L6mjkxi",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01KAaaThx9ECArF2DLk25Wb2",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "timestamp": "2026-04-16T16:49:30.369Z",
+        "parent_tool_use_id": "toolu_017yFZ6fdc1YuFQs2kazZJgT",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "timestamp": "2026-04-17T16:19:31.807Z",
         "type": "user",
-        "uuid": "adbc2893-eb8e-4a9b-a394-489de9448245"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "content": "bash-b-output",
-              "is_error": false,
-              "tool_use_id": "toolu_01Fs5jCcLLqTaWNc29HYvynx",
-              "type": "tool_result"
-            }
-          ],
-          "role": "user"
-        },
-        "parent_tool_use_id": "toolu_01KAaaThx9ECArF2DLk25Wb2",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "timestamp": "2026-04-16T16:49:30.394Z",
-        "type": "user",
-        "uuid": "c0fc16d3-33a5-4249-b2d3-6059ef6e13fd"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "content": "bash-c-output",
-              "is_error": false,
-              "tool_use_id": "toolu_01JryftVjZfvmx6zb7gS79jA",
-              "type": "tool_result"
-            }
-          ],
-          "role": "user"
-        },
-        "parent_tool_use_id": "toolu_01BJazP9dLcM1R7oxe9FpCBY",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "timestamp": "2026-04-16T16:49:30.395Z",
-        "type": "user",
-        "uuid": "8dfc210b-4d5a-434e-9883-83ba547efbc6"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "description": "Reading task_c.txt",
-        "last_tool_name": "Read",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "subtype": "task_progress",
-        "task_id": "a5f236905d911563d",
-        "tool_use_id": "toolu_01BJazP9dLcM1R7oxe9FpCBY",
-        "type": "system",
-        "usage": {
-          "duration_ms": 1490,
-          "tool_uses": 2,
-          "total_tokens": 17518
-        },
-        "uuid": "f4d303c8-c216-4414-8d6b-5f6e4325cb51"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "caller": {
-                "type": "direct"
-              },
-              "id": "toolu_01MQBvf8n4BVTYSB5qFcbBPm",
-              "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_concurrent_subagents_prod0/concurrent_subagent_workspace/task_c.txt"
-              },
-              "name": "Read",
-              "type": "tool_use"
-            }
-          ],
-          "context_management": null,
-          "id": "msg_0135394SsGCQh6G3xUqdZQLq",
-          "model": "claude-haiku-4-5-20251001",
-          "role": "assistant",
-          "stop_details": null,
-          "stop_reason": null,
-          "stop_sequence": null,
-          "type": "message",
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1068
-            },
-            "cache_creation_input_tokens": 1068,
-            "cache_read_input_tokens": 16423,
-            "inference_geo": "not_available",
-            "input_tokens": 3,
-            "output_tokens": 8,
-            "service_tier": "standard"
-          }
-        },
-        "parent_tool_use_id": "toolu_01BJazP9dLcM1R7oxe9FpCBY",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "type": "assistant",
-        "uuid": "3177ab86-e76b-461a-b54a-87e350dc7185"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "content": "1\ttask_label=C\n2\towner=gamma\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_01MQBvf8n4BVTYSB5qFcbBPm",
-              "type": "tool_result"
-            }
-          ],
-          "role": "user"
-        },
-        "parent_tool_use_id": "toolu_01BJazP9dLcM1R7oxe9FpCBY",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "timestamp": "2026-04-16T16:49:30.425Z",
-        "type": "user",
-        "uuid": "89830bec-a99b-4f78-b50b-90ad8e510875"
+        "uuid": "0c9ba936-d0af-47c9-acbb-e6c2ec8e8613"
       }
     },
     {
@@ -859,35 +715,56 @@
             {
               "content": "bash-a-output",
               "is_error": false,
-              "tool_use_id": "toolu_01L8KYMaByAkreocgAPqTwiH",
+              "tool_use_id": "toolu_017NRTmuBTmTjt1X8DFFMvAw",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01Ae5YSMa19oDXWp6hNyRT7M",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "timestamp": "2026-04-16T16:49:30.393Z",
+        "parent_tool_use_id": "toolu_01CdZ7e2eZqRGeYCmQhKcG7K",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "timestamp": "2026-04-17T16:19:31.906Z",
         "type": "user",
-        "uuid": "fa3b57ba-473f-43a7-9156-f38409c25a2b"
+        "uuid": "8d42cd56-92e8-4ee7-9a13-90d81dcb3a95"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Reading task_a.txt",
-        "last_tool_name": "Read",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "message": {
+          "content": [
+            {
+              "content": "bash-b-output",
+              "is_error": false,
+              "tool_use_id": "toolu_014J8Asf3FC9iXzEMoUg1TbQ",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": "toolu_017yFZ6fdc1YuFQs2kazZJgT",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "timestamp": "2026-04-17T16:19:31.908Z",
+        "type": "user",
+        "uuid": "d3ec97f0-8618-45eb-96cc-ee23d83148e8"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "description": "Running echo bash-c-output",
+        "last_tool_name": "Bash",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "subtype": "task_progress",
-        "task_id": "a5c14f2c1e2f33795",
-        "tool_use_id": "toolu_01Ae5YSMa19oDXWp6hNyRT7M",
+        "task_id": "a4c582314e0225673",
+        "tool_use_id": "toolu_01X1zCmGAowCxrH9vvrVvihb",
         "type": "system",
         "usage": {
-          "duration_ms": 2242,
-          "tool_uses": 2,
-          "total_tokens": 17509
+          "duration_ms": 1470,
+          "tool_uses": 1,
+          "total_tokens": 17497
         },
-        "uuid": "c849bccc-9cf0-410c-89c7-d1eef1fc86a8"
+        "uuid": "00e7fa62-62ba-4d07-b2d8-7220f4b83dc0"
       }
     },
     {
@@ -899,16 +776,16 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_017Soosc8JU2U61u37x82XS6",
+              "id": "toolu_017nYDRkoHnWNTEHwxt7bie2",
               "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_concurrent_subagents_prod0/concurrent_subagent_workspace/task_a.txt"
+                "command": "echo bash-c-output"
               },
-              "name": "Read",
+              "name": "Bash",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01V1Qhf7aGMzwHB9qW2B7Ahy",
+          "id": "msg_01PSoyN2j3Rb5jCHxmmrYjSG",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -918,20 +795,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1068
+              "ephemeral_5m_input_tokens": 438
             },
-            "cache_creation_input_tokens": 1068,
-            "cache_read_input_tokens": 16423,
+            "cache_creation_input_tokens": 438,
+            "cache_read_input_tokens": 17050,
             "inference_geo": "not_available",
             "input_tokens": 3,
-            "output_tokens": 5,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01Ae5YSMa19oDXWp6hNyRT7M",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "parent_tool_use_id": "toolu_01X1zCmGAowCxrH9vvrVvihb",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "type": "assistant",
-        "uuid": "eccd9c39-629d-49c6-a17f-4dbd6e566d16"
+        "uuid": "d2af586b-5c29-4e5b-adb9-e9e52aac6d2d"
       }
     },
     {
@@ -940,37 +817,37 @@
         "message": {
           "content": [
             {
-              "content": "1\ttask_label=A\n2\towner=alpha\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_017Soosc8JU2U61u37x82XS6",
+              "content": "bash-c-output",
+              "is_error": false,
+              "tool_use_id": "toolu_017nYDRkoHnWNTEHwxt7bie2",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01Ae5YSMa19oDXWp6hNyRT7M",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "timestamp": "2026-04-16T16:49:30.922Z",
+        "parent_tool_use_id": "toolu_01X1zCmGAowCxrH9vvrVvihb",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "timestamp": "2026-04-17T16:19:32.208Z",
         "type": "user",
-        "uuid": "0d110221-c34a-41ec-bcb8-4e7d8e5f3ea2"
+        "uuid": "d930b56f-c9f4-4c41-9419-b153e8959c32"
       }
     },
     {
       "op": "read",
       "payload": {
-        "output_file": "",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "status": "completed",
-        "subtype": "task_notification",
-        "summary": "Subagent C: Bash echo and read task_c.txt",
-        "task_id": "a5f236905d911563d",
-        "tool_use_id": "toolu_01BJazP9dLcM1R7oxe9FpCBY",
+        "description": "Reading task_c.txt",
+        "last_tool_name": "Read",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "subtype": "task_progress",
+        "task_id": "a4c582314e0225673",
+        "tool_use_id": "toolu_01X1zCmGAowCxrH9vvrVvihb",
         "type": "system",
         "usage": {
-          "duration_ms": 2454,
+          "duration_ms": 1896,
           "tool_uses": 2,
-          "total_tokens": 18690
+          "total_tokens": 17500
         },
-        "uuid": "069d2d57-fdd7-44fb-a6fa-4c09ae48a448"
+        "uuid": "3235ed6a-80fa-4f9a-8ae6-df12397c35ef"
       }
     },
     {
@@ -979,100 +856,42 @@
         "message": {
           "content": [
             {
-              "content": [
-                {
-                  "text": "task_label=C\nowner=gamma",
-                  "type": "text"
-                },
-                {
-                  "text": "agentId: a5f236905d911563d (use SendMessage with to: 'a5f236905d911563d' to continue this agent)\n<usage>total_tokens: 18677\ntool_uses: 2\nduration_ms: 2456</usage>",
-                  "type": "text"
-                }
-              ],
-              "tool_use_id": "toolu_01BJazP9dLcM1R7oxe9FpCBY",
-              "type": "tool_result"
+              "caller": {
+                "type": "direct"
+              },
+              "id": "toolu_01NyK33GUpjUWzxthn697AfH",
+              "input": {
+                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-580/test_concurrent_subagents_prod0/concurrent_subagent_workspace/task_c.txt"
+              },
+              "name": "Read",
+              "type": "tool_use"
             }
           ],
-          "role": "user"
-        },
-        "parent_tool_use_id": null,
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "timestamp": "2026-04-16T16:49:31.388Z",
-        "tool_use_result": {
-          "agentId": "a5f236905d911563d",
-          "agentType": "general-purpose",
-          "content": [
-            {
-              "text": "task_label=C\nowner=gamma",
-              "type": "text"
-            }
-          ],
-          "prompt": "Run the bash command `echo bash-c-output` and then read the file task_c.txt. After completing both tool calls, return only the contents of task_c.txt and nothing else.",
-          "status": "completed",
-          "toolStats": {
-            "bashCount": 1,
-            "editFileCount": 0,
-            "linesAdded": 0,
-            "linesRemoved": 0,
-            "otherToolCount": 0,
-            "readCount": 1,
-            "searchCount": 0
-          },
-          "totalDurationMs": 2456,
-          "totalTokens": 18677,
-          "totalToolUseCount": 2,
+          "context_management": null,
+          "id": "msg_01PSoyN2j3Rb5jCHxmmrYjSG",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1608
+              "ephemeral_5m_input_tokens": 438
             },
-            "cache_creation_input_tokens": 1608,
+            "cache_creation_input_tokens": 438,
             "cache_read_input_tokens": 17050,
-            "inference_geo": "",
-            "input_tokens": 7,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 1608
-                },
-                "cache_creation_input_tokens": 1608,
-                "cache_read_input_tokens": 17050,
-                "input_tokens": 7,
-                "output_tokens": 12,
-                "type": "message"
-              }
-            ],
-            "output_tokens": 12,
-            "server_tool_use": {
-              "web_fetch_requests": 0,
-              "web_search_requests": 0
-            },
-            "service_tier": "standard",
-            "speed": "standard"
+            "inference_geo": "not_available",
+            "input_tokens": 3,
+            "output_tokens": 3,
+            "service_tier": "standard"
           }
         },
-        "type": "user",
-        "uuid": "ad7d26ea-15a5-4a25-bf79-e9fca2b75962"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "output_file": "",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "status": "completed",
-        "subtype": "task_notification",
-        "summary": "Subagent B: Bash echo and read task_b.txt",
-        "task_id": "add47d812bc724d7f",
-        "tool_use_id": "toolu_01KAaaThx9ECArF2DLk25Wb2",
-        "type": "system",
-        "usage": {
-          "duration_ms": 2641,
-          "tool_uses": 2,
-          "total_tokens": 18676
-        },
-        "uuid": "690811ec-0a95-45ce-ba44-3bd2a7c2aebb"
+        "parent_tool_use_id": "toolu_01X1zCmGAowCxrH9vvrVvihb",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "type": "assistant",
+        "uuid": "b1f0560e-1b83-43f1-afce-f9388a5f2a27"
       }
     },
     {
@@ -1081,100 +900,37 @@
         "message": {
           "content": [
             {
-              "content": [
-                {
-                  "text": "task_label=B\nowner=beta",
-                  "type": "text"
-                },
-                {
-                  "text": "agentId: add47d812bc724d7f (use SendMessage with to: 'add47d812bc724d7f' to continue this agent)\n<usage>total_tokens: 18678\ntool_uses: 2\nduration_ms: 2641</usage>",
-                  "type": "text"
-                }
-              ],
-              "tool_use_id": "toolu_01KAaaThx9ECArF2DLk25Wb2",
+              "content": "1\ttask_label=C\n2\towner=gamma\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
+              "tool_use_id": "toolu_01NyK33GUpjUWzxthn697AfH",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": null,
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "timestamp": "2026-04-16T16:49:31.406Z",
-        "tool_use_result": {
-          "agentId": "add47d812bc724d7f",
-          "agentType": "general-purpose",
-          "content": [
-            {
-              "text": "task_label=B\nowner=beta",
-              "type": "text"
-            }
-          ],
-          "prompt": "Run the bash command `echo bash-b-output` and then read the file task_b.txt. After completing both tool calls, return only the contents of task_b.txt and nothing else.",
-          "status": "completed",
-          "toolStats": {
-            "bashCount": 1,
-            "editFileCount": 0,
-            "linesAdded": 0,
-            "linesRemoved": 0,
-            "otherToolCount": 0,
-            "readCount": 1,
-            "searchCount": 0
-          },
-          "totalDurationMs": 2641,
-          "totalTokens": 18678,
-          "totalToolUseCount": 2,
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1490
-            },
-            "cache_creation_input_tokens": 1490,
-            "cache_read_input_tokens": 17050,
-            "inference_geo": "",
-            "input_tokens": 126,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 1490
-                },
-                "cache_creation_input_tokens": 1490,
-                "cache_read_input_tokens": 17050,
-                "input_tokens": 126,
-                "output_tokens": 12,
-                "type": "message"
-              }
-            ],
-            "output_tokens": 12,
-            "server_tool_use": {
-              "web_fetch_requests": 0,
-              "web_search_requests": 0
-            },
-            "service_tier": "standard",
-            "speed": "standard"
-          }
-        },
+        "parent_tool_use_id": "toolu_01X1zCmGAowCxrH9vvrVvihb",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "timestamp": "2026-04-17T16:19:32.626Z",
         "type": "user",
-        "uuid": "f9bd174e-d97c-4792-ae82-21c3c1fe04ca"
+        "uuid": "cc135ff4-f829-4c51-a9f8-8adf67399977"
       }
     },
     {
       "op": "read",
       "payload": {
         "output_file": "",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "status": "completed",
         "subtype": "task_notification",
-        "summary": "Subagent A: Bash echo and read task_a.txt",
-        "task_id": "a5c14f2c1e2f33795",
-        "tool_use_id": "toolu_01Ae5YSMa19oDXWp6hNyRT7M",
+        "summary": "Subagent A: bash and read task",
+        "task_id": "a7252fc6493b55b42",
+        "tool_use_id": "toolu_01CdZ7e2eZqRGeYCmQhKcG7K",
         "type": "system",
         "usage": {
-          "duration_ms": 3841,
+          "duration_ms": 2729,
           "tool_uses": 2,
-          "total_tokens": 18681
+          "total_tokens": 18679
         },
-        "uuid": "6463f4c8-d71b-459b-a3e2-93179c7b9979"
+        "uuid": "dcdf8f9c-ddd9-4921-9e51-3a56aa1bf14a"
       }
     },
     {
@@ -1189,21 +945,21 @@
                   "type": "text"
                 },
                 {
-                  "text": "agentId: a5c14f2c1e2f33795 (use SendMessage with to: 'a5c14f2c1e2f33795' to continue this agent)\n<usage>total_tokens: 18677\ntool_uses: 2\nduration_ms: 3842</usage>",
+                  "text": "agentId: a7252fc6493b55b42 (use SendMessage with to: 'a7252fc6493b55b42' to continue this agent)\n<usage>total_tokens: 18681\ntool_uses: 2\nduration_ms: 2730</usage>",
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01Ae5YSMa19oDXWp6hNyRT7M",
+              "tool_use_id": "toolu_01CdZ7e2eZqRGeYCmQhKcG7K",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
-        "timestamp": "2026-04-16T16:49:32.518Z",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "timestamp": "2026-04-17T16:19:32.951Z",
         "tool_use_result": {
-          "agentId": "a5c14f2c1e2f33795",
+          "agentId": "a7252fc6493b55b42",
           "agentType": "general-purpose",
           "content": [
             {
@@ -1211,7 +967,7 @@
               "type": "text"
             }
           ],
-          "prompt": "Run the bash command `echo bash-a-output` and then read the file task_a.txt. After completing both tool calls, return only the contents of task_a.txt and nothing else.",
+          "prompt": "Run `echo bash-a-output` using Bash, then read the contents of task_a.txt using the Read tool. Return only the contents of task_a.txt file.",
           "status": "completed",
           "toolStats": {
             "bashCount": 1,
@@ -1222,31 +978,19 @@
             "readCount": 1,
             "searchCount": 0
           },
-          "totalDurationMs": 3842,
-          "totalTokens": 18677,
+          "totalDurationMs": 2730,
+          "totalTokens": 18681,
           "totalToolUseCount": 2,
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1167
+              "ephemeral_5m_input_tokens": 1055
             },
-            "cache_creation_input_tokens": 1167,
-            "cache_read_input_tokens": 17491,
+            "cache_creation_input_tokens": 1055,
+            "cache_read_input_tokens": 17488,
             "inference_geo": "",
-            "input_tokens": 7,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 1167
-                },
-                "cache_creation_input_tokens": 1167,
-                "cache_read_input_tokens": 17491,
-                "input_tokens": 7,
-                "output_tokens": 12,
-                "type": "message"
-              }
-            ],
+            "input_tokens": 126,
+            "iterations": [],
             "output_tokens": 12,
             "server_tool_use": {
               "web_fetch_requests": 0,
@@ -1257,7 +1001,187 @@
           }
         },
         "type": "user",
-        "uuid": "3751ada5-4163-4309-bd7b-5653c345b4e6"
+        "uuid": "557bb9d5-37a6-4756-bfdf-ce2c5c932ad4"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "output_file": "",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "status": "completed",
+        "subtype": "task_notification",
+        "summary": "Subagent C: bash and read task",
+        "task_id": "a4c582314e0225673",
+        "tool_use_id": "toolu_01X1zCmGAowCxrH9vvrVvihb",
+        "type": "system",
+        "usage": {
+          "duration_ms": 2728,
+          "tool_uses": 2,
+          "total_tokens": 18676
+        },
+        "uuid": "5b4727cd-0936-44ad-8edf-89f62fb2d5a6"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "Here are the contents of task_c.txt:\n\n```\ntask_label=C\nowner=gamma\n```",
+                  "type": "text"
+                },
+                {
+                  "text": "agentId: a4c582314e0225673 (use SendMessage with to: 'a4c582314e0225673' to continue this agent)\n<usage>total_tokens: 18694\ntool_uses: 2\nduration_ms: 2729</usage>",
+                  "type": "text"
+                }
+              ],
+              "tool_use_id": "toolu_01X1zCmGAowCxrH9vvrVvihb",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "timestamp": "2026-04-17T16:19:33.457Z",
+        "tool_use_result": {
+          "agentId": "a4c582314e0225673",
+          "agentType": "general-purpose",
+          "content": [
+            {
+              "text": "Here are the contents of task_c.txt:\n\n```\ntask_label=C\nowner=gamma\n```",
+              "type": "text"
+            }
+          ],
+          "prompt": "Run `echo bash-c-output` using Bash, then read the contents of task_c.txt using the Read tool. Return only the contents of task_c.txt file.",
+          "status": "completed",
+          "toolStats": {
+            "bashCount": 1,
+            "editFileCount": 0,
+            "linesAdded": 0,
+            "linesRemoved": 0,
+            "otherToolCount": 0,
+            "readCount": 1,
+            "searchCount": 0
+          },
+          "totalDurationMs": 2729,
+          "totalTokens": 18694,
+          "totalToolUseCount": 2,
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 1171
+            },
+            "cache_creation_input_tokens": 1171,
+            "cache_read_input_tokens": 17488,
+            "inference_geo": "",
+            "input_tokens": 7,
+            "iterations": [],
+            "output_tokens": 28,
+            "server_tool_use": {
+              "web_fetch_requests": 0,
+              "web_search_requests": 0
+            },
+            "service_tier": "standard",
+            "speed": "standard"
+          }
+        },
+        "type": "user",
+        "uuid": "47295a79-ae7f-48ea-b882-149e981829c1"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "output_file": "",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "status": "completed",
+        "subtype": "task_notification",
+        "summary": "Subagent B: bash and read task",
+        "task_id": "a9b2b0632eb62cc71",
+        "tool_use_id": "toolu_017yFZ6fdc1YuFQs2kazZJgT",
+        "type": "system",
+        "usage": {
+          "duration_ms": 3339,
+          "tool_uses": 2,
+          "total_tokens": 18679
+        },
+        "uuid": "a2fec2d0-9727-417c-82c1-db672b4ec667"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "Here are the contents of task_b.txt:\n\n```\ntask_label=B\nowner=beta\n```",
+                  "type": "text"
+                },
+                {
+                  "text": "agentId: a9b2b0632eb62cc71 (use SendMessage with to: 'a9b2b0632eb62cc71' to continue this agent)\n<usage>total_tokens: 18691\ntool_uses: 2\nduration_ms: 3340</usage>",
+                  "type": "text"
+                }
+              ],
+              "tool_use_id": "toolu_017yFZ6fdc1YuFQs2kazZJgT",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
+        "timestamp": "2026-04-17T16:19:33.772Z",
+        "tool_use_result": {
+          "agentId": "a9b2b0632eb62cc71",
+          "agentType": "general-purpose",
+          "content": [
+            {
+              "text": "Here are the contents of task_b.txt:\n\n```\ntask_label=B\nowner=beta\n```",
+              "type": "text"
+            }
+          ],
+          "prompt": "Run `echo bash-b-output` using Bash, then read the contents of task_b.txt using the Read tool. Return only the contents of task_b.txt file.",
+          "status": "completed",
+          "toolStats": {
+            "bashCount": 1,
+            "editFileCount": 0,
+            "linesAdded": 0,
+            "linesRemoved": 0,
+            "otherToolCount": 0,
+            "readCount": 1,
+            "searchCount": 0
+          },
+          "totalDurationMs": 3340,
+          "totalTokens": 18691,
+          "totalToolUseCount": 2,
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 1049
+            },
+            "cache_creation_input_tokens": 1049,
+            "cache_read_input_tokens": 17488,
+            "inference_geo": "",
+            "input_tokens": 126,
+            "iterations": [],
+            "output_tokens": 28,
+            "server_tool_use": {
+              "web_fetch_requests": 0,
+              "web_search_requests": 0
+            },
+            "service_tier": "standard",
+            "speed": "standard"
+          }
+        },
+        "type": "user",
+        "uuid": "17c7f72e-d6d7-4e3e-8063-11024486bf6e"
       }
     },
     {
@@ -1267,12 +1191,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "Perfect! All three subagents have completed their tasks and returned the file contents. Let me extract the results:\n\nSubagent A returned:\n```\ntask_label=A\nowner=alpha\n```\n\nSubagent B returned:\n```\ntask_label=B\nowner=beta\n```\n\nSubagent C returned:\n```\ntask_label=C\nowner=gamma\n```\n\nNow I need to reply with exactly three lines in order A, B, C:",
+              "thinking": "Great! All three subagents have completed their tasks and returned the file contents. Now I need to reply with exactly three lines in order A, B, C based on the contents they returned:\n\nSubagent A returned:\n```\ntask_label=A\nowner=alpha\n```\n\nSubagent B returned:\n```\ntask_label=B\nowner=beta\n```\n\nSubagent C returned:\n```\ntask_label=C\nowner=gamma\n```\n\nThe user asked me to reply with exactly three lines in order A, B, C. I should output the contents in the format they were returned.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01GLW892sGZ9t33keKVAhHKh",
+          "id": "msg_01AGQxjRLmcC9Hqqu1c9JKHy",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -1282,20 +1206,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 817
+              "ephemeral_5m_input_tokens": 801
             },
-            "cache_creation_input_tokens": 817,
+            "cache_creation_input_tokens": 801,
             "cache_read_input_tokens": 23360,
             "inference_geo": "not_available",
-            "input_tokens": 222,
+            "input_tokens": 135,
             "output_tokens": 8,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "type": "assistant",
-        "uuid": "0b257162-29e6-4690-954d-875bdd668f8e"
+        "uuid": "6b80d39e-fbe9-4792-abad-340816fadfed"
       }
     },
     {
@@ -1309,7 +1233,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01GLW892sGZ9t33keKVAhHKh",
+          "id": "msg_01AGQxjRLmcC9Hqqu1c9JKHy",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -1319,74 +1243,62 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 817
+              "ephemeral_5m_input_tokens": 801
             },
-            "cache_creation_input_tokens": 817,
+            "cache_creation_input_tokens": 801,
             "cache_read_input_tokens": 23360,
             "inference_geo": "not_available",
-            "input_tokens": 222,
+            "input_tokens": 135,
             "output_tokens": 8,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "type": "assistant",
-        "uuid": "21f50744-ebbd-42d0-b9b3-6c65ffa54b44"
+        "uuid": "4a2090e6-97fb-43cd-826d-49a92e02f699"
       }
     },
     {
       "op": "read",
       "payload": {
         "api_error_status": null,
-        "duration_api_ms": 16195,
-        "duration_ms": 9762,
+        "duration_api_ms": 14883,
+        "duration_ms": 8350,
         "fast_mode_state": "off",
         "is_error": false,
         "modelUsage": {
           "claude-haiku-4-5-20251001": {
-            "cacheCreationInputTokens": 9866,
-            "cacheReadInputTokens": 146000,
+            "cacheCreationInputTokens": 6644,
+            "cacheReadInputTokens": 149080,
             "contextWindow": 200000,
-            "costUSD": 0.0350125,
-            "inputTokens": 900,
+            "costUSD": 0.031020000000000002,
+            "inputTokens": 932,
             "maxOutputTokens": 32000,
-            "outputTokens": 1436,
+            "outputTokens": 1375,
             "webSearchRequests": 0
           }
         },
         "num_turns": 4,
         "permission_denials": [],
         "result": "task_label=A\nowner=alpha\n\ntask_label=B\nowner=beta\n\ntask_label=C\nowner=gamma",
-        "session_id": "a7834957-c3b0-4a17-b6c6-440a968c602d",
+        "session_id": "782217c5-8ba9-4977-a3cd-a8374cabb47c",
         "stop_reason": "end_turn",
         "subtype": "success",
         "terminal_reason": "completed",
-        "total_cost_usd": 0.0350125,
+        "total_cost_usd": 0.031020000000000002,
         "type": "result",
         "usage": {
           "cache_creation": {
             "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 2397
+            "ephemeral_5m_input_tokens": 801
           },
-          "cache_creation_input_tokens": 2397,
-          "cache_read_input_tokens": 45140,
+          "cache_creation_input_tokens": 801,
+          "cache_read_input_tokens": 46720,
           "inference_geo": "",
-          "input_tokens": 232,
-          "iterations": [
-            {
-              "cache_creation": {
-                "ephemeral_1h_input_tokens": 0,
-                "ephemeral_5m_input_tokens": 817
-              },
-              "cache_creation_input_tokens": 817,
-              "cache_read_input_tokens": 23360,
-              "input_tokens": 222,
-              "output_tokens": 147,
-              "type": "message"
-            }
-          ],
-          "output_tokens": 838,
+          "input_tokens": 145,
+          "iterations": [],
+          "output_tokens": 733,
           "server_tool_use": {
             "web_fetch_requests": 0,
             "web_search_requests": 0
@@ -1394,9 +1306,9 @@
           "service_tier": "standard",
           "speed": "standard"
         },
-        "uuid": "76412524-4dd0-43a7-9fa6-8bba2dfa52a6"
+        "uuid": "de70af4e-d73f-446c-9dc8-ce11dde0059e"
       }
     }
   ],
-  "sdk_version": "0.1.60"
+  "sdk_version": "0.1.61"
 }

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_five_parallel_bundled_subagents_preserve_task_parenting.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_five_parallel_bundled_subagents_preserve_task_parenting.json
@@ -10,7 +10,7 @@
             "hooks": null,
             "subtype": "initialize"
           },
-          "request_id": "req_1_77e40926",
+          "request_id": "req_1_91d7d787",
           "type": "control_request"
         }
       }
@@ -19,7 +19,7 @@
       "op": "read",
       "payload": {
         "response": {
-          "request_id": "req_1_77e40926",
+          "request_id": "req_1_91d7d787",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
@@ -61,7 +61,7 @@
           "statusline-setup"
         ],
         "apiKeySource": "ANTHROPIC_API_KEY",
-        "claude_code_version": "2.1.111",
+        "claude_code_version": "2.1.112",
         "cwd": "<REDACTED_CWD>",
         "fast_mode_state": "off",
         "mcp_servers": [],
@@ -78,7 +78,7 @@
             "source": "rust-analyzer-lsp@claude-plugins-official"
           }
         ],
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "skills": [
           "update-config",
           "debug",
@@ -144,7 +144,7 @@
           "Write"
         ],
         "type": "system",
-        "uuid": "7afd897d-4b30-4078-8d21-1890b76d9b59"
+        "uuid": "bae04ac7-6004-456f-bc5e-49f2475e1cda"
       }
     },
     {
@@ -154,12 +154,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The user wants me to:\n1. Use exactly five bundled general-purpose subagents\n2. Each subagent reads one file from note_0.txt through note_4.txt\n3. I need to make all five Agent tool calls before waiting for any results\n4. Each subagent should only do a Read on its assigned file and return label=<n> | owner=<owner>\n5. After all five finish, I should reply with exactly five lines in order 0 through 4\n6. Don't answer directly without using all five subagents\n\nLet me construct five Agent tool calls, each for a different note file.",
+              "thinking": "The user wants me to:\n1. Use exactly five bundled general-purpose subagents\n2. Each subagent should handle one file (note_0.txt through note_4.txt)\n3. In my first response, emit all five Agent tool calls before waiting for results\n4. No explanatory text before/between Agent tool calls\n5. Each subagent must Read exactly its assigned file and return \"label=<n> | owner=<owner>\"\n6. After all five finish, reply with exactly five lines in order 0 through 4\n7. Don't answer directly without using all five subagents\n\nSo I need to create 5 Agent calls, each for a different file, without any explanatory text between them.\n\nLet me construct these calls:\n- Agent for note_0.txt\n- Agent for note_1.txt\n- Agent for note_2.txt\n- Agent for note_3.txt\n- Agent for note_4.txt\n\nEach should read its file and return \"label=<n> | owner=<owner>\"",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01E3W2cpbLjAxz8Dq75c2Xqw",
+          "id": "msg_013aFvnR3FXXSHHDaKAELGAq",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -169,10 +169,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 0
+              "ephemeral_5m_input_tokens": 1528
             },
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 23308,
+            "cache_creation_input_tokens": 1528,
+            "cache_read_input_tokens": 21780,
             "inference_geo": "not_available",
             "input_tokens": 10,
             "output_tokens": 6,
@@ -180,9 +180,9 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "type": "assistant",
-        "uuid": "89818f62-4068-4017-a5c5-173c6fa45115"
+        "uuid": "fb63d87f-5fab-4e2e-86ea-c66f29cf562b"
       }
     },
     {
@@ -194,17 +194,17 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01WKMicrUQAX3VsnYsMSWauL",
+              "id": "toolu_01TeP8MLQnQwJKTJVPSEAf4e",
               "input": {
-                "description": "Process note_0.txt and extract label and owner",
-                "prompt": "Read note_0.txt and return only label=<n> | owner=<owner>. Do not include any other text."
+                "description": "Read note_0.txt and report",
+                "prompt": "Read the file note_0.txt using the Read tool. Extract the label number and owner name. Return only in format: label=0 | owner=<owner_name>"
               },
               "name": "Agent",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01E3W2cpbLjAxz8Dq75c2Xqw",
+          "id": "msg_013aFvnR3FXXSHHDaKAELGAq",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -214,10 +214,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 0
+              "ephemeral_5m_input_tokens": 1528
             },
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 23308,
+            "cache_creation_input_tokens": 1528,
+            "cache_read_input_tokens": 21780,
             "inference_geo": "not_available",
             "input_tokens": 10,
             "output_tokens": 6,
@@ -225,23 +225,23 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "type": "assistant",
-        "uuid": "fa59243a-21a2-4258-b0d9-d94e98733cad"
+        "uuid": "8650b5d5-0df9-4189-bc08-248b27498d1e"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Process note_0.txt and extract label and owner",
-        "prompt": "Read note_0.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "description": "Read note_0.txt and report",
+        "prompt": "Read the file note_0.txt using the Read tool. Extract the label number and owner name. Return only in format: label=0 | owner=<owner_name>",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "subtype": "task_started",
-        "task_id": "ad640a7440d17f641",
+        "task_id": "a6e681864955f6978",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01WKMicrUQAX3VsnYsMSWauL",
+        "tool_use_id": "toolu_01TeP8MLQnQwJKTJVPSEAf4e",
         "type": "system",
-        "uuid": "3f6f17ba-8889-4b8f-ba15-b56021663262"
+        "uuid": "d5608d22-b333-4e7f-8184-097d7cc198d5"
       }
     },
     {
@@ -250,17 +250,17 @@
         "message": {
           "content": [
             {
-              "text": "Read note_0.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
+              "text": "Read the file note_0.txt using the Read tool. Extract the label number and owner name. Return only in format: label=0 | owner=<owner_name>",
               "type": "text"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01WKMicrUQAX3VsnYsMSWauL",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:12.216Z",
+        "parent_tool_use_id": "toolu_01TeP8MLQnQwJKTJVPSEAf4e",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:00.976Z",
         "type": "user",
-        "uuid": "417b6c64-c04a-4f0a-b861-81eb51b6b5c7"
+        "uuid": "498cae38-e3f9-446b-b7f1-56989c5e4200"
       }
     },
     {
@@ -272,17 +272,17 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01Qro41aL9iA5NwY63FnsAHR",
+              "id": "toolu_01LRALL7Qjhsca9dZwRy2M4d",
               "input": {
-                "description": "Process note_1.txt and extract label and owner",
-                "prompt": "Read note_1.txt and return only label=<n> | owner=<owner>. Do not include any other text."
+                "description": "Read note_1.txt and report",
+                "prompt": "Read the file note_1.txt using the Read tool. Extract the label number and owner name. Return only in format: label=1 | owner=<owner_name>"
               },
               "name": "Agent",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01E3W2cpbLjAxz8Dq75c2Xqw",
+          "id": "msg_013aFvnR3FXXSHHDaKAELGAq",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -292,10 +292,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 0
+              "ephemeral_5m_input_tokens": 1528
             },
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 23308,
+            "cache_creation_input_tokens": 1528,
+            "cache_read_input_tokens": 21780,
             "inference_geo": "not_available",
             "input_tokens": 10,
             "output_tokens": 6,
@@ -303,23 +303,23 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "type": "assistant",
-        "uuid": "9b993f80-9f4e-450d-99d8-c602216d39a5"
+        "uuid": "4ac9d3cd-8e7d-4f01-9feb-e9e308d3a26d"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Process note_1.txt and extract label and owner",
-        "prompt": "Read note_1.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "description": "Read note_1.txt and report",
+        "prompt": "Read the file note_1.txt using the Read tool. Extract the label number and owner name. Return only in format: label=1 | owner=<owner_name>",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "subtype": "task_started",
-        "task_id": "a034f7e6a8e37791a",
+        "task_id": "ab3b561a9904c4e1b",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01Qro41aL9iA5NwY63FnsAHR",
+        "tool_use_id": "toolu_01LRALL7Qjhsca9dZwRy2M4d",
         "type": "system",
-        "uuid": "36878af6-e653-4eb4-82c9-48a6bbfaa3a9"
+        "uuid": "cb8f2806-f31e-4678-a5f1-4d9f8acaa1c7"
       }
     },
     {
@@ -328,17 +328,17 @@
         "message": {
           "content": [
             {
-              "text": "Read note_1.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
+              "text": "Read the file note_1.txt using the Read tool. Extract the label number and owner name. Return only in format: label=1 | owner=<owner_name>",
               "type": "text"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01Qro41aL9iA5NwY63FnsAHR",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:12.277Z",
+        "parent_tool_use_id": "toolu_01LRALL7Qjhsca9dZwRy2M4d",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:01.615Z",
         "type": "user",
-        "uuid": "ed32679c-39c9-49a2-be5a-1e30c5d42c2d"
+        "uuid": "5fe0f3c8-5e3d-4ef7-aa49-c2513bc47d66"
       }
     },
     {
@@ -350,17 +350,17 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01CohiSJACWPsGHRBVBBMWfA",
+              "id": "toolu_0162aayLJZWexA4TA79vwo9p",
               "input": {
-                "description": "Process note_2.txt and extract label and owner",
-                "prompt": "Read note_2.txt and return only label=<n> | owner=<owner>. Do not include any other text."
+                "description": "Read note_2.txt and report",
+                "prompt": "Read the file note_2.txt using the Read tool. Extract the label number and owner name. Return only in format: label=2 | owner=<owner_name>"
               },
               "name": "Agent",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01E3W2cpbLjAxz8Dq75c2Xqw",
+          "id": "msg_013aFvnR3FXXSHHDaKAELGAq",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -370,10 +370,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 0
+              "ephemeral_5m_input_tokens": 1528
             },
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 23308,
+            "cache_creation_input_tokens": 1528,
+            "cache_read_input_tokens": 21780,
             "inference_geo": "not_available",
             "input_tokens": 10,
             "output_tokens": 6,
@@ -381,23 +381,23 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "type": "assistant",
-        "uuid": "6bfd6c4a-45fa-479c-9899-98b8343682d0"
+        "uuid": "2b41b12f-a840-48f0-85fd-b0054ca2a0d4"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Process note_2.txt and extract label and owner",
-        "prompt": "Read note_2.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "description": "Read note_2.txt and report",
+        "prompt": "Read the file note_2.txt using the Read tool. Extract the label number and owner name. Return only in format: label=2 | owner=<owner_name>",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "subtype": "task_started",
-        "task_id": "a1064b1c87bb5b847",
+        "task_id": "a22734fb2ae496167",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01CohiSJACWPsGHRBVBBMWfA",
+        "tool_use_id": "toolu_0162aayLJZWexA4TA79vwo9p",
         "type": "system",
-        "uuid": "ab9df761-ddf2-4c51-9df5-a686053a1a3b"
+        "uuid": "eef4bc0d-d2c2-4013-9aa1-223935c664f7"
       }
     },
     {
@@ -406,17 +406,17 @@
         "message": {
           "content": [
             {
-              "text": "Read note_2.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
+              "text": "Read the file note_2.txt using the Read tool. Extract the label number and owner name. Return only in format: label=2 | owner=<owner_name>",
               "type": "text"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01CohiSJACWPsGHRBVBBMWfA",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:12.516Z",
+        "parent_tool_use_id": "toolu_0162aayLJZWexA4TA79vwo9p",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:02.115Z",
         "type": "user",
-        "uuid": "53d1456b-fd03-4276-a3b9-33d5a7b1f5df"
+        "uuid": "46a578dd-a263-4f0b-b3a5-53a3b7bebf77"
       }
     },
     {
@@ -428,17 +428,17 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01RJqjfcgN1DUpGtAgEY9oa9",
+              "id": "toolu_01EVtW8C54Q54ATbmPyrnTkQ",
               "input": {
-                "description": "Process note_3.txt and extract label and owner",
-                "prompt": "Read note_3.txt and return only label=<n> | owner=<owner>. Do not include any other text."
+                "description": "Read note_3.txt and report",
+                "prompt": "Read the file note_3.txt using the Read tool. Extract the label number and owner name. Return only in format: label=3 | owner=<owner_name>"
               },
               "name": "Agent",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01E3W2cpbLjAxz8Dq75c2Xqw",
+          "id": "msg_013aFvnR3FXXSHHDaKAELGAq",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -448,10 +448,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 0
+              "ephemeral_5m_input_tokens": 1528
             },
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 23308,
+            "cache_creation_input_tokens": 1528,
+            "cache_read_input_tokens": 21780,
             "inference_geo": "not_available",
             "input_tokens": 10,
             "output_tokens": 6,
@@ -459,23 +459,23 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "type": "assistant",
-        "uuid": "d599a905-4dbc-41e6-ad86-6ead6c772c7f"
+        "uuid": "189f185e-97c9-4c68-bffc-ae0752c32cd7"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Process note_3.txt and extract label and owner",
-        "prompt": "Read note_3.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "description": "Read note_3.txt and report",
+        "prompt": "Read the file note_3.txt using the Read tool. Extract the label number and owner name. Return only in format: label=3 | owner=<owner_name>",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "subtype": "task_started",
-        "task_id": "ac9f57f48110b4896",
+        "task_id": "a75fbc8a882d8b035",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01RJqjfcgN1DUpGtAgEY9oa9",
+        "tool_use_id": "toolu_01EVtW8C54Q54ATbmPyrnTkQ",
         "type": "system",
-        "uuid": "f827c531-945d-4bf5-97e7-9efe8a2c8c28"
+        "uuid": "d41d7ba5-6e2e-410a-846c-493ff5f04356"
       }
     },
     {
@@ -484,17 +484,17 @@
         "message": {
           "content": [
             {
-              "text": "Read note_3.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
+              "text": "Read the file note_3.txt using the Read tool. Extract the label number and owner name. Return only in format: label=3 | owner=<owner_name>",
               "type": "text"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01RJqjfcgN1DUpGtAgEY9oa9",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:12.898Z",
+        "parent_tool_use_id": "toolu_01EVtW8C54Q54ATbmPyrnTkQ",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:02.170Z",
         "type": "user",
-        "uuid": "79d7eb8e-0eee-4c45-84ba-8359ef280517"
+        "uuid": "a3323b62-4eb2-4d53-b3ec-1ca694f5a3b0"
       }
     },
     {
@@ -506,17 +506,17 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01Ax9ZKLVW4dqdr2fEAWKT4J",
+              "id": "toolu_01DUg1LJYUx5RsfcHwE2xikm",
               "input": {
-                "description": "Process note_4.txt and extract label and owner",
-                "prompt": "Read note_4.txt and return only label=<n> | owner=<owner>. Do not include any other text."
+                "description": "Read note_4.txt and report",
+                "prompt": "Read the file note_4.txt using the Read tool. Extract the label number and owner name. Return only in format: label=4 | owner=<owner_name>"
               },
               "name": "Agent",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01E3W2cpbLjAxz8Dq75c2Xqw",
+          "id": "msg_013aFvnR3FXXSHHDaKAELGAq",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -526,10 +526,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 0
+              "ephemeral_5m_input_tokens": 1528
             },
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 23308,
+            "cache_creation_input_tokens": 1528,
+            "cache_read_input_tokens": 21780,
             "inference_geo": "not_available",
             "input_tokens": 10,
             "output_tokens": 6,
@@ -537,23 +537,23 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "type": "assistant",
-        "uuid": "81d9810b-e034-4e0e-83cf-bf08e968d45d"
+        "uuid": "016c649c-1183-4519-974d-c7895fa69859"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Process note_4.txt and extract label and owner",
-        "prompt": "Read note_4.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "description": "Read note_4.txt and report",
+        "prompt": "Read the file note_4.txt using the Read tool. Extract the label number and owner name. Return only in format: label=4 | owner=<owner_name>",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "subtype": "task_started",
-        "task_id": "a8aca87b86939fe8e",
+        "task_id": "ad0cb35dc9dfeb8df",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01Ax9ZKLVW4dqdr2fEAWKT4J",
+        "tool_use_id": "toolu_01DUg1LJYUx5RsfcHwE2xikm",
         "type": "system",
-        "uuid": "1c4ab8df-6d25-474d-a58b-eeca26ecc8c6"
+        "uuid": "aaf59eca-8e6f-4223-810b-2e07b89bf1e6"
       }
     },
     {
@@ -562,17 +562,17 @@
         "message": {
           "content": [
             {
-              "text": "Read note_4.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
+              "text": "Read the file note_4.txt using the Read tool. Extract the label number and owner name. Return only in format: label=4 | owner=<owner_name>",
               "type": "text"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01Ax9ZKLVW4dqdr2fEAWKT4J",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:13.086Z",
+        "parent_tool_use_id": "toolu_01DUg1LJYUx5RsfcHwE2xikm",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:02.365Z",
         "type": "user",
-        "uuid": "63f00218-77f1-437c-be51-bac1c8d4a4c3"
+        "uuid": "5f556bde-1ad6-4d29-909b-facb10a9adc1"
       }
     },
     {
@@ -580,17 +580,17 @@
       "payload": {
         "description": "Reading note_0.txt",
         "last_tool_name": "Read",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "subtype": "task_progress",
-        "task_id": "ad640a7440d17f641",
-        "tool_use_id": "toolu_01WKMicrUQAX3VsnYsMSWauL",
+        "task_id": "a6e681864955f6978",
+        "tool_use_id": "toolu_01TeP8MLQnQwJKTJVPSEAf4e",
         "type": "system",
         "usage": {
-          "duration_ms": 1345,
+          "duration_ms": 1883,
           "tool_uses": 1,
-          "total_tokens": 17544
+          "total_tokens": 17497
         },
-        "uuid": "d4142b86-b135-46d6-b798-56a02c4f9f97"
+        "uuid": "adde3e23-b692-4699-9320-4065d39dcaa3"
       }
     },
     {
@@ -602,16 +602,16 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_011ThrP7mxxzGYU527hXp458",
+              "id": "toolu_01J528X9G7SfotN8LJmvQJpg",
               "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_five_parallel_bundled_sub0/subagent_parenting_workspace/note_0.txt"
+                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-578/test_five_parallel_bundled_sub0/subagent_parenting_workspace/note_0.txt"
               },
               "name": "Read",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_0186VDwwsjP6ZUuyua31K5ve",
+          "id": "msg_01H5VCscagBnjPA3Xkh3du44",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -621,20 +621,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1055
+              "ephemeral_5m_input_tokens": 1065
             },
-            "cache_creation_input_tokens": 1055,
+            "cache_creation_input_tokens": 1065,
             "cache_read_input_tokens": 16423,
             "inference_geo": "not_available",
             "input_tokens": 3,
-            "output_tokens": 63,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01WKMicrUQAX3VsnYsMSWauL",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "parent_tool_use_id": "toolu_01TeP8MLQnQwJKTJVPSEAf4e",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "type": "assistant",
-        "uuid": "bb423b16-5c42-4599-a17e-a4ad8d6a00d9"
+        "uuid": "9be35935-e281-4dae-9e6c-bc90bbbfc6b8"
       }
     },
     {
@@ -644,35 +644,35 @@
           "content": [
             {
               "content": "1\tlabel=0\n2\towner=owner_0\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_011ThrP7mxxzGYU527hXp458",
+              "tool_use_id": "toolu_01J528X9G7SfotN8LJmvQJpg",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01WKMicrUQAX3VsnYsMSWauL",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:13.571Z",
+        "parent_tool_use_id": "toolu_01TeP8MLQnQwJKTJVPSEAf4e",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:02.861Z",
         "type": "user",
-        "uuid": "8eb28185-553c-4bf7-9fa7-d37f5310ae7e"
+        "uuid": "c0771e78-38b9-485e-bb4a-0b77b51a77f3"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Reading note_1.txt",
+        "description": "Reading note_2.txt",
         "last_tool_name": "Read",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "subtype": "task_progress",
-        "task_id": "a034f7e6a8e37791a",
-        "tool_use_id": "toolu_01Qro41aL9iA5NwY63FnsAHR",
+        "task_id": "a22734fb2ae496167",
+        "tool_use_id": "toolu_0162aayLJZWexA4TA79vwo9p",
         "type": "system",
         "usage": {
           "duration_ms": 1350,
           "tool_uses": 1,
-          "total_tokens": 17483
+          "total_tokens": 17507
         },
-        "uuid": "0c32e14e-47d8-4db7-ad42-6517a5646f3a"
+        "uuid": "56663127-4e63-419f-ae89-d1bbf3dd7b37"
       }
     },
     {
@@ -684,16 +684,16 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_016f1NE7yTwvwk221Y3fYTSo",
+              "id": "toolu_01TKjmdXGjziXtsMTeKTKQEV",
               "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_five_parallel_bundled_sub0/subagent_parenting_workspace/note_1.txt"
+                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-578/test_five_parallel_bundled_sub0/subagent_parenting_workspace/note_2.txt"
               },
               "name": "Read",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01DJQzVusLK3usXsq1V342Vg",
+          "id": "msg_01H7J85B5DG3eibFAa2yPWvi",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -703,58 +703,38 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1055
+              "ephemeral_5m_input_tokens": 436
             },
-            "cache_creation_input_tokens": 1055,
-            "cache_read_input_tokens": 16423,
+            "cache_creation_input_tokens": 436,
+            "cache_read_input_tokens": 17052,
             "inference_geo": "not_available",
             "input_tokens": 3,
-            "output_tokens": 1,
+            "output_tokens": 8,
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01Qro41aL9iA5NwY63FnsAHR",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "parent_tool_use_id": "toolu_0162aayLJZWexA4TA79vwo9p",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "type": "assistant",
-        "uuid": "43419291-04df-43a4-9b5b-23180f704086"
+        "uuid": "311b2759-75e2-4527-ad8e-d24a711d3c55"
       }
     },
     {
       "op": "read",
       "payload": {
-        "message": {
-          "content": [
-            {
-              "content": "1\tlabel=1\n2\towner=owner_1\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_016f1NE7yTwvwk221Y3fYTSo",
-              "type": "tool_result"
-            }
-          ],
-          "role": "user"
-        },
-        "parent_tool_use_id": "toolu_01Qro41aL9iA5NwY63FnsAHR",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:13.629Z",
-        "type": "user",
-        "uuid": "774db6e0-4913-4af2-92c3-f407d5cc1f62"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "description": "Running find /private/var/folders/1r/0r49yqc973s87vl4n1x_\u2026",
-        "last_tool_name": "Bash",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "description": "Reading note_3.txt",
+        "last_tool_name": "Read",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "subtype": "task_progress",
-        "task_id": "a1064b1c87bb5b847",
-        "tool_use_id": "toolu_01CohiSJACWPsGHRBVBBMWfA",
+        "task_id": "a75fbc8a882d8b035",
+        "tool_use_id": "toolu_01EVtW8C54Q54ATbmPyrnTkQ",
         "type": "system",
         "usage": {
-          "duration_ms": 1568,
+          "duration_ms": 1295,
           "tool_uses": 1,
-          "total_tokens": 17483
+          "total_tokens": 17507
         },
-        "uuid": "06bc540b-05d6-42e1-b109-f77b6c455b96"
+        "uuid": "0d48cda9-de46-4d69-b251-ad62eb1f87f0"
       }
     },
     {
@@ -766,16 +746,16 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01JUH8CmMtronyjBbXZ4RMZ7",
+              "id": "toolu_01Po3tYPjK83X2UzsWK3qEbT",
               "input": {
-                "command": "find /private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_five_parallel_bundled_sub0/subagent_parenting_workspace -name \"note_2.txt\" -type f"
+                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-578/test_five_parallel_bundled_sub0/subagent_parenting_workspace/note_3.txt"
               },
-              "name": "Bash",
+              "name": "Read",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01VUVoMeKbqUEMThmi5D2ACP",
+          "id": "msg_019tuAu4w3hKkkQbmqw2CcQ7",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -785,20 +765,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1055
+              "ephemeral_5m_input_tokens": 436
             },
-            "cache_creation_input_tokens": 1055,
-            "cache_read_input_tokens": 16423,
+            "cache_creation_input_tokens": 436,
+            "cache_read_input_tokens": 17052,
             "inference_geo": "not_available",
             "input_tokens": 3,
-            "output_tokens": 1,
+            "output_tokens": 8,
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01CohiSJACWPsGHRBVBBMWfA",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "parent_tool_use_id": "toolu_01EVtW8C54Q54ATbmPyrnTkQ",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "type": "assistant",
-        "uuid": "3da6acba-41bf-44eb-bb80-4488ce3e5cc8"
+        "uuid": "f27a7eb8-18d8-463f-af35-0bfccda0d85a"
       }
     },
     {
@@ -807,38 +787,139 @@
         "message": {
           "content": [
             {
-              "content": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_five_parallel_bundled_sub0/subagent_parenting_workspace/note_2.txt",
-              "is_error": false,
-              "tool_use_id": "toolu_01JUH8CmMtronyjBbXZ4RMZ7",
+              "content": "1\tlabel=2\n2\towner=owner_2\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
+              "tool_use_id": "toolu_01TKjmdXGjziXtsMTeKTKQEV",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01CohiSJACWPsGHRBVBBMWfA",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:14.312Z",
+        "parent_tool_use_id": "toolu_0162aayLJZWexA4TA79vwo9p",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:03.467Z",
         "type": "user",
-        "uuid": "962d2984-f93d-4e35-924d-f71b1090fd6d"
+        "uuid": "89b4c080-6910-4ae3-b76a-c79565c8c206"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": "1\tlabel=3\n2\towner=owner_3\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
+              "tool_use_id": "toolu_01Po3tYPjK83X2UzsWK3qEbT",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": "toolu_01EVtW8C54Q54ATbmPyrnTkQ",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:03.467Z",
+        "type": "user",
+        "uuid": "98e2c642-a192-4db3-9650-081d14de3e2d"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "description": "Reading note_4.txt",
+        "last_tool_name": "Read",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "subtype": "task_progress",
+        "task_id": "ad0cb35dc9dfeb8df",
+        "tool_use_id": "toolu_01DUg1LJYUx5RsfcHwE2xikm",
+        "type": "system",
+        "usage": {
+          "duration_ms": 1230,
+          "tool_uses": 1,
+          "total_tokens": 17507
+        },
+        "uuid": "6378acaa-d943-4bcc-a54c-cf05d8312be3"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "caller": {
+                "type": "direct"
+              },
+              "id": "toolu_017WTKvbCRaNiza3N1XcPXQb",
+              "input": {
+                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-578/test_five_parallel_bundled_sub0/subagent_parenting_workspace/note_4.txt"
+              },
+              "name": "Read",
+              "type": "tool_use"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_011jZamKAkKgDNk3cEqDbn5R",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 436
+            },
+            "cache_creation_input_tokens": 436,
+            "cache_read_input_tokens": 17052,
+            "inference_geo": "not_available",
+            "input_tokens": 3,
+            "output_tokens": 8,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": "toolu_01DUg1LJYUx5RsfcHwE2xikm",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "type": "assistant",
+        "uuid": "999eaaf6-7b9b-4e2e-adf6-2a2ac6194b5f"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": "1\tlabel=4\n2\towner=owner_4\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
+              "tool_use_id": "toolu_017WTKvbCRaNiza3N1XcPXQb",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": "toolu_01DUg1LJYUx5RsfcHwE2xikm",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:03.597Z",
+        "type": "user",
+        "uuid": "55606e66-dc05-4389-9956-1e9966e460fa"
       }
     },
     {
       "op": "read",
       "payload": {
         "output_file": "",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "status": "completed",
         "subtype": "task_notification",
-        "summary": "Process note_0.txt and extract label and owner",
-        "task_id": "ad640a7440d17f641",
-        "tool_use_id": "toolu_01WKMicrUQAX3VsnYsMSWauL",
+        "summary": "Read note_0.txt and report",
+        "task_id": "a6e681864955f6978",
+        "tool_use_id": "toolu_01TeP8MLQnQwJKTJVPSEAf4e",
         "type": "system",
         "usage": {
-          "duration_ms": 2186,
+          "duration_ms": 2641,
           "tool_uses": 1,
-          "total_tokens": 18612
+          "total_tokens": 18578
         },
-        "uuid": "01de3323-5910-455a-9917-9b12dd87dba6"
+        "uuid": "04598806-8fcc-40cb-b761-fc005cb32172"
       }
     },
     {
@@ -853,21 +934,21 @@
                   "type": "text"
                 },
                 {
-                  "text": "agentId: ad640a7440d17f641 (use SendMessage with to: 'ad640a7440d17f641' to continue this agent)\n<usage>total_tokens: 18561\ntool_uses: 1\nduration_ms: 2190</usage>",
+                  "text": "agentId: a6e681864955f6978 (use SendMessage with to: 'a6e681864955f6978' to continue this agent)\n<usage>total_tokens: 18584\ntool_uses: 1\nduration_ms: 2642</usage>",
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01WKMicrUQAX3VsnYsMSWauL",
+              "tool_use_id": "toolu_01TeP8MLQnQwJKTJVPSEAf4e",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:14.403Z",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:03.617Z",
         "tool_use_result": {
-          "agentId": "ad640a7440d17f641",
+          "agentId": "a6e681864955f6978",
           "agentType": "general-purpose",
           "content": [
             {
@@ -875,7 +956,7 @@
               "type": "text"
             }
           ],
-          "prompt": "Read note_0.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
+          "prompt": "Read the file note_0.txt using the Read tool. Extract the label number and owner name. Return only in format: label=0 | owner=<owner_name>",
           "status": "completed",
           "toolStats": {
             "bashCount": 0,
@@ -886,492 +967,131 @@
             "readCount": 1,
             "searchCount": 0
           },
-          "totalDurationMs": 2190,
-          "totalTokens": 18561,
+          "totalDurationMs": 2642,
+          "totalTokens": 18584,
           "totalToolUseCount": 1,
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 2143
+            },
+            "cache_creation_input_tokens": 2143,
+            "cache_read_input_tokens": 16423,
+            "inference_geo": "",
+            "input_tokens": 5,
+            "iterations": [],
+            "output_tokens": 13,
+            "server_tool_use": {
+              "web_fetch_requests": 0,
+              "web_search_requests": 0
+            },
+            "service_tier": "standard",
+            "speed": "standard"
+          }
+        },
+        "type": "user",
+        "uuid": "e2d36bdf-e8bb-4b3e-b378-2264b3cd98b6"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "description": "Reading note_1.txt",
+        "last_tool_name": "Read",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "subtype": "task_progress",
+        "task_id": "ab3b561a9904c4e1b",
+        "tool_use_id": "toolu_01LRALL7Qjhsca9dZwRy2M4d",
+        "type": "system",
+        "usage": {
+          "duration_ms": 2256,
+          "tool_uses": 1,
+          "total_tokens": 17497
+        },
+        "uuid": "704817c2-b81d-4791-91f1-1c1a93dc763c"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "caller": {
+                "type": "direct"
+              },
+              "id": "toolu_01LmJtc9JTaWka4opDK9svCs",
+              "input": {
+                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-578/test_five_parallel_bundled_sub0/subagent_parenting_workspace/note_1.txt"
+              },
+              "name": "Read",
+              "type": "tool_use"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01PGQUg79viKLX82tgncZdEz",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
               "ephemeral_5m_input_tokens": 1065
             },
             "cache_creation_input_tokens": 1065,
-            "cache_read_input_tokens": 17478,
-            "inference_geo": "",
-            "input_tokens": 5,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 1065
-                },
-                "cache_creation_input_tokens": 1065,
-                "cache_read_input_tokens": 17478,
-                "input_tokens": 5,
-                "output_tokens": 13,
-                "type": "message"
-              }
-            ],
-            "output_tokens": 13,
-            "server_tool_use": {
-              "web_fetch_requests": 0,
-              "web_search_requests": 0
-            },
-            "service_tier": "standard",
-            "speed": "standard"
+            "cache_read_input_tokens": 16423,
+            "inference_geo": "not_available",
+            "input_tokens": 3,
+            "output_tokens": 3,
+            "service_tier": "standard"
           }
         },
+        "parent_tool_use_id": "toolu_01LRALL7Qjhsca9dZwRy2M4d",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "type": "assistant",
+        "uuid": "59eb9a7a-3118-44e2-bee4-8255e4a69e22"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": "1\tlabel=1\n2\towner=owner_1\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
+              "tool_use_id": "toolu_01LmJtc9JTaWka4opDK9svCs",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": "toolu_01LRALL7Qjhsca9dZwRy2M4d",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:03.873Z",
         "type": "user",
-        "uuid": "a25b508a-b7c9-4531-8f69-5c9aa7a69143"
+        "uuid": "a1cd55be-6d92-4e2f-9c91-ab990b60ee3f"
       }
     },
     {
       "op": "read",
       "payload": {
         "output_file": "",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "status": "completed",
         "subtype": "task_notification",
-        "summary": "Process note_1.txt and extract label and owner",
-        "task_id": "a034f7e6a8e37791a",
-        "tool_use_id": "toolu_01Qro41aL9iA5NwY63FnsAHR",
+        "summary": "Read note_3.txt and report",
+        "task_id": "a75fbc8a882d8b035",
+        "tool_use_id": "toolu_01EVtW8C54Q54ATbmPyrnTkQ",
         "type": "system",
         "usage": {
-          "duration_ms": 2392,
+          "duration_ms": 2233,
           "tool_uses": 1,
-          "total_tokens": 18569
+          "total_tokens": 18588
         },
-        "uuid": "3384ddff-0630-4d94-9494-c75458a32d27"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "content": [
-                {
-                  "text": "label=1 | owner=owner_1",
-                  "type": "text"
-                },
-                {
-                  "text": "agentId: a034f7e6a8e37791a (use SendMessage with to: 'a034f7e6a8e37791a' to continue this agent)\n<usage>total_tokens: 18579\ntool_uses: 1\nduration_ms: 2393</usage>",
-                  "type": "text"
-                }
-              ],
-              "tool_use_id": "toolu_01Qro41aL9iA5NwY63FnsAHR",
-              "type": "tool_result"
-            }
-          ],
-          "role": "user"
-        },
-        "parent_tool_use_id": null,
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:14.669Z",
-        "tool_use_result": {
-          "agentId": "a034f7e6a8e37791a",
-          "agentType": "general-purpose",
-          "content": [
-            {
-              "text": "label=1 | owner=owner_1",
-              "type": "text"
-            }
-          ],
-          "prompt": "Read note_1.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
-          "status": "completed",
-          "toolStats": {
-            "bashCount": 0,
-            "editFileCount": 0,
-            "linesAdded": 0,
-            "linesRemoved": 0,
-            "otherToolCount": 0,
-            "readCount": 1,
-            "searchCount": 0
-          },
-          "totalDurationMs": 2393,
-          "totalTokens": 18579,
-          "totalToolUseCount": 1,
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1509
-            },
-            "cache_creation_input_tokens": 1509,
-            "cache_read_input_tokens": 17052,
-            "inference_geo": "",
-            "input_tokens": 5,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 1509
-                },
-                "cache_creation_input_tokens": 1509,
-                "cache_read_input_tokens": 17052,
-                "input_tokens": 5,
-                "output_tokens": 13,
-                "type": "message"
-              }
-            ],
-            "output_tokens": 13,
-            "server_tool_use": {
-              "web_fetch_requests": 0,
-              "web_search_requests": 0
-            },
-            "service_tier": "standard",
-            "speed": "standard"
-          }
-        },
-        "type": "user",
-        "uuid": "752336c4-7f8a-436f-bdbc-6a4bbde1f075"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "description": "Running find /private/var/folders/1r/0r49yqc973s87vl4n1x_\u2026",
-        "last_tool_name": "Bash",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "subtype": "task_progress",
-        "task_id": "a8aca87b86939fe8e",
-        "tool_use_id": "toolu_01Ax9ZKLVW4dqdr2fEAWKT4J",
-        "type": "system",
-        "usage": {
-          "duration_ms": 1584,
-          "tool_uses": 1,
-          "total_tokens": 17483
-        },
-        "uuid": "b04888e3-4799-40bd-8c6d-1cc698cc15f7"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "caller": {
-                "type": "direct"
-              },
-              "id": "toolu_01RdEdN8H6VZpq87fJqnA2T4",
-              "input": {
-                "command": "find /private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_five_parallel_bundled_sub0/subagent_parenting_workspace -name \"note_4.txt\" -type f"
-              },
-              "name": "Bash",
-              "type": "tool_use"
-            }
-          ],
-          "context_management": null,
-          "id": "msg_01Pdxo8dm2JGCYmD8zNbN9VA",
-          "model": "claude-haiku-4-5-20251001",
-          "role": "assistant",
-          "stop_details": null,
-          "stop_reason": null,
-          "stop_sequence": null,
-          "type": "message",
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 426
-            },
-            "cache_creation_input_tokens": 426,
-            "cache_read_input_tokens": 17052,
-            "inference_geo": "not_available",
-            "input_tokens": 3,
-            "output_tokens": 1,
-            "service_tier": "standard"
-          }
-        },
-        "parent_tool_use_id": "toolu_01Ax9ZKLVW4dqdr2fEAWKT4J",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "type": "assistant",
-        "uuid": "4e91ad62-427f-4418-8d05-a4d9f9b4029f"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "content": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_five_parallel_bundled_sub0/subagent_parenting_workspace/note_4.txt",
-              "is_error": false,
-              "tool_use_id": "toolu_01RdEdN8H6VZpq87fJqnA2T4",
-              "type": "tool_result"
-            }
-          ],
-          "role": "user"
-        },
-        "parent_tool_use_id": "toolu_01Ax9ZKLVW4dqdr2fEAWKT4J",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:14.690Z",
-        "type": "user",
-        "uuid": "104284f4-dc00-4666-9ea4-c627fc892ba0"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "description": "Reading note_3.txt",
-        "last_tool_name": "Read",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "subtype": "task_progress",
-        "task_id": "ac9f57f48110b4896",
-        "tool_use_id": "toolu_01RJqjfcgN1DUpGtAgEY9oa9",
-        "type": "system",
-        "usage": {
-          "duration_ms": 2235,
-          "tool_uses": 1,
-          "total_tokens": 17483
-        },
-        "uuid": "f5731768-afe3-4c29-b524-8cf2f7238adf"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "caller": {
-                "type": "direct"
-              },
-              "id": "toolu_01PD2QqGJwdtwgrdJuJQ731V",
-              "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_five_parallel_bundled_sub0/subagent_parenting_workspace/note_3.txt"
-              },
-              "name": "Read",
-              "type": "tool_use"
-            }
-          ],
-          "context_management": null,
-          "id": "msg_015zMVWGudGX8z5LXtVthepY",
-          "model": "claude-haiku-4-5-20251001",
-          "role": "assistant",
-          "stop_details": null,
-          "stop_reason": null,
-          "stop_sequence": null,
-          "type": "message",
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 426
-            },
-            "cache_creation_input_tokens": 426,
-            "cache_read_input_tokens": 17052,
-            "inference_geo": "not_available",
-            "input_tokens": 3,
-            "output_tokens": 1,
-            "service_tier": "standard"
-          }
-        },
-        "parent_tool_use_id": "toolu_01RJqjfcgN1DUpGtAgEY9oa9",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "type": "assistant",
-        "uuid": "dddc4bc3-abd9-4168-828f-b164d2df5f8c"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "content": "1\tlabel=3\n2\towner=owner_3\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_01PD2QqGJwdtwgrdJuJQ731V",
-              "type": "tool_result"
-            }
-          ],
-          "role": "user"
-        },
-        "parent_tool_use_id": "toolu_01RJqjfcgN1DUpGtAgEY9oa9",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:15.135Z",
-        "type": "user",
-        "uuid": "c11e3994-cc42-4182-afd1-0f04c80bc5ee"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "description": "Reading note_2.txt",
-        "last_tool_name": "Read",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "subtype": "task_progress",
-        "task_id": "a1064b1c87bb5b847",
-        "tool_use_id": "toolu_01CohiSJACWPsGHRBVBBMWfA",
-        "type": "system",
-        "usage": {
-          "duration_ms": 3288,
-          "tool_uses": 2,
-          "total_tokens": 18553
-        },
-        "uuid": "26c386aa-d5ae-4c0f-a691-2b3435a93388"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "caller": {
-                "type": "direct"
-              },
-              "id": "toolu_01BgYDSP1XryPadTuX9fKx1a",
-              "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_five_parallel_bundled_sub0/subagent_parenting_workspace/note_2.txt"
-              },
-              "name": "Read",
-              "type": "tool_use"
-            }
-          ],
-          "context_management": null,
-          "id": "msg_01MwnUyB6incdLzpsJgRLZcp",
-          "model": "claude-haiku-4-5-20251001",
-          "role": "assistant",
-          "stop_details": null,
-          "stop_reason": null,
-          "stop_sequence": null,
-          "type": "message",
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1066
-            },
-            "cache_creation_input_tokens": 1066,
-            "cache_read_input_tokens": 17478,
-            "inference_geo": "not_available",
-            "input_tokens": 5,
-            "output_tokens": 1,
-            "service_tier": "standard"
-          }
-        },
-        "parent_tool_use_id": "toolu_01CohiSJACWPsGHRBVBBMWfA",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "type": "assistant",
-        "uuid": "442c8637-8138-41c5-808d-d28da4d55f00"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "content": "1\tlabel=2\n2\towner=owner_2\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_01BgYDSP1XryPadTuX9fKx1a",
-              "type": "tool_result"
-            }
-          ],
-          "role": "user"
-        },
-        "parent_tool_use_id": "toolu_01CohiSJACWPsGHRBVBBMWfA",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:15.808Z",
-        "type": "user",
-        "uuid": "1881ec15-da36-4c84-97ec-6f1814b20d49"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "description": "Reading note_4.txt",
-        "last_tool_name": "Read",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "subtype": "task_progress",
-        "task_id": "a8aca87b86939fe8e",
-        "tool_use_id": "toolu_01Ax9ZKLVW4dqdr2fEAWKT4J",
-        "type": "system",
-        "usage": {
-          "duration_ms": 2942,
-          "tool_uses": 2,
-          "total_tokens": 18558
-        },
-        "uuid": "bbe285ee-c532-4edf-a5a5-abaa4b9070c5"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "caller": {
-                "type": "direct"
-              },
-              "id": "toolu_0177b6VMoM14id8ooQ9YkQWY",
-              "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_five_parallel_bundled_sub0/subagent_parenting_workspace/note_4.txt"
-              },
-              "name": "Read",
-              "type": "tool_use"
-            }
-          ],
-          "context_management": null,
-          "id": "msg_01HxP5bAQ9zKY4JDGeXa3NuZ",
-          "model": "claude-haiku-4-5-20251001",
-          "role": "assistant",
-          "stop_details": null,
-          "stop_reason": null,
-          "stop_sequence": null,
-          "type": "message",
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1497
-            },
-            "cache_creation_input_tokens": 1497,
-            "cache_read_input_tokens": 17052,
-            "inference_geo": "not_available",
-            "input_tokens": 5,
-            "output_tokens": 1,
-            "service_tier": "standard"
-          }
-        },
-        "parent_tool_use_id": "toolu_01Ax9ZKLVW4dqdr2fEAWKT4J",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "type": "assistant",
-        "uuid": "9d20424d-15e5-4bf0-9025-6666e76fbccf"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "content": "1\tlabel=4\n2\towner=owner_4\n3\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_0177b6VMoM14id8ooQ9YkQWY",
-              "type": "tool_result"
-            }
-          ],
-          "role": "user"
-        },
-        "parent_tool_use_id": "toolu_01Ax9ZKLVW4dqdr2fEAWKT4J",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:16.030Z",
-        "type": "user",
-        "uuid": "e0650d1a-56cd-4f6e-8216-6cb3bfcd0fd1"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "output_file": "",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "status": "completed",
-        "subtype": "task_notification",
-        "summary": "Process note_3.txt and extract label and owner",
-        "task_id": "ac9f57f48110b4896",
-        "tool_use_id": "toolu_01RJqjfcgN1DUpGtAgEY9oa9",
-        "type": "system",
-        "usage": {
-          "duration_ms": 3282,
-          "tool_uses": 1,
-          "total_tokens": 18567
-        },
-        "uuid": "9ad0f52b-814e-4475-93de-a2e1f71785c4"
+        "uuid": "639a3358-bdb0-4997-b3f4-8e36d1b111c1"
       }
     },
     {
@@ -1386,21 +1106,21 @@
                   "type": "text"
                 },
                 {
-                  "text": "agentId: ac9f57f48110b4896 (use SendMessage with to: 'ac9f57f48110b4896' to continue this agent)\n<usage>total_tokens: 18577\ntool_uses: 1\nduration_ms: 3283</usage>",
+                  "text": "agentId: a75fbc8a882d8b035 (use SendMessage with to: 'a75fbc8a882d8b035' to continue this agent)\n<usage>total_tokens: 18584\ntool_uses: 1\nduration_ms: 2233</usage>",
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01RJqjfcgN1DUpGtAgEY9oa9",
+              "tool_use_id": "toolu_01EVtW8C54Q54ATbmPyrnTkQ",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:16.181Z",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:04.403Z",
         "tool_use_result": {
-          "agentId": "ac9f57f48110b4896",
+          "agentId": "a75fbc8a882d8b035",
           "agentType": "general-purpose",
           "content": [
             {
@@ -1408,7 +1128,7 @@
               "type": "text"
             }
           ],
-          "prompt": "Read note_3.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
+          "prompt": "Read the file note_3.txt using the Read tool. Extract the label number and owner name. Return only in format: label=3 | owner=<owner_name>",
           "status": "completed",
           "toolStats": {
             "bashCount": 0,
@@ -1419,31 +1139,19 @@
             "readCount": 1,
             "searchCount": 0
           },
-          "totalDurationMs": 3283,
-          "totalTokens": 18577,
+          "totalDurationMs": 2233,
+          "totalTokens": 18584,
           "totalToolUseCount": 1,
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1081
+              "ephemeral_5m_input_tokens": 1078
             },
-            "cache_creation_input_tokens": 1081,
-            "cache_read_input_tokens": 17478,
+            "cache_creation_input_tokens": 1078,
+            "cache_read_input_tokens": 17488,
             "inference_geo": "",
             "input_tokens": 5,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 1081
-                },
-                "cache_creation_input_tokens": 1081,
-                "cache_read_input_tokens": 17478,
-                "input_tokens": 5,
-                "output_tokens": 13,
-                "type": "message"
-              }
-            ],
+            "iterations": [],
             "output_tokens": 13,
             "server_tool_use": {
               "web_fetch_requests": 0,
@@ -1454,26 +1162,26 @@
           }
         },
         "type": "user",
-        "uuid": "35992380-889a-4100-a178-c9ca51b8adba"
+        "uuid": "4ff8d593-0706-40b6-b489-77d6be02f60d"
       }
     },
     {
       "op": "read",
       "payload": {
         "output_file": "",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "status": "completed",
         "subtype": "task_notification",
-        "summary": "Process note_2.txt and extract label and owner",
-        "task_id": "a1064b1c87bb5b847",
-        "tool_use_id": "toolu_01CohiSJACWPsGHRBVBBMWfA",
+        "summary": "Read note_2.txt and report",
+        "task_id": "a22734fb2ae496167",
+        "tool_use_id": "toolu_0162aayLJZWexA4TA79vwo9p",
         "type": "system",
         "usage": {
-          "duration_ms": 4215,
-          "tool_uses": 2,
-          "total_tokens": 18800
+          "duration_ms": 2819,
+          "tool_uses": 1,
+          "total_tokens": 18588
         },
-        "uuid": "e188d1a5-7c06-426b-8a2d-01536bf6331d"
+        "uuid": "afe8eb53-235d-4953-98d9-f48020069cca"
       }
     },
     {
@@ -1488,21 +1196,21 @@
                   "type": "text"
                 },
                 {
-                  "text": "agentId: a1064b1c87bb5b847 (use SendMessage with to: 'a1064b1c87bb5b847' to continue this agent)\n<usage>total_tokens: 18808\ntool_uses: 2\nduration_ms: 4216</usage>",
+                  "text": "agentId: a22734fb2ae496167 (use SendMessage with to: 'a22734fb2ae496167' to continue this agent)\n<usage>total_tokens: 18584\ntool_uses: 1\nduration_ms: 2819</usage>",
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01CohiSJACWPsGHRBVBBMWfA",
+              "tool_use_id": "toolu_0162aayLJZWexA4TA79vwo9p",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:16.732Z",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:04.934Z",
         "tool_use_result": {
-          "agentId": "a1064b1c87bb5b847",
+          "agentId": "a22734fb2ae496167",
           "agentType": "general-purpose",
           "content": [
             {
@@ -1510,10 +1218,10 @@
               "type": "text"
             }
           ],
-          "prompt": "Read note_2.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
+          "prompt": "Read the file note_2.txt using the Read tool. Extract the label number and owner name. Return only in format: label=2 | owner=<owner_name>",
           "status": "completed",
           "toolStats": {
-            "bashCount": 1,
+            "bashCount": 0,
             "editFileCount": 0,
             "linesAdded": 0,
             "linesRemoved": 0,
@@ -1521,31 +1229,19 @@
             "readCount": 1,
             "searchCount": 0
           },
-          "totalDurationMs": 4216,
-          "totalTokens": 18808,
-          "totalToolUseCount": 2,
+          "totalDurationMs": 2819,
+          "totalTokens": 18584,
+          "totalToolUseCount": 1,
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 246
+              "ephemeral_5m_input_tokens": 1078
             },
-            "cache_creation_input_tokens": 246,
-            "cache_read_input_tokens": 18544,
+            "cache_creation_input_tokens": 1078,
+            "cache_read_input_tokens": 17488,
             "inference_geo": "",
             "input_tokens": 5,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 246
-                },
-                "cache_creation_input_tokens": 246,
-                "cache_read_input_tokens": 18544,
-                "input_tokens": 5,
-                "output_tokens": 13,
-                "type": "message"
-              }
-            ],
+            "iterations": [],
             "output_tokens": 13,
             "server_tool_use": {
               "web_fetch_requests": 0,
@@ -1556,26 +1252,26 @@
           }
         },
         "type": "user",
-        "uuid": "57764441-ff34-41f3-8f3f-84fc587fb862"
+        "uuid": "c1b57345-398b-4c90-80c7-1ebe5d201946"
       }
     },
     {
       "op": "read",
       "payload": {
         "output_file": "",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "status": "completed",
         "subtype": "task_notification",
-        "summary": "Process note_4.txt and extract label and owner",
-        "task_id": "a8aca87b86939fe8e",
-        "tool_use_id": "toolu_01Ax9ZKLVW4dqdr2fEAWKT4J",
+        "summary": "Read note_4.txt and report",
+        "task_id": "ad0cb35dc9dfeb8df",
+        "tool_use_id": "toolu_01DUg1LJYUx5RsfcHwE2xikm",
         "type": "system",
         "usage": {
-          "duration_ms": 3968,
-          "tool_uses": 2,
-          "total_tokens": 18805
+          "duration_ms": 3020,
+          "tool_uses": 1,
+          "total_tokens": 18588
         },
-        "uuid": "2472b570-4fb9-43f3-bb64-a2b0195e61f4"
+        "uuid": "6662139e-2a62-447c-9b4e-62acb5d0dd0a"
       }
     },
     {
@@ -1590,21 +1286,21 @@
                   "type": "text"
                 },
                 {
-                  "text": "agentId: a8aca87b86939fe8e (use SendMessage with to: 'a8aca87b86939fe8e' to continue this agent)\n<usage>total_tokens: 18813\ntool_uses: 2\nduration_ms: 3970</usage>",
+                  "text": "agentId: ad0cb35dc9dfeb8df (use SendMessage with to: 'ad0cb35dc9dfeb8df' to continue this agent)\n<usage>total_tokens: 18584\ntool_uses: 1\nduration_ms: 3020</usage>",
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01Ax9ZKLVW4dqdr2fEAWKT4J",
+              "tool_use_id": "toolu_01DUg1LJYUx5RsfcHwE2xikm",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
-        "timestamp": "2026-04-16T16:49:17.056Z",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:05.385Z",
         "tool_use_result": {
-          "agentId": "a8aca87b86939fe8e",
+          "agentId": "ad0cb35dc9dfeb8df",
           "agentType": "general-purpose",
           "content": [
             {
@@ -1612,10 +1308,10 @@
               "type": "text"
             }
           ],
-          "prompt": "Read note_4.txt and return only label=<n> | owner=<owner>. Do not include any other text.",
+          "prompt": "Read the file note_4.txt using the Read tool. Extract the label number and owner name. Return only in format: label=4 | owner=<owner_name>",
           "status": "completed",
           "toolStats": {
-            "bashCount": 1,
+            "bashCount": 0,
             "editFileCount": 0,
             "linesAdded": 0,
             "linesRemoved": 0,
@@ -1623,31 +1319,19 @@
             "readCount": 1,
             "searchCount": 0
           },
-          "totalDurationMs": 3970,
-          "totalTokens": 18813,
-          "totalToolUseCount": 2,
+          "totalDurationMs": 3020,
+          "totalTokens": 18584,
+          "totalToolUseCount": 1,
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1316
+              "ephemeral_5m_input_tokens": 1078
             },
-            "cache_creation_input_tokens": 1316,
-            "cache_read_input_tokens": 17478,
+            "cache_creation_input_tokens": 1078,
+            "cache_read_input_tokens": 17488,
             "inference_geo": "",
-            "input_tokens": 6,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 1316
-                },
-                "cache_creation_input_tokens": 1316,
-                "cache_read_input_tokens": 17478,
-                "input_tokens": 6,
-                "output_tokens": 13,
-                "type": "message"
-              }
-            ],
+            "input_tokens": 5,
+            "iterations": [],
             "output_tokens": 13,
             "server_tool_use": {
               "web_fetch_requests": 0,
@@ -1658,7 +1342,97 @@
           }
         },
         "type": "user",
-        "uuid": "e55e53f8-b5e7-4f8d-bdc4-2619ef620157"
+        "uuid": "20a996dd-7a21-47c3-a9b3-7143b6a85bc5"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "output_file": "",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "status": "completed",
+        "subtype": "task_notification",
+        "summary": "Read note_1.txt and report",
+        "task_id": "ab3b561a9904c4e1b",
+        "tool_use_id": "toolu_01LRALL7Qjhsca9dZwRy2M4d",
+        "type": "system",
+        "usage": {
+          "duration_ms": 4343,
+          "tool_uses": 1,
+          "total_tokens": 18584
+        },
+        "uuid": "3a4ac9a3-4a48-47d6-9c87-311839e7f203"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "Based on the file contents:\n\nlabel=1 | owner=owner_1",
+                  "type": "text"
+                },
+                {
+                  "text": "agentId: ab3b561a9904c4e1b (use SendMessage with to: 'ab3b561a9904c4e1b' to continue this agent)\n<usage>total_tokens: 18597\ntool_uses: 1\nduration_ms: 4344</usage>",
+                  "type": "text"
+                }
+              ],
+              "tool_use_id": "toolu_01LRALL7Qjhsca9dZwRy2M4d",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
+        "timestamp": "2026-04-17T16:18:05.959Z",
+        "tool_use_result": {
+          "agentId": "ab3b561a9904c4e1b",
+          "agentType": "general-purpose",
+          "content": [
+            {
+              "text": "Based on the file contents:\n\nlabel=1 | owner=owner_1",
+              "type": "text"
+            }
+          ],
+          "prompt": "Read the file note_1.txt using the Read tool. Extract the label number and owner name. Return only in format: label=1 | owner=<owner_name>",
+          "status": "completed",
+          "toolStats": {
+            "bashCount": 0,
+            "editFileCount": 0,
+            "linesAdded": 0,
+            "linesRemoved": 0,
+            "otherToolCount": 0,
+            "readCount": 1,
+            "searchCount": 0
+          },
+          "totalDurationMs": 4344,
+          "totalTokens": 18597,
+          "totalToolUseCount": 1,
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 1084
+            },
+            "cache_creation_input_tokens": 1084,
+            "cache_read_input_tokens": 17488,
+            "inference_geo": "",
+            "input_tokens": 5,
+            "iterations": [],
+            "output_tokens": 20,
+            "server_tool_use": {
+              "web_fetch_requests": 0,
+              "web_search_requests": 0
+            },
+            "service_tier": "standard",
+            "speed": "standard"
+          }
+        },
+        "type": "user",
+        "uuid": "95cf2852-552d-4501-a96e-18305c0cc537"
       }
     },
     {
@@ -1668,12 +1442,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "Great! All five subagents have returned their results. Now I need to format the response as exactly five lines in order 0 through 4, with the extracted information:\n\nFrom the results:\n- label=0 | owner=owner_0\n- label=1 | owner=owner_1\n- label=2 | owner=owner_2\n- label=3 | owner=owner_3\n- label=4 | owner=owner_4\n\nI should output these in order.",
+              "thinking": "All five subagents have completed. Now I need to reply with exactly five lines in order 0 through 4. The results are:\n- label=0 | owner=owner_0\n- label=1 | owner=owner_1\n- label=2 | owner=owner_2\n- label=3 | owner=owner_3\n- label=4 | owner=owner_4\n\nI should output exactly these five lines in order.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01GuaC1ciEk3SucrNtiuFzGs",
+          "id": "msg_01722Sp1MYkDmhc3U2zft9aA",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -1683,20 +1457,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1165
+              "ephemeral_5m_input_tokens": 967
             },
-            "cache_creation_input_tokens": 1165,
+            "cache_creation_input_tokens": 967,
             "cache_read_input_tokens": 23308,
             "inference_geo": "not_available",
-            "input_tokens": 8,
+            "input_tokens": 335,
             "output_tokens": 1,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "type": "assistant",
-        "uuid": "b8ce004f-1b34-4559-b852-6de1120063f2"
+        "uuid": "f05f302b-b834-4536-b49a-df352012ebca"
       }
     },
     {
@@ -1710,7 +1484,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01GuaC1ciEk3SucrNtiuFzGs",
+          "id": "msg_01722Sp1MYkDmhc3U2zft9aA",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -1720,74 +1494,62 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1165
+              "ephemeral_5m_input_tokens": 967
             },
-            "cache_creation_input_tokens": 1165,
+            "cache_creation_input_tokens": 967,
             "cache_read_input_tokens": 23308,
             "inference_geo": "not_available",
-            "input_tokens": 8,
+            "input_tokens": 335,
             "output_tokens": 1,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "type": "assistant",
-        "uuid": "60574c1f-fe69-4f3b-bcae-3347abf675ef"
+        "uuid": "794826a0-42d0-407c-933d-9149e4d244f8"
       }
     },
     {
       "op": "read",
       "payload": {
         "api_error_status": null,
-        "duration_api_ms": 22933,
-        "duration_ms": 9850,
+        "duration_api_ms": 22918,
+        "duration_ms": 10065,
         "fast_mode_state": "off",
         "is_error": false,
         "modelUsage": {
           "claude-haiku-4-5-20251001": {
-            "cacheCreationInputTokens": 12962,
-            "cacheReadInputTokens": 252549,
+            "cacheCreationInputTokens": 12394,
+            "cacheReadInputTokens": 215465,
             "contextWindow": 200000,
-            "costUSD": 0.05131840000000001,
-            "inputTokens": 536,
+            "costUSD": 0.04645099999999999,
+            "inputTokens": 852,
             "maxOutputTokens": 32000,
-            "outputTokens": 1865,
+            "outputTokens": 1712,
             "webSearchRequests": 0
           }
         },
         "num_turns": 6,
         "permission_denials": [],
         "result": "label=0 | owner=owner_0\nlabel=1 | owner=owner_1\nlabel=2 | owner=owner_2\nlabel=3 | owner=owner_3\nlabel=4 | owner=owner_4",
-        "session_id": "ad817e01-44ab-4861-801d-66db16c299c5",
+        "session_id": "44a7a745-93a8-49c2-8f45-366a423d0f9d",
         "stop_reason": "end_turn",
         "subtype": "success",
         "terminal_reason": "completed",
-        "total_cost_usd": 0.05131840000000001,
+        "total_cost_usd": 0.04645099999999999,
         "type": "result",
         "usage": {
           "cache_creation": {
             "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 1165
+            "ephemeral_5m_input_tokens": 2495
           },
-          "cache_creation_input_tokens": 1165,
-          "cache_read_input_tokens": 46616,
+          "cache_creation_input_tokens": 2495,
+          "cache_read_input_tokens": 45088,
           "inference_geo": "",
-          "input_tokens": 18,
-          "iterations": [
-            {
-              "cache_creation": {
-                "ephemeral_1h_input_tokens": 0,
-                "ephemeral_5m_input_tokens": 1165
-              },
-              "cache_creation_input_tokens": 1165,
-              "cache_read_input_tokens": 23308,
-              "input_tokens": 8,
-              "output_tokens": 175,
-              "type": "message"
-            }
-          ],
-          "output_tokens": 776,
+          "input_tokens": 345,
+          "iterations": [],
+          "output_tokens": 896,
           "server_tool_use": {
             "web_fetch_requests": 0,
             "web_search_requests": 0
@@ -1795,9 +1557,9 @@
           "service_tier": "standard",
           "speed": "standard"
         },
-        "uuid": "ba996a5d-a8a3-40f9-9710-22fe3e46de1a"
+        "uuid": "64be572a-2559-4b46-be2b-54ac537449e8"
       }
     }
   ],
-  "sdk_version": "0.1.60"
+  "sdk_version": "0.1.61"
 }

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_hook_spans_parent_to_matching_tool_and_final_llm.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_hook_spans_parent_to_matching_tool_and_final_llm.json
@@ -35,7 +35,7 @@
             },
             "subtype": "initialize"
           },
-          "request_id": "req_1_0a055126",
+          "request_id": "req_1_68c31028",
           "type": "control_request"
         }
       }
@@ -44,7 +44,7 @@
       "op": "read",
       "payload": {
         "response": {
-          "request_id": "req_1_0a055126",
+          "request_id": "req_1_68c31028",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
@@ -86,7 +86,7 @@
           "statusline-setup"
         ],
         "apiKeySource": "ANTHROPIC_API_KEY",
-        "claude_code_version": "2.1.111",
+        "claude_code_version": "2.1.112",
         "cwd": "<REDACTED_CWD>",
         "fast_mode_state": "off",
         "mcp_servers": [
@@ -112,7 +112,7 @@
             "source": "rust-analyzer-lsp@claude-plugins-official"
           }
         ],
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
         "skills": [
           "update-config",
           "debug",
@@ -239,7 +239,7 @@
           "mcp__linear-server__update_document"
         ],
         "type": "system",
-        "uuid": "c33a7109-5e7b-4710-b291-f7d5ce3b80f3"
+        "uuid": "1e07611c-ff40-459f-8816-52e3b29fb84e"
       }
     },
     {
@@ -249,12 +249,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The user wants me to:\n1. Run `pwd` and `ls` in the workspace\n2. Read `trip_notes.md`\n3. Summarize the current budget and hotel status\n\nLet me start by running the bash commands to see what's in the workspace.",
+              "thinking": "The user is asking me to:\n1. Run `pwd` and `ls` in the workspace\n2. Read `trip_notes.md` \n3. Summarize the current budget and hotel status\n\nLet me start by running those bash commands.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_015pwzREf4z7LN4HsMPaCZ4N",
+          "id": "msg_01CEyFmy1n8GiMLaokFNTwHB",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -267,17 +267,17 @@
               "ephemeral_5m_input_tokens": 5774
             },
             "cache_creation_input_tokens": 5774,
-            "cache_read_input_tokens": 35611,
+            "cache_read_input_tokens": 35723,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 3,
+            "output_tokens": 1,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
         "type": "assistant",
-        "uuid": "7eab8b41-9120-4f2d-ac4b-2b7507d321ca"
+        "uuid": "dca5d178-b6a5-4e74-b21a-499a9f8c654e"
       }
     },
     {
@@ -289,17 +289,17 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_0176yTLZRLruyQbQzbNri2wW",
+              "id": "toolu_016w2GUiEMuJMCdyhboZcKCP",
               "input": {
                 "command": "pwd && ls -la",
-                "description": "Check current working directory and list files"
+                "description": "Show current directory and list files"
               },
               "name": "Bash",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_015pwzREf4z7LN4HsMPaCZ4N",
+          "id": "msg_01CEyFmy1n8GiMLaokFNTwHB",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -312,17 +312,17 @@
               "ephemeral_5m_input_tokens": 5774
             },
             "cache_creation_input_tokens": 5774,
-            "cache_read_input_tokens": 35611,
+            "cache_read_input_tokens": 35723,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 3,
+            "output_tokens": 1,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
         "type": "assistant",
-        "uuid": "03d5d7a7-ef0d-481d-aa42-55314d0e4342"
+        "uuid": "770aa1a2-6d21-4ac0-9a6f-11a99d936133"
       }
     },
     {
@@ -334,19 +334,19 @@
             "cwd": "<REDACTED_CWD>",
             "hook_event_name": "PreToolUse",
             "permission_mode": "bypassPermissions",
-            "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+            "session_id": "3316b244-1496-427a-95ea-f86132304c12",
             "tool_input": {
               "command": "pwd && ls -la",
-              "description": "Check current working directory and list files"
+              "description": "Show current directory and list files"
             },
             "tool_name": "Bash",
-            "tool_use_id": "toolu_0176yTLZRLruyQbQzbNri2wW",
+            "tool_use_id": "toolu_016w2GUiEMuJMCdyhboZcKCP",
             "transcript_path": "<REDACTED_PATH>"
           },
           "subtype": "hook_callback",
-          "tool_use_id": "toolu_0176yTLZRLruyQbQzbNri2wW"
+          "tool_use_id": "toolu_016w2GUiEMuJMCdyhboZcKCP"
         },
-        "request_id": "13a91cc6-87ce-4538-81d5-db607085a54a",
+        "request_id": "1c5af700-7064-42a2-a84c-4bdbc568cf4d",
         "type": "control_request"
       }
     },
@@ -356,7 +356,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "13a91cc6-87ce-4538-81d5-db607085a54a",
+            "request_id": "1c5af700-7064-42a2-a84c-4bdbc568cf4d",
             "response": {},
             "subtype": "success"
           },
@@ -373,10 +373,10 @@
             "cwd": "<REDACTED_CWD>",
             "hook_event_name": "PostToolUse",
             "permission_mode": "bypassPermissions",
-            "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+            "session_id": "3316b244-1496-427a-95ea-f86132304c12",
             "tool_input": {
               "command": "pwd && ls -la",
-              "description": "Check current working directory and list files"
+              "description": "Show current directory and list files"
             },
             "tool_name": "Bash",
             "tool_response": {
@@ -384,15 +384,15 @@
               "isImage": false,
               "noOutputExpected": false,
               "stderr": "",
-              "stdout": "<REDACTED_PATH>\ntotal 2776\ndrwxr-xr-x@  5 abhijeetprasad  staff      160 Apr 16 11:59 __pycache__\ndrwxr-xr-x@ 22 abhijeetprasad  staff      704 Apr 16 12:06 .\ndrwxr-xr-x@ 38 abhijeetprasad  staff     1216 Apr 16 11:12 ..\n-rw-r--r--@  1 abhijeetprasad  staff     6148 Apr 16 11:40 .DS_Store\n-rw-r--r--@  1 abhijeetprasad  staff       17 Mar 25 13:23 .envrc\n-rw-r--r--@  1 abhijeetprasad  staff       30 Mar 25 13:23 .gitignore\ndrwxr-xr-x@  7 abhijeetprasad  staff      224 Apr 15 18:18 .mypy_cache\ndrwxr-xr-x@ 58 abhijeetprasad  staff     1856 Apr 16 12:46 .nox\ndrwxr-xr-x@  8 abhijeetprasad  staff      256 Apr 15 17:31 .venv\n-rw-r--r--@  1 abhijeetprasad  staff       46 Apr 14 11:50 AGENTS.md\ndrwxr-xr-x@  8 abhijeetprasad  staff      256 Apr 14 11:50 benchmarks\ndrwxr-xr-x@  4 abhijeetprasad  staff      128 Apr 15 18:44 build\nlrwxr-xr-x   1 abhijeetprasad  staff        9 Apr 14 11:50 CLAUDE.md -> AGENTS.md\ndrwxr-xr-x@  5 abhijeetprasad  staff      160 Apr 15 18:37 dist\ndrwxr-xr-x@ 16 abhijeetprasad  staff      512 Apr 14 11:50 examples\n-rw-r--r--   1 abhijeetprasad  staff     2815 Apr 15 19:00 Makefile\n-rw-r--r--   1 abhijeetprasad  staff    22262 Apr 15 19:00 noxfile.py\n-rw-r--r--   1 abhijeetprasad  staff    10210 Apr 16 12:06 pyproject.toml\n-rw-r--r--@  1 abhijeetprasad  staff     1754 Mar 25 13:23 README.md\ndrwxr-xr-x@ 11 abhijeetprasad  staff      352 Apr 16 12:06 scripts\ndrwxr-xr-x@  4 abhijeetprasad  staff      128 Mar 25 13:41 src\n-rw-r--r--   1 abhijeetprasad  staff  1353544 Apr 16 12:06 uv.lock"
+              "stdout": "<REDACTED_PATH>\ntotal 2784\ndrwxr-xr-x@  5 abhijeetprasad  staff      160 Apr 17 12:10 __pycache__\ndrwxr-xr-x@ 22 abhijeetprasad  staff      704 Apr 17 10:40 .\ndrwxr-xr-x@ 38 abhijeetprasad  staff     1216 Apr 16 18:57 ..\n-rw-r--r--@  1 abhijeetprasad  staff     6148 Apr 16 11:40 .DS_Store\n-rw-r--r--@  1 abhijeetprasad  staff       17 Mar 25 13:23 .envrc\n-rw-r--r--@  1 abhijeetprasad  staff       30 Mar 25 13:23 .gitignore\ndrwxr-xr-x@  7 abhijeetprasad  staff      224 Apr 15 18:18 .mypy_cache\ndrwxr-xr-x@ 60 abhijeetprasad  staff     1920 Apr 17 12:14 .nox\ndrwxr-xr-x@  8 abhijeetprasad  staff      256 Apr 15 17:31 .venv\n-rw-r--r--@  1 abhijeetprasad  staff       46 Apr 14 11:50 AGENTS.md\ndrwxr-xr-x@  8 abhijeetprasad  staff      256 Apr 14 11:50 benchmarks\ndrwxr-xr-x@  4 abhijeetprasad  staff      128 Apr 15 18:44 build\nlrwxr-xr-x   1 abhijeetprasad  staff        9 Apr 14 11:50 CLAUDE.md -> AGENTS.md\ndrwxr-xr-x@  5 abhijeetprasad  staff      160 Apr 15 18:37 dist\ndrwxr-xr-x@ 16 abhijeetprasad  staff      512 Apr 14 11:50 examples\n-rw-r--r--   1 abhijeetprasad  staff     2815 Apr 15 19:00 Makefile\n-rw-r--r--   1 abhijeetprasad  staff    22927 Apr 17 10:40 noxfile.py\n-rw-r--r--@  1 abhijeetprasad  staff    10381 Apr 17 12:10 pyproject.toml\n-rw-r--r--@  1 abhijeetprasad  staff     1754 Mar 25 13:23 README.md\ndrwxr-xr-x@ 12 abhijeetprasad  staff      384 Apr 17 10:40 scripts\ndrwxr-xr-x@  4 abhijeetprasad  staff      128 Mar 25 13:41 src\n-rw-r--r--   1 abhijeetprasad  staff  1358709 Apr 17 10:40 uv.lock"
             },
-            "tool_use_id": "toolu_0176yTLZRLruyQbQzbNri2wW",
+            "tool_use_id": "toolu_016w2GUiEMuJMCdyhboZcKCP",
             "transcript_path": "<REDACTED_PATH>"
           },
           "subtype": "hook_callback",
-          "tool_use_id": "toolu_0176yTLZRLruyQbQzbNri2wW"
+          "tool_use_id": "toolu_016w2GUiEMuJMCdyhboZcKCP"
         },
-        "request_id": "38c460e6-397e-4752-865c-9a3f1d446da7",
+        "request_id": "319ee805-018b-40a5-b817-f44ce39f67db",
         "type": "control_request"
       }
     },
@@ -402,7 +402,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "38c460e6-397e-4752-865c-9a3f1d446da7",
+            "request_id": "319ee805-018b-40a5-b817-f44ce39f67db",
             "response": {},
             "subtype": "success"
           },
@@ -416,26 +416,26 @@
         "message": {
           "content": [
             {
-              "content": "<REDACTED_PATH>\ntotal 2776\ndrwxr-xr-x@  5 abhijeetprasad  staff      160 Apr 16 11:59 __pycache__\ndrwxr-xr-x@ 22 abhijeetprasad  staff      704 Apr 16 12:06 .\ndrwxr-xr-x@ 38 abhijeetprasad  staff     1216 Apr 16 11:12 ..\n-rw-r--r--@  1 abhijeetprasad  staff     6148 Apr 16 11:40 .DS_Store\n-rw-r--r--@  1 abhijeetprasad  staff       17 Mar 25 13:23 .envrc\n-rw-r--r--@  1 abhijeetprasad  staff       30 Mar 25 13:23 .gitignore\ndrwxr-xr-x@  7 abhijeetprasad  staff      224 Apr 15 18:18 .mypy_cache\ndrwxr-xr-x@ 58 abhijeetprasad  staff     1856 Apr 16 12:46 .nox\ndrwxr-xr-x@  8 abhijeetprasad  staff      256 Apr 15 17:31 .venv\n-rw-r--r--@  1 abhijeetprasad  staff       46 Apr 14 11:50 AGENTS.md\ndrwxr-xr-x@  8 abhijeetprasad  staff      256 Apr 14 11:50 benchmarks\ndrwxr-xr-x@  4 abhijeetprasad  staff      128 Apr 15 18:44 build\nlrwxr-xr-x   1 abhijeetprasad  staff        9 Apr 14 11:50 CLAUDE.md -> AGENTS.md\ndrwxr-xr-x@  5 abhijeetprasad  staff      160 Apr 15 18:37 dist\ndrwxr-xr-x@ 16 abhijeetprasad  staff      512 Apr 14 11:50 examples\n-rw-r--r--   1 abhijeetprasad  staff     2815 Apr 15 19:00 Makefile\n-rw-r--r--   1 abhijeetprasad  staff    22262 Apr 15 19:00 noxfile.py\n-rw-r--r--   1 abhijeetprasad  staff    10210 Apr 16 12:06 pyproject.toml\n-rw-r--r--@  1 abhijeetprasad  staff     1754 Mar 25 13:23 README.md\ndrwxr-xr-x@ 11 abhijeetprasad  staff      352 Apr 16 12:06 scripts\ndrwxr-xr-x@  4 abhijeetprasad  staff      128 Mar 25 13:41 src\n-rw-r--r--   1 abhijeetprasad  staff  1353544 Apr 16 12:06 uv.lock",
+              "content": "<REDACTED_PATH>\ntotal 2784\ndrwxr-xr-x@  5 abhijeetprasad  staff      160 Apr 17 12:10 __pycache__\ndrwxr-xr-x@ 22 abhijeetprasad  staff      704 Apr 17 10:40 .\ndrwxr-xr-x@ 38 abhijeetprasad  staff     1216 Apr 16 18:57 ..\n-rw-r--r--@  1 abhijeetprasad  staff     6148 Apr 16 11:40 .DS_Store\n-rw-r--r--@  1 abhijeetprasad  staff       17 Mar 25 13:23 .envrc\n-rw-r--r--@  1 abhijeetprasad  staff       30 Mar 25 13:23 .gitignore\ndrwxr-xr-x@  7 abhijeetprasad  staff      224 Apr 15 18:18 .mypy_cache\ndrwxr-xr-x@ 60 abhijeetprasad  staff     1920 Apr 17 12:14 .nox\ndrwxr-xr-x@  8 abhijeetprasad  staff      256 Apr 15 17:31 .venv\n-rw-r--r--@  1 abhijeetprasad  staff       46 Apr 14 11:50 AGENTS.md\ndrwxr-xr-x@  8 abhijeetprasad  staff      256 Apr 14 11:50 benchmarks\ndrwxr-xr-x@  4 abhijeetprasad  staff      128 Apr 15 18:44 build\nlrwxr-xr-x   1 abhijeetprasad  staff        9 Apr 14 11:50 CLAUDE.md -> AGENTS.md\ndrwxr-xr-x@  5 abhijeetprasad  staff      160 Apr 15 18:37 dist\ndrwxr-xr-x@ 16 abhijeetprasad  staff      512 Apr 14 11:50 examples\n-rw-r--r--   1 abhijeetprasad  staff     2815 Apr 15 19:00 Makefile\n-rw-r--r--   1 abhijeetprasad  staff    22927 Apr 17 10:40 noxfile.py\n-rw-r--r--@  1 abhijeetprasad  staff    10381 Apr 17 12:10 pyproject.toml\n-rw-r--r--@  1 abhijeetprasad  staff     1754 Mar 25 13:23 README.md\ndrwxr-xr-x@ 12 abhijeetprasad  staff      384 Apr 17 10:40 scripts\ndrwxr-xr-x@  4 abhijeetprasad  staff      128 Mar 25 13:41 src\n-rw-r--r--   1 abhijeetprasad  staff  1358709 Apr 17 10:40 uv.lock",
               "is_error": false,
-              "tool_use_id": "toolu_0176yTLZRLruyQbQzbNri2wW",
+              "tool_use_id": "toolu_016w2GUiEMuJMCdyhboZcKCP",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
-        "timestamp": "2026-04-16T16:47:20.665Z",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
+        "timestamp": "2026-04-17T16:15:14.561Z",
         "tool_use_result": {
           "interrupted": false,
           "isImage": false,
           "noOutputExpected": false,
           "stderr": "",
-          "stdout": "<REDACTED_PATH>\ntotal 2776\ndrwxr-xr-x@  5 abhijeetprasad  staff      160 Apr 16 11:59 __pycache__\ndrwxr-xr-x@ 22 abhijeetprasad  staff      704 Apr 16 12:06 .\ndrwxr-xr-x@ 38 abhijeetprasad  staff     1216 Apr 16 11:12 ..\n-rw-r--r--@  1 abhijeetprasad  staff     6148 Apr 16 11:40 .DS_Store\n-rw-r--r--@  1 abhijeetprasad  staff       17 Mar 25 13:23 .envrc\n-rw-r--r--@  1 abhijeetprasad  staff       30 Mar 25 13:23 .gitignore\ndrwxr-xr-x@  7 abhijeetprasad  staff      224 Apr 15 18:18 .mypy_cache\ndrwxr-xr-x@ 58 abhijeetprasad  staff     1856 Apr 16 12:46 .nox\ndrwxr-xr-x@  8 abhijeetprasad  staff      256 Apr 15 17:31 .venv\n-rw-r--r--@  1 abhijeetprasad  staff       46 Apr 14 11:50 AGENTS.md\ndrwxr-xr-x@  8 abhijeetprasad  staff      256 Apr 14 11:50 benchmarks\ndrwxr-xr-x@  4 abhijeetprasad  staff      128 Apr 15 18:44 build\nlrwxr-xr-x   1 abhijeetprasad  staff        9 Apr 14 11:50 CLAUDE.md -> AGENTS.md\ndrwxr-xr-x@  5 abhijeetprasad  staff      160 Apr 15 18:37 dist\ndrwxr-xr-x@ 16 abhijeetprasad  staff      512 Apr 14 11:50 examples\n-rw-r--r--   1 abhijeetprasad  staff     2815 Apr 15 19:00 Makefile\n-rw-r--r--   1 abhijeetprasad  staff    22262 Apr 15 19:00 noxfile.py\n-rw-r--r--   1 abhijeetprasad  staff    10210 Apr 16 12:06 pyproject.toml\n-rw-r--r--@  1 abhijeetprasad  staff     1754 Mar 25 13:23 README.md\ndrwxr-xr-x@ 11 abhijeetprasad  staff      352 Apr 16 12:06 scripts\ndrwxr-xr-x@  4 abhijeetprasad  staff      128 Mar 25 13:41 src\n-rw-r--r--   1 abhijeetprasad  staff  1353544 Apr 16 12:06 uv.lock"
+          "stdout": "<REDACTED_PATH>\ntotal 2784\ndrwxr-xr-x@  5 abhijeetprasad  staff      160 Apr 17 12:10 __pycache__\ndrwxr-xr-x@ 22 abhijeetprasad  staff      704 Apr 17 10:40 .\ndrwxr-xr-x@ 38 abhijeetprasad  staff     1216 Apr 16 18:57 ..\n-rw-r--r--@  1 abhijeetprasad  staff     6148 Apr 16 11:40 .DS_Store\n-rw-r--r--@  1 abhijeetprasad  staff       17 Mar 25 13:23 .envrc\n-rw-r--r--@  1 abhijeetprasad  staff       30 Mar 25 13:23 .gitignore\ndrwxr-xr-x@  7 abhijeetprasad  staff      224 Apr 15 18:18 .mypy_cache\ndrwxr-xr-x@ 60 abhijeetprasad  staff     1920 Apr 17 12:14 .nox\ndrwxr-xr-x@  8 abhijeetprasad  staff      256 Apr 15 17:31 .venv\n-rw-r--r--@  1 abhijeetprasad  staff       46 Apr 14 11:50 AGENTS.md\ndrwxr-xr-x@  8 abhijeetprasad  staff      256 Apr 14 11:50 benchmarks\ndrwxr-xr-x@  4 abhijeetprasad  staff      128 Apr 15 18:44 build\nlrwxr-xr-x   1 abhijeetprasad  staff        9 Apr 14 11:50 CLAUDE.md -> AGENTS.md\ndrwxr-xr-x@  5 abhijeetprasad  staff      160 Apr 15 18:37 dist\ndrwxr-xr-x@ 16 abhijeetprasad  staff      512 Apr 14 11:50 examples\n-rw-r--r--   1 abhijeetprasad  staff     2815 Apr 15 19:00 Makefile\n-rw-r--r--   1 abhijeetprasad  staff    22927 Apr 17 10:40 noxfile.py\n-rw-r--r--@  1 abhijeetprasad  staff    10381 Apr 17 12:10 pyproject.toml\n-rw-r--r--@  1 abhijeetprasad  staff     1754 Mar 25 13:23 README.md\ndrwxr-xr-x@ 12 abhijeetprasad  staff      384 Apr 17 10:40 scripts\ndrwxr-xr-x@  4 abhijeetprasad  staff      128 Mar 25 13:41 src\n-rw-r--r--   1 abhijeetprasad  staff  1358709 Apr 17 10:40 uv.lock"
         },
         "type": "user",
-        "uuid": "0059da29-bbd1-416b-b315-f492ea28c718"
+        "uuid": "5edb2526-6372-4ab2-8309-8e96bc045434"
       }
     },
     {
@@ -445,12 +445,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "I can see we're in `<REDACTED_PATH> I don't see a `trip_notes.md` file in this directory. Let me check if it exists elsewhere, perhaps in the parent directory or check the home directory.",
+              "thinking": "The current directory is `<REDACTED_PATH> I don't see `trip_notes.md` in this directory. Let me check if it exists in the parent directory or elsewhere.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01S6kiqa3VHDVXUv4Rq9cL5X",
+          "id": "msg_01XC49BiAKBrtDpY8dgv4w9M",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -460,57 +460,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 6758
+              "ephemeral_5m_input_tokens": 979
             },
-            "cache_creation_input_tokens": 6758,
-            "cache_read_input_tokens": 35611,
+            "cache_creation_input_tokens": 979,
+            "cache_read_input_tokens": 41497,
             "inference_geo": "not_available",
             "input_tokens": 8,
-            "output_tokens": 1,
+            "output_tokens": 2,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
         "type": "assistant",
-        "uuid": "69cfdc70-06cf-43a3-9e03-e5220911efa3"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "text": "I don't see `trip_notes.md` in the current directory. Let me check the parent directory and home directory:",
-              "type": "text"
-            }
-          ],
-          "context_management": null,
-          "id": "msg_01S6kiqa3VHDVXUv4Rq9cL5X",
-          "model": "claude-haiku-4-5-20251001",
-          "role": "assistant",
-          "stop_details": null,
-          "stop_reason": null,
-          "stop_sequence": null,
-          "type": "message",
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 6758
-            },
-            "cache_creation_input_tokens": 6758,
-            "cache_read_input_tokens": 35611,
-            "inference_geo": "not_available",
-            "input_tokens": 8,
-            "output_tokens": 1,
-            "service_tier": "standard"
-          }
-        },
-        "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
-        "type": "assistant",
-        "uuid": "4109d985-a0f2-4fcf-9e0e-e211aea7a878"
+        "uuid": "5dc52169-0c7f-4dc2-8b6c-8127f7686d05"
       }
     },
     {
@@ -522,17 +485,17 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01Lr4FnkEKuMtNonFLkeV4si",
+              "id": "toolu_015gMYpoWRoYRQGr1PzfNqf3",
               "input": {
-                "command": "ls -la .. | grep -i trip && ls -la ~ | grep -i trip && ls -la <REDACTED_PATH> | grep -i trip",
-                "description": "Search for trip_notes.md in parent and home directories"
+                "command": "find <REDACTED_PATH> -name \"trip_notes.md\" 2>/dev/null",
+                "description": "Search for trip_notes.md file"
               },
               "name": "Bash",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01S6kiqa3VHDVXUv4Rq9cL5X",
+          "id": "msg_01XC49BiAKBrtDpY8dgv4w9M",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -542,20 +505,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 6758
+              "ephemeral_5m_input_tokens": 979
             },
-            "cache_creation_input_tokens": 6758,
-            "cache_read_input_tokens": 35611,
+            "cache_creation_input_tokens": 979,
+            "cache_read_input_tokens": 41497,
             "inference_geo": "not_available",
             "input_tokens": 8,
-            "output_tokens": 1,
+            "output_tokens": 2,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
         "type": "assistant",
-        "uuid": "d481e47d-71fe-4c40-8bfd-b61a14636d35"
+        "uuid": "b19499a3-e3a8-4ac0-91af-cb722cc55b8a"
       }
     },
     {
@@ -567,19 +530,19 @@
             "cwd": "<REDACTED_CWD>",
             "hook_event_name": "PreToolUse",
             "permission_mode": "bypassPermissions",
-            "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+            "session_id": "3316b244-1496-427a-95ea-f86132304c12",
             "tool_input": {
-              "command": "ls -la .. | grep -i trip && ls -la ~ | grep -i trip && ls -la <REDACTED_PATH> | grep -i trip",
-              "description": "Search for trip_notes.md in parent and home directories"
+              "command": "find <REDACTED_PATH> -name \"trip_notes.md\" 2>/dev/null",
+              "description": "Search for trip_notes.md file"
             },
             "tool_name": "Bash",
-            "tool_use_id": "toolu_01Lr4FnkEKuMtNonFLkeV4si",
+            "tool_use_id": "toolu_015gMYpoWRoYRQGr1PzfNqf3",
             "transcript_path": "<REDACTED_PATH>"
           },
           "subtype": "hook_callback",
-          "tool_use_id": "toolu_01Lr4FnkEKuMtNonFLkeV4si"
+          "tool_use_id": "toolu_015gMYpoWRoYRQGr1PzfNqf3"
         },
-        "request_id": "d3edfab6-97d9-432b-be1e-9d0501f7d079",
+        "request_id": "dbf8fb69-6f8d-400e-9397-3bae452b6c13",
         "type": "control_request"
       }
     },
@@ -589,7 +552,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "d3edfab6-97d9-432b-be1e-9d0501f7d079",
+            "request_id": "dbf8fb69-6f8d-400e-9397-3bae452b6c13",
             "response": {},
             "subtype": "success"
           },
@@ -606,27 +569,26 @@
             "cwd": "<REDACTED_CWD>",
             "hook_event_name": "PostToolUse",
             "permission_mode": "bypassPermissions",
-            "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+            "session_id": "3316b244-1496-427a-95ea-f86132304c12",
             "tool_input": {
-              "command": "ls -la .. | grep -i trip && ls -la ~ | grep -i trip && ls -la <REDACTED_PATH> | grep -i trip",
-              "description": "Search for trip_notes.md in parent and home directories"
+              "command": "find <REDACTED_PATH> -name \"trip_notes.md\" 2>/dev/null",
+              "description": "Search for trip_notes.md file"
             },
             "tool_name": "Bash",
             "tool_response": {
               "interrupted": false,
               "isImage": false,
               "noOutputExpected": false,
-              "returnCodeInterpretation": "No matches found",
               "stderr": "",
               "stdout": ""
             },
-            "tool_use_id": "toolu_01Lr4FnkEKuMtNonFLkeV4si",
+            "tool_use_id": "toolu_015gMYpoWRoYRQGr1PzfNqf3",
             "transcript_path": "<REDACTED_PATH>"
           },
           "subtype": "hook_callback",
-          "tool_use_id": "toolu_01Lr4FnkEKuMtNonFLkeV4si"
+          "tool_use_id": "toolu_015gMYpoWRoYRQGr1PzfNqf3"
         },
-        "request_id": "2f77ce31-035e-44cb-8a3c-05ccf5837924",
+        "request_id": "85b5061c-38f1-444a-848d-a1949072a9d1",
         "type": "control_request"
       }
     },
@@ -636,12 +598,39 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "2f77ce31-035e-44cb-8a3c-05ccf5837924",
+            "request_id": "85b5061c-38f1-444a-848d-a1949072a9d1",
             "response": {},
             "subtype": "success"
           },
           "type": "control_response"
         }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "description": "Search for trip_notes.md file",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
+        "subtype": "task_started",
+        "task_id": "b1wx048yy",
+        "task_type": "local_bash",
+        "tool_use_id": "toolu_015gMYpoWRoYRQGr1PzfNqf3",
+        "type": "system",
+        "uuid": "ed642ebc-9bf2-4435-9726-d67218d66b46"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "output_file": "",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
+        "status": "completed",
+        "subtype": "task_notification",
+        "summary": "Search for trip_notes.md file",
+        "task_id": "b1wx048yy",
+        "tool_use_id": "toolu_015gMYpoWRoYRQGr1PzfNqf3",
+        "type": "system",
+        "uuid": "13a78244-df97-4662-b832-634c70bffeca"
       }
     },
     {
@@ -652,25 +641,24 @@
             {
               "content": "(Bash completed with no output)",
               "is_error": false,
-              "tool_use_id": "toolu_01Lr4FnkEKuMtNonFLkeV4si",
+              "tool_use_id": "toolu_015gMYpoWRoYRQGr1PzfNqf3",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
-        "timestamp": "2026-04-16T16:47:22.784Z",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
+        "timestamp": "2026-04-17T16:15:48.759Z",
         "tool_use_result": {
           "interrupted": false,
           "isImage": false,
           "noOutputExpected": false,
-          "returnCodeInterpretation": "No matches found",
           "stderr": "",
           "stdout": ""
         },
         "type": "user",
-        "uuid": "43cd4cf3-11b5-4e20-9464-5f7ac966d588"
+        "uuid": "3444b96c-1433-42c0-9334-6622aeddaf03"
       }
     },
     {
@@ -680,12 +668,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The file doesn't exist in those locations. Let me try a broader search using find.",
+              "thinking": "The file doesn't seem to exist in the workspace. Let me check if it's in the home directory or another common location.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_017YRXaKd736PbJxf13nTYR9",
+          "id": "msg_01FgbaXyJEBXsHeQ5kCBw3fE",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -695,10 +683,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1224
+              "ephemeral_5m_input_tokens": 189
             },
-            "cache_creation_input_tokens": 1224,
-            "cache_read_input_tokens": 41385,
+            "cache_creation_input_tokens": 189,
+            "cache_read_input_tokens": 42476,
             "inference_geo": "not_available",
             "input_tokens": 8,
             "output_tokens": 1,
@@ -706,9 +694,9 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
         "type": "assistant",
-        "uuid": "55a25ce9-09be-49be-8db8-868e7f7a9cec"
+        "uuid": "b8867eaa-c8c6-416d-87a6-f1ba4fae1d02"
       }
     },
     {
@@ -720,17 +708,17 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01PUGgXabrSSEx2617C7zdFg",
+              "id": "toolu_01MY35jrkaEKSgNsr9vagL9w",
               "input": {
-                "command": "find <REDACTED_PATH> -name \"trip_notes.md\" -type f 2>/dev/null",
-                "description": "Search for trip_notes.md file in the user's home directory"
+                "command": "find ~ -name \"trip_notes.md\" 2>/dev/null | head -20",
+                "description": "Search home directory for trip_notes.md"
               },
               "name": "Bash",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_017YRXaKd736PbJxf13nTYR9",
+          "id": "msg_01FgbaXyJEBXsHeQ5kCBw3fE",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -740,10 +728,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1224
+              "ephemeral_5m_input_tokens": 189
             },
-            "cache_creation_input_tokens": 1224,
-            "cache_read_input_tokens": 41385,
+            "cache_creation_input_tokens": 189,
+            "cache_read_input_tokens": 42476,
             "inference_geo": "not_available",
             "input_tokens": 8,
             "output_tokens": 1,
@@ -751,9 +739,9 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
         "type": "assistant",
-        "uuid": "abd41f73-f758-4d11-aaa1-c1aa87818731"
+        "uuid": "6148bd13-02df-42f8-8ce6-28a325f60b63"
       }
     },
     {
@@ -765,19 +753,19 @@
             "cwd": "<REDACTED_CWD>",
             "hook_event_name": "PreToolUse",
             "permission_mode": "bypassPermissions",
-            "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+            "session_id": "3316b244-1496-427a-95ea-f86132304c12",
             "tool_input": {
-              "command": "find <REDACTED_PATH> -name \"trip_notes.md\" -type f 2>/dev/null",
-              "description": "Search for trip_notes.md file in the user's home directory"
+              "command": "find ~ -name \"trip_notes.md\" 2>/dev/null | head -20",
+              "description": "Search home directory for trip_notes.md"
             },
             "tool_name": "Bash",
-            "tool_use_id": "toolu_01PUGgXabrSSEx2617C7zdFg",
+            "tool_use_id": "toolu_01MY35jrkaEKSgNsr9vagL9w",
             "transcript_path": "<REDACTED_PATH>"
           },
           "subtype": "hook_callback",
-          "tool_use_id": "toolu_01PUGgXabrSSEx2617C7zdFg"
+          "tool_use_id": "toolu_01MY35jrkaEKSgNsr9vagL9w"
         },
-        "request_id": "8d8d83d4-5879-4fba-b59e-174f1958a139",
+        "request_id": "9ecfa6fe-7d5c-4fea-8dc6-26a16b3304ba",
         "type": "control_request"
       }
     },
@@ -787,7 +775,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "8d8d83d4-5879-4fba-b59e-174f1958a139",
+            "request_id": "9ecfa6fe-7d5c-4fea-8dc6-26a16b3304ba",
             "response": {},
             "subtype": "success"
           },
@@ -804,27 +792,26 @@
             "cwd": "<REDACTED_CWD>",
             "hook_event_name": "PostToolUse",
             "permission_mode": "bypassPermissions",
-            "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+            "session_id": "3316b244-1496-427a-95ea-f86132304c12",
             "tool_input": {
-              "command": "find <REDACTED_PATH> -name \"trip_notes.md\" -type f 2>/dev/null",
-              "description": "Search for trip_notes.md file in the user's home directory"
+              "command": "find ~ -name \"trip_notes.md\" 2>/dev/null | head -20",
+              "description": "Search home directory for trip_notes.md"
             },
             "tool_name": "Bash",
             "tool_response": {
               "interrupted": false,
               "isImage": false,
               "noOutputExpected": false,
-              "returnCodeInterpretation": "Some directories were inaccessible",
               "stderr": "",
               "stdout": "<REDACTED_PATH>"
             },
-            "tool_use_id": "toolu_01PUGgXabrSSEx2617C7zdFg",
+            "tool_use_id": "toolu_01MY35jrkaEKSgNsr9vagL9w",
             "transcript_path": "<REDACTED_PATH>"
           },
           "subtype": "hook_callback",
-          "tool_use_id": "toolu_01PUGgXabrSSEx2617C7zdFg"
+          "tool_use_id": "toolu_01MY35jrkaEKSgNsr9vagL9w"
         },
-        "request_id": "d35f15ec-eaaf-4c38-90f0-913da0403a57",
+        "request_id": "8a5d557a-0322-43b1-9ec7-9e5ea9f4c062",
         "type": "control_request"
       }
     },
@@ -834,7 +821,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "d35f15ec-eaaf-4c38-90f0-913da0403a57",
+            "request_id": "8a5d557a-0322-43b1-9ec7-9e5ea9f4c062",
             "response": {},
             "subtype": "success"
           },
@@ -845,28 +832,28 @@
     {
       "op": "read",
       "payload": {
-        "description": "Search for trip_notes.md file in the user's home directory",
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+        "description": "Search home directory for trip_notes.md",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
         "subtype": "task_started",
-        "task_id": "bjvwiondn",
+        "task_id": "b7lzrxspx",
         "task_type": "local_bash",
-        "tool_use_id": "toolu_01PUGgXabrSSEx2617C7zdFg",
+        "tool_use_id": "toolu_01MY35jrkaEKSgNsr9vagL9w",
         "type": "system",
-        "uuid": "158bd95a-85bc-4c8c-80d9-4298ac838c25"
+        "uuid": "c14aa0c1-cdbf-473f-b22b-cf9a68505b14"
       }
     },
     {
       "op": "read",
       "payload": {
         "output_file": "",
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
-        "status": "failed",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
+        "status": "completed",
         "subtype": "task_notification",
-        "summary": "Search for trip_notes.md file in the user's home directory",
-        "task_id": "bjvwiondn",
-        "tool_use_id": "toolu_01PUGgXabrSSEx2617C7zdFg",
+        "summary": "Search home directory for trip_notes.md",
+        "task_id": "b7lzrxspx",
+        "tool_use_id": "toolu_01MY35jrkaEKSgNsr9vagL9w",
         "type": "system",
-        "uuid": "498bf24a-a18a-4ccb-9190-d7df5ddcbf9a"
+        "uuid": "b2ea8772-fdf5-4a6a-9ea8-4f100f93f475"
       }
     },
     {
@@ -877,25 +864,24 @@
             {
               "content": "<REDACTED_PATH>",
               "is_error": false,
-              "tool_use_id": "toolu_01PUGgXabrSSEx2617C7zdFg",
+              "tool_use_id": "toolu_01MY35jrkaEKSgNsr9vagL9w",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
-        "timestamp": "2026-04-16T16:48:45.594Z",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
+        "timestamp": "2026-04-17T16:17:34.823Z",
         "tool_use_result": {
           "interrupted": false,
           "isImage": false,
           "noOutputExpected": false,
-          "returnCodeInterpretation": "Some directories were inaccessible",
           "stderr": "",
           "stdout": "<REDACTED_PATH>"
         },
         "type": "user",
-        "uuid": "7161b512-8d74-425b-a55d-87b40f096077"
+        "uuid": "46420514-a75d-4ff2-b659-5d51e3045bb7"
       }
     },
     {
@@ -905,12 +891,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "Found it! The trip_notes.md file is located at `<REDACTED_PATH> Let me read that file now.",
+              "thinking": "Found it! The file is at `<REDACTED_PATH> Let me read it now.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01CbfdnA1J7juHD5aKb8Djut",
+          "id": "msg_01YYWpimTSQnUrn3iKDRQekJ",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -920,10 +906,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 185
+              "ephemeral_5m_input_tokens": 181
             },
-            "cache_creation_input_tokens": 185,
-            "cache_read_input_tokens": 42609,
+            "cache_creation_input_tokens": 181,
+            "cache_read_input_tokens": 42665,
             "inference_geo": "not_available",
             "input_tokens": 8,
             "output_tokens": 1,
@@ -931,9 +917,9 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
         "type": "assistant",
-        "uuid": "3dc9c831-337e-48d7-b2a5-a89adf21c922"
+        "uuid": "b1604de8-1929-4666-accb-e312f1c60537"
       }
     },
     {
@@ -945,7 +931,7 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01LgLtt7wEwdF2SsFRAu7nuh",
+              "id": "toolu_01C6gtu1raZYSSW8yojvEmr1",
               "input": {
                 "file_path": "<REDACTED_PATH>"
               },
@@ -954,7 +940,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01CbfdnA1J7juHD5aKb8Djut",
+          "id": "msg_01YYWpimTSQnUrn3iKDRQekJ",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -964,10 +950,10 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 185
+              "ephemeral_5m_input_tokens": 181
             },
-            "cache_creation_input_tokens": 185,
-            "cache_read_input_tokens": 42609,
+            "cache_creation_input_tokens": 181,
+            "cache_read_input_tokens": 42665,
             "inference_geo": "not_available",
             "input_tokens": 8,
             "output_tokens": 1,
@@ -975,9 +961,9 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
         "type": "assistant",
-        "uuid": "452a6a75-6a61-4b82-8710-b3a335288e84"
+        "uuid": "19feabb0-84a5-48dd-97fc-a28c144eecdd"
       }
     },
     {
@@ -989,18 +975,18 @@
             "cwd": "<REDACTED_CWD>",
             "hook_event_name": "PreToolUse",
             "permission_mode": "bypassPermissions",
-            "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+            "session_id": "3316b244-1496-427a-95ea-f86132304c12",
             "tool_input": {
               "file_path": "<REDACTED_PATH>"
             },
             "tool_name": "Read",
-            "tool_use_id": "toolu_01LgLtt7wEwdF2SsFRAu7nuh",
+            "tool_use_id": "toolu_01C6gtu1raZYSSW8yojvEmr1",
             "transcript_path": "<REDACTED_PATH>"
           },
           "subtype": "hook_callback",
-          "tool_use_id": "toolu_01LgLtt7wEwdF2SsFRAu7nuh"
+          "tool_use_id": "toolu_01C6gtu1raZYSSW8yojvEmr1"
         },
-        "request_id": "71fa8983-f509-444f-84e4-e324e9043fbe",
+        "request_id": "5c00935b-cae7-4f95-82d6-f2152047a289",
         "type": "control_request"
       }
     },
@@ -1010,7 +996,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "71fa8983-f509-444f-84e4-e324e9043fbe",
+            "request_id": "5c00935b-cae7-4f95-82d6-f2152047a289",
             "response": {},
             "subtype": "success"
           },
@@ -1027,7 +1013,7 @@
             "cwd": "<REDACTED_CWD>",
             "hook_event_name": "PostToolUse",
             "permission_mode": "bypassPermissions",
-            "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+            "session_id": "3316b244-1496-427a-95ea-f86132304c12",
             "tool_input": {
               "file_path": "<REDACTED_PATH>"
             },
@@ -1042,13 +1028,13 @@
               },
               "type": "text"
             },
-            "tool_use_id": "toolu_01LgLtt7wEwdF2SsFRAu7nuh",
+            "tool_use_id": "toolu_01C6gtu1raZYSSW8yojvEmr1",
             "transcript_path": "<REDACTED_PATH>"
           },
           "subtype": "hook_callback",
-          "tool_use_id": "toolu_01LgLtt7wEwdF2SsFRAu7nuh"
+          "tool_use_id": "toolu_01C6gtu1raZYSSW8yojvEmr1"
         },
-        "request_id": "8c11b0de-2ba0-4294-b7e5-826a2e552373",
+        "request_id": "b8595d0d-256f-4511-b7dc-a578ff23b77f",
         "type": "control_request"
       }
     },
@@ -1058,7 +1044,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "8c11b0de-2ba0-4294-b7e5-826a2e552373",
+            "request_id": "b8595d0d-256f-4511-b7dc-a578ff23b77f",
             "response": {},
             "subtype": "success"
           },
@@ -1073,15 +1059,15 @@
           "content": [
             {
               "content": "1\t# Tokyo Trip Notes\n2\t\n3\t- Budget: 1500 USD\n4\t- Hotel: Park Hotel Tokyo\n5\t- Transit plan: TBD\n6\t- Reminder: buy JR Pass\n7\t\n8\tSummary: still rough, needs cleanup.\n9\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_01LgLtt7wEwdF2SsFRAu7nuh",
+              "tool_use_id": "toolu_01C6gtu1raZYSSW8yojvEmr1",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
-        "timestamp": "2026-04-16T16:48:47.435Z",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
+        "timestamp": "2026-04-17T16:17:36.346Z",
         "tool_use_result": {
           "file": {
             "content": "# Tokyo Trip Notes\n\n- Budget: 1500 USD\n- Hotel: Park Hotel Tokyo\n- Transit plan: TBD\n- Reminder: buy JR Pass\n\nSummary: still rough, needs cleanup.\n",
@@ -1093,7 +1079,7 @@
           "type": "text"
         },
         "type": "user",
-        "uuid": "86304b07-39b8-40ba-ad48-52161a917107"
+        "uuid": "69b568d3-39b1-4c1c-87bc-e9f7921bf767"
       }
     },
     {
@@ -1103,12 +1089,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "Great! I found the trip_notes.md file and have read its contents. Now let me summarize the current budget and hotel status as requested.",
+              "thinking": "Perfect! I found and read the trip_notes.md file. Now I can summarize the budget and hotel status for the user.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01KK3nEY4FPYfWn3eRuMgu4g",
+          "id": "msg_01KETzzW5WGZcUfSLBPVoNyW",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -1118,20 +1104,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 311
+              "ephemeral_5m_input_tokens": 304
             },
-            "cache_creation_input_tokens": 311,
-            "cache_read_input_tokens": 42794,
+            "cache_creation_input_tokens": 304,
+            "cache_read_input_tokens": 42846,
             "inference_geo": "not_available",
             "input_tokens": 8,
-            "output_tokens": 1,
+            "output_tokens": 5,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
         "type": "assistant",
-        "uuid": "9e63e50c-b793-441c-8b99-42ee997f4d9b"
+        "uuid": "6e805f4b-9a84-4e03-900a-88ac36bdfe6b"
       }
     },
     {
@@ -1140,12 +1126,12 @@
         "message": {
           "content": [
             {
-              "text": "Perfect! I found the file. Here's the summary of the Tokyo trip budget and hotel status:\n\n## Current Trip Status Summary\n\n**Budget:**\n- Total allocated: **$1,500 USD**\n\n**Hotel:**\n- Booked at: **Park Hotel Tokyo**\n\n**Overall Status:**\nThe notes indicate the trip planning is still in rough/early stages and needs cleanup. There are still items to finalize, including:\n- Transit plan (TBD - to be determined)\n- Reminder to purchase JR Pass for local transportation\n\nThe file is located at `<REDACTED_PATH>",
+              "text": "Perfect! I found the file. Here's a summary of the current budget and hotel status from the trip notes:\n\n## Trip Budget & Hotel Status\n\n**Budget:** $1,500 USD\n\n**Hotel:** Park Hotel Tokyo\n\n**Current Status:** The notes indicate the trip planning is still in rough shape and needs cleanup. Additional items noted include:\n- Transit plan is still to be determined (TBD)\n- There's a reminder to purchase a JR Pass\n\nThe file is located at: `<REDACTED_PATH>",
               "type": "text"
             }
           ],
           "context_management": null,
-          "id": "msg_01KK3nEY4FPYfWn3eRuMgu4g",
+          "id": "msg_01KETzzW5WGZcUfSLBPVoNyW",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -1155,20 +1141,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 311
+              "ephemeral_5m_input_tokens": 304
             },
-            "cache_creation_input_tokens": 311,
-            "cache_read_input_tokens": 42794,
+            "cache_creation_input_tokens": 304,
+            "cache_read_input_tokens": 42846,
             "inference_geo": "not_available",
             "input_tokens": 8,
-            "output_tokens": 1,
+            "output_tokens": 5,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
         "type": "assistant",
-        "uuid": "e2df00f4-e47c-4e89-ba5c-322ef2a79c57"
+        "uuid": "b06f2081-72d6-4a26-a7c3-049fc8880554"
       }
     },
     {
@@ -1179,16 +1165,16 @@
           "input": {
             "cwd": "<REDACTED_CWD>",
             "hook_event_name": "Stop",
-            "last_assistant_message": "Perfect! I found the file. Here's the summary of the Tokyo trip budget and hotel status:\n\n## Current Trip Status Summary\n\n**Budget:**\n- Total allocated: **$1,500 USD**\n\n**Hotel:**\n- Booked at: **Park Hotel Tokyo**\n\n**Overall Status:**\nThe notes indicate the trip planning is still in rough/early stages and needs cleanup. There are still items to finalize, including:\n- Transit plan (TBD - to be determined)\n- Reminder to purchase JR Pass for local transportation\n\nThe file is located at `<REDACTED_PATH>",
+            "last_assistant_message": "Perfect! I found the file. Here's a summary of the current budget and hotel status from the trip notes:\n\n## Trip Budget & Hotel Status\n\n**Budget:** $1,500 USD\n\n**Hotel:** Park Hotel Tokyo\n\n**Current Status:** The notes indicate the trip planning is still in rough shape and needs cleanup. Additional items noted include:\n- Transit plan is still to be determined (TBD)\n- There's a reminder to purchase a JR Pass\n\nThe file is located at: `<REDACTED_PATH>",
             "permission_mode": "bypassPermissions",
-            "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+            "session_id": "3316b244-1496-427a-95ea-f86132304c12",
             "stop_hook_active": false,
             "transcript_path": "<REDACTED_PATH>"
           },
           "subtype": "hook_callback",
-          "tool_use_id": "81ea2c59-2a6f-4d74-adc3-95b82aa4fb15"
+          "tool_use_id": "bb516579-8a53-4312-84c2-bed92aa006e1"
         },
-        "request_id": "37406c20-5ec0-427e-b442-b052462d7014",
+        "request_id": "c970de2c-336b-43d9-8678-dbc7ebf7e7cf",
         "type": "control_request"
       }
     },
@@ -1198,7 +1184,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "37406c20-5ec0-427e-b442-b052462d7014",
+            "request_id": "c970de2c-336b-43d9-8678-dbc7ebf7e7cf",
             "response": {},
             "subtype": "success"
           },
@@ -1210,54 +1196,42 @@
       "op": "read",
       "payload": {
         "api_error_status": null,
-        "duration_api_ms": 11769,
-        "duration_ms": 91645,
+        "duration_api_ms": 12635,
+        "duration_ms": 146116,
         "fast_mode_state": "off",
         "is_error": false,
         "modelUsage": {
           "claude-haiku-4-5-20251001": {
-            "cacheCreationInputTokens": 14252,
-            "cacheReadInputTokens": 198010,
+            "cacheCreationInputTokens": 7427,
+            "cacheReadInputTokens": 205207,
             "contextWindow": 200000,
-            "costUSD": 0.042302,
+            "costUSD": 0.03405045,
             "inputTokens": 411,
             "maxOutputTokens": 32000,
-            "outputTokens": 855,
+            "outputTokens": 767,
             "webSearchRequests": 0
           }
         },
         "num_turns": 5,
         "permission_denials": [],
-        "result": "Perfect! I found the file. Here's the summary of the Tokyo trip budget and hotel status:\n\n## Current Trip Status Summary\n\n**Budget:**\n- Total allocated: **$1,500 USD**\n\n**Hotel:**\n- Booked at: **Park Hotel Tokyo**\n\n**Overall Status:**\nThe notes indicate the trip planning is still in rough/early stages and needs cleanup. There are still items to finalize, including:\n- Transit plan (TBD - to be determined)\n- Reminder to purchase JR Pass for local transportation\n\nThe file is located at `<REDACTED_PATH>",
-        "session_id": "475354ee-e4de-46b8-9555-6e35eeb29c68",
+        "result": "Perfect! I found the file. Here's a summary of the current budget and hotel status from the trip notes:\n\n## Trip Budget & Hotel Status\n\n**Budget:** $1,500 USD\n\n**Hotel:** Park Hotel Tokyo\n\n**Current Status:** The notes indicate the trip planning is still in rough shape and needs cleanup. Additional items noted include:\n- Transit plan is still to be determined (TBD)\n- There's a reminder to purchase a JR Pass\n\nThe file is located at: `<REDACTED_PATH>",
+        "session_id": "3316b244-1496-427a-95ea-f86132304c12",
         "stop_reason": "end_turn",
         "subtype": "success",
         "terminal_reason": "completed",
-        "total_cost_usd": 0.042302,
+        "total_cost_usd": 0.03405045,
         "type": "result",
         "usage": {
           "cache_creation": {
             "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 14252
+            "ephemeral_5m_input_tokens": 7427
           },
-          "cache_creation_input_tokens": 14252,
-          "cache_read_input_tokens": 198010,
+          "cache_creation_input_tokens": 7427,
+          "cache_read_input_tokens": 205207,
           "inference_geo": "",
           "input_tokens": 42,
-          "iterations": [
-            {
-              "cache_creation": {
-                "ephemeral_1h_input_tokens": 0,
-                "ephemeral_5m_input_tokens": 311
-              },
-              "cache_creation_input_tokens": 311,
-              "cache_read_input_tokens": 42794,
-              "input_tokens": 8,
-              "output_tokens": 198,
-              "type": "message"
-            }
-          ],
-          "output_tokens": 840,
+          "iterations": [],
+          "output_tokens": 751,
           "server_tool_use": {
             "web_fetch_requests": 0,
             "web_search_requests": 0
@@ -1265,9 +1239,9 @@
           "service_tier": "standard",
           "speed": "standard"
         },
-        "uuid": "69c06b9a-deda-47d5-9f98-8be41238d1f3"
+        "uuid": "2088d539-8e41-4348-b818-987761b6b907"
       }
     }
   ],
-  "sdk_version": "0.1.60"
+  "sdk_version": "0.1.61"
 }

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_interleaved_subagent_tool_output_preserved.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_interleaved_subagent_tool_output_preserved.json
@@ -10,7 +10,7 @@
             "hooks": null,
             "subtype": "initialize"
           },
-          "request_id": "req_1_2360c389",
+          "request_id": "req_1_54affa20",
           "type": "control_request"
         }
       }
@@ -19,7 +19,7 @@
       "op": "read",
       "payload": {
         "response": {
-          "request_id": "req_1_2360c389",
+          "request_id": "req_1_54affa20",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
@@ -61,7 +61,7 @@
           "statusline-setup"
         ],
         "apiKeySource": "ANTHROPIC_API_KEY",
-        "claude_code_version": "2.1.111",
+        "claude_code_version": "2.1.112",
         "cwd": "<REDACTED_CWD>",
         "fast_mode_state": "off",
         "mcp_servers": [],
@@ -78,7 +78,7 @@
             "source": "rust-analyzer-lsp@claude-plugins-official"
           }
         ],
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "skills": [
           "update-config",
           "debug",
@@ -144,7 +144,7 @@
           "Write"
         ],
         "type": "system",
-        "uuid": "84762ac6-3391-4b0d-b82e-2e92e56b685c"
+        "uuid": "953d07e1-2244-476d-808b-7882a677b432"
       }
     },
     {
@@ -154,12 +154,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The user is asking me to:\n1. Launch two independent general-purpose subagents\n2. First subagent: Run `echo alpha-bash-output` with Bash, then Read alpha.txt, return only file contents\n3. Second subagent: Run `echo beta-bash-output` with Bash, then Read beta.txt, return only file contents\n4. After both finish, reply with exactly two lines in order: alpha then beta\n5. Use both subagents - don't answer directly\n\nI need to use the Agent tool twice with the subagent_type as \"general-purpose\". Since these are independent tasks, I can make both Agent calls in the same function_calls block.\n\nLet me construct the prompts carefully:\n\nFor the first agent:\n- Run `echo alpha-bash-output`\n- Then use Read on alpha.txt\n- Return only the file contents from alpha.txt\n\nFor the second agent:\n- Run `echo beta-bash-output`\n- Then use Read on beta.txt\n- Return only the file contents from beta.txt\n\nBoth agents should complete their tasks and return their results. Then I'll combine them into exactly two lines.",
+              "thinking": "The user is asking me to:\n1. Launch two general-purpose subagents (using the Agent tool)\n2. Both should be independent tasks that can run in parallel\n3. First agent: run `echo alpha-bash-output` and then read from alpha.txt, returning just the file contents\n4. Second agent: run `echo beta-bash-output` and then read from beta.txt, returning just the file contents\n5. After both finish, reply with exactly two lines: alpha contents then beta contents\n6. Don't ask clarifying questions, don't answer directly without using both subagents\n\nThis is a good use case for running multiple agents in parallel since they're independent. The API supports this - I can make multiple Agent tool calls in a single message block.\n\nLet me craft the prompts for each agent carefully:\n- Each agent should use Bash to run the echo command\n- Then use the Read tool to read the respective file\n- Return only the file contents (not the echo output)\n\nLet me make both Agent calls in parallel.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01TF6e51gE2nye8gzmBeCfmg",
+          "id": "msg_01KLgZrpgpjn1m2bD4fhuG8V",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -180,9 +180,9 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "type": "assistant",
-        "uuid": "08a0a7ac-6d7d-47dc-aa57-e8a4ca438701"
+        "uuid": "acc0bda1-d3c6-4f0e-bcdc-474250ebebf7"
       }
     },
     {
@@ -194,10 +194,10 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01446HHFKW9agaCaDV21AgbT",
+              "id": "toolu_016YKqSeabuKrCff6WFaiXfj",
               "input": {
-                "description": "Run bash echo and read alpha.txt",
-                "prompt": "Use Bash to run: echo alpha-bash-output\nThen use Read to read the file alpha.txt\nReturn only the contents of alpha.txt, nothing else.",
+                "description": "Run alpha bash command and read alpha.txt",
+                "prompt": "Run `echo alpha-bash-output` using Bash, then use the Read tool to read the contents of alpha.txt. After both tool calls complete, return only the file contents from alpha.txt - nothing else.",
                 "subagent_type": "general-purpose"
               },
               "name": "Agent",
@@ -205,7 +205,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01TF6e51gE2nye8gzmBeCfmg",
+          "id": "msg_01KLgZrpgpjn1m2bD4fhuG8V",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -226,23 +226,23 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "type": "assistant",
-        "uuid": "129fb21d-7510-475a-af45-d078878c93d3"
+        "uuid": "0c42007f-ec5e-417c-814a-9150096a352e"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Run bash echo and read alpha.txt",
-        "prompt": "Use Bash to run: echo alpha-bash-output\nThen use Read to read the file alpha.txt\nReturn only the contents of alpha.txt, nothing else.",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "description": "Run alpha bash command and read alpha.txt",
+        "prompt": "Run `echo alpha-bash-output` using Bash, then use the Read tool to read the contents of alpha.txt. After both tool calls complete, return only the file contents from alpha.txt - nothing else.",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "subtype": "task_started",
-        "task_id": "ae3d087a550001dcc",
+        "task_id": "a97d9688370965216",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01446HHFKW9agaCaDV21AgbT",
+        "tool_use_id": "toolu_016YKqSeabuKrCff6WFaiXfj",
         "type": "system",
-        "uuid": "fa26c76b-e76f-4312-913c-18886520e9d6"
+        "uuid": "6fb5907f-16fb-4fc1-9442-da791373c83f"
       }
     },
     {
@@ -251,17 +251,17 @@
         "message": {
           "content": [
             {
-              "text": "Use Bash to run: echo alpha-bash-output\nThen use Read to read the file alpha.txt\nReturn only the contents of alpha.txt, nothing else.",
+              "text": "Run `echo alpha-bash-output` using Bash, then use the Read tool to read the contents of alpha.txt. After both tool calls complete, return only the file contents from alpha.txt - nothing else.",
               "type": "text"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01446HHFKW9agaCaDV21AgbT",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
-        "timestamp": "2026-04-16T16:49:50.467Z",
+        "parent_tool_use_id": "toolu_016YKqSeabuKrCff6WFaiXfj",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
+        "timestamp": "2026-04-17T16:18:36.679Z",
         "type": "user",
-        "uuid": "185c38ff-e36f-4c20-af21-9e20e3b87002"
+        "uuid": "5a079c37-162c-4d05-82b5-c4c05b820367"
       }
     },
     {
@@ -273,10 +273,10 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01CdrXcdgPDfuZDTLWbus5t8",
+              "id": "toolu_01SeYbHZ8FBi3v9EJNHqPGoG",
               "input": {
-                "description": "Run bash echo and read beta.txt",
-                "prompt": "Use Bash to run: echo beta-bash-output\nThen use Read to read the file beta.txt\nReturn only the contents of beta.txt, nothing else.",
+                "description": "Run beta bash command and read beta.txt",
+                "prompt": "Run `echo beta-bash-output` using Bash, then use the Read tool to read the contents of beta.txt. After both tool calls complete, return only the file contents from beta.txt - nothing else.",
                 "subagent_type": "general-purpose"
               },
               "name": "Agent",
@@ -284,7 +284,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01TF6e51gE2nye8gzmBeCfmg",
+          "id": "msg_01KLgZrpgpjn1m2bD4fhuG8V",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -305,23 +305,23 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "type": "assistant",
-        "uuid": "cdbca3df-5fa7-4c70-b76c-fb34234d4dd6"
+        "uuid": "3c91a353-f161-4382-b3bc-c18d3289a29b"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Run bash echo and read beta.txt",
-        "prompt": "Use Bash to run: echo beta-bash-output\nThen use Read to read the file beta.txt\nReturn only the contents of beta.txt, nothing else.",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "description": "Run beta bash command and read beta.txt",
+        "prompt": "Run `echo beta-bash-output` using Bash, then use the Read tool to read the contents of beta.txt. After both tool calls complete, return only the file contents from beta.txt - nothing else.",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "subtype": "task_started",
-        "task_id": "a78972a026caaf745",
+        "task_id": "abfb3d0c6cb757568",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01CdrXcdgPDfuZDTLWbus5t8",
+        "tool_use_id": "toolu_01SeYbHZ8FBi3v9EJNHqPGoG",
         "type": "system",
-        "uuid": "e132010e-36f5-405c-aa66-1a4b5f0da645"
+        "uuid": "92b88be5-4dae-4020-8471-2607504797cd"
       }
     },
     {
@@ -330,17 +330,17 @@
         "message": {
           "content": [
             {
-              "text": "Use Bash to run: echo beta-bash-output\nThen use Read to read the file beta.txt\nReturn only the contents of beta.txt, nothing else.",
+              "text": "Run `echo beta-bash-output` using Bash, then use the Read tool to read the contents of beta.txt. After both tool calls complete, return only the file contents from beta.txt - nothing else.",
               "type": "text"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01CdrXcdgPDfuZDTLWbus5t8",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
-        "timestamp": "2026-04-16T16:49:50.787Z",
+        "parent_tool_use_id": "toolu_01SeYbHZ8FBi3v9EJNHqPGoG",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
+        "timestamp": "2026-04-17T16:18:36.933Z",
         "type": "user",
-        "uuid": "e6f5f514-e0ab-4852-b5be-ff3650fc568b"
+        "uuid": "111eafb2-32ee-4d2c-b8c4-4b45f44cb8d1"
       }
     },
     {
@@ -348,17 +348,17 @@
       "payload": {
         "description": "Running echo alpha-bash-output",
         "last_tool_name": "Bash",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "subtype": "task_progress",
-        "task_id": "ae3d087a550001dcc",
-        "tool_use_id": "toolu_01446HHFKW9agaCaDV21AgbT",
+        "task_id": "a97d9688370965216",
+        "tool_use_id": "toolu_016YKqSeabuKrCff6WFaiXfj",
         "type": "system",
         "usage": {
-          "duration_ms": 1367,
+          "duration_ms": 1213,
           "tool_uses": 1,
-          "total_tokens": 17496
+          "total_tokens": 17504
         },
-        "uuid": "18e7c1a2-cbc4-4ad3-8a7a-7eaa433ae5e2"
+        "uuid": "d16b969a-7830-4533-8dd0-cd0f1fea93c5"
       }
     },
     {
@@ -370,7 +370,7 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01RXiZnoUgHSGtpcgnhqRhyP",
+              "id": "toolu_01UtSyaTeYZ6gEfy2gmgRp2U",
               "input": {
                 "command": "echo alpha-bash-output"
               },
@@ -379,7 +379,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01FGrLwdS7Y93hzpsutkcPsc",
+          "id": "msg_015FC1XfnpwoWTXuBhqLdaRT",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -389,20 +389,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1064
+              "ephemeral_5m_input_tokens": 1074
             },
-            "cache_creation_input_tokens": 1064,
+            "cache_creation_input_tokens": 1074,
             "cache_read_input_tokens": 16423,
             "inference_geo": "not_available",
             "input_tokens": 3,
-            "output_tokens": 3,
+            "output_tokens": 2,
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01446HHFKW9agaCaDV21AgbT",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "parent_tool_use_id": "toolu_016YKqSeabuKrCff6WFaiXfj",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "type": "assistant",
-        "uuid": "e92f8e72-6644-4687-a96e-7e00fb9f0157"
+        "uuid": "856ba447-ced4-447c-bfd3-b574ac405f00"
       }
     },
     {
@@ -413,17 +413,17 @@
             {
               "content": "alpha-bash-output",
               "is_error": false,
-              "tool_use_id": "toolu_01RXiZnoUgHSGtpcgnhqRhyP",
+              "tool_use_id": "toolu_01UtSyaTeYZ6gEfy2gmgRp2U",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01446HHFKW9agaCaDV21AgbT",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
-        "timestamp": "2026-04-16T16:49:52.025Z",
+        "parent_tool_use_id": "toolu_016YKqSeabuKrCff6WFaiXfj",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
+        "timestamp": "2026-04-17T16:18:38.090Z",
         "type": "user",
-        "uuid": "a24e2fd3-92ab-4ab7-ac79-ff3dbb0f34c8"
+        "uuid": "bd6f6c29-6310-414c-bbd7-1813de928569"
       }
     },
     {
@@ -431,17 +431,17 @@
       "payload": {
         "description": "Reading alpha.txt",
         "last_tool_name": "Read",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "subtype": "task_progress",
-        "task_id": "ae3d087a550001dcc",
-        "tool_use_id": "toolu_01446HHFKW9agaCaDV21AgbT",
+        "task_id": "a97d9688370965216",
+        "tool_use_id": "toolu_016YKqSeabuKrCff6WFaiXfj",
         "type": "system",
         "usage": {
-          "duration_ms": 1593,
+          "duration_ms": 1524,
           "tool_uses": 2,
-          "total_tokens": 17499
+          "total_tokens": 17506
         },
-        "uuid": "7e894b97-642a-4d51-b3fe-4bb0d18f71b4"
+        "uuid": "874ebbd9-59a5-474d-829a-9b5716eefa3a"
       }
     },
     {
@@ -453,16 +453,16 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01LhRdpDqfevbWyXREw7fLbi",
+              "id": "toolu_01CYL2s8A9fQYF4Cqag9XKvE",
               "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_interleaved_subagent_tool1/interleaved_parenting_workspace/alpha.txt"
+                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-578/test_interleaved_subagent_tool1/interleaved_parenting_workspace/alpha.txt"
               },
               "name": "Read",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01FGrLwdS7Y93hzpsutkcPsc",
+          "id": "msg_015FC1XfnpwoWTXuBhqLdaRT",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -472,20 +472,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1064
+              "ephemeral_5m_input_tokens": 1074
             },
-            "cache_creation_input_tokens": 1064,
+            "cache_creation_input_tokens": 1074,
             "cache_read_input_tokens": 16423,
             "inference_geo": "not_available",
             "input_tokens": 3,
-            "output_tokens": 3,
+            "output_tokens": 2,
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01446HHFKW9agaCaDV21AgbT",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "parent_tool_use_id": "toolu_016YKqSeabuKrCff6WFaiXfj",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "type": "assistant",
-        "uuid": "eaeb4e88-b77e-40a0-a1db-ff222e255b2e"
+        "uuid": "806541b3-2842-43e2-ac56-d23edea10efd"
       }
     },
     {
@@ -495,17 +495,17 @@
           "content": [
             {
               "content": "1\talpha_file_contents\n2\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_01LhRdpDqfevbWyXREw7fLbi",
+              "tool_use_id": "toolu_01CYL2s8A9fQYF4Cqag9XKvE",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01446HHFKW9agaCaDV21AgbT",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
-        "timestamp": "2026-04-16T16:49:52.063Z",
+        "parent_tool_use_id": "toolu_016YKqSeabuKrCff6WFaiXfj",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
+        "timestamp": "2026-04-17T16:18:38.206Z",
         "type": "user",
-        "uuid": "f33d0659-2be6-46e4-a7f4-2b5ad2c8ebf8"
+        "uuid": "826614c2-abc4-40e3-b517-53522bbb9588"
       }
     },
     {
@@ -513,17 +513,17 @@
       "payload": {
         "description": "Running echo beta-bash-output",
         "last_tool_name": "Bash",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "subtype": "task_progress",
-        "task_id": "a78972a026caaf745",
-        "tool_use_id": "toolu_01CdrXcdgPDfuZDTLWbus5t8",
+        "task_id": "abfb3d0c6cb757568",
+        "tool_use_id": "toolu_01SeYbHZ8FBi3v9EJNHqPGoG",
         "type": "system",
         "usage": {
-          "duration_ms": 1642,
+          "duration_ms": 1330,
           "tool_uses": 1,
-          "total_tokens": 17496
+          "total_tokens": 17506
         },
-        "uuid": "57eac193-b656-421d-a998-7b43d122d058"
+        "uuid": "3332fbd1-2ec8-4f31-a8ab-e1a58d40af26"
       }
     },
     {
@@ -535,7 +535,7 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_011C3HZsnBJGYK6v67JF7bu4",
+              "id": "toolu_01XFgRCz53Rqt5nxRaeyUmuJ",
               "input": {
                 "command": "echo beta-bash-output"
               },
@@ -544,7 +544,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01MqTKyCQ6YXdPpDGNgRYiwV",
+          "id": "msg_01SEzqoKDuzTj1Rb5w97mAPn",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -554,20 +554,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 434
+              "ephemeral_5m_input_tokens": 1074
             },
-            "cache_creation_input_tokens": 434,
-            "cache_read_input_tokens": 17053,
+            "cache_creation_input_tokens": 1074,
+            "cache_read_input_tokens": 16423,
             "inference_geo": "not_available",
             "input_tokens": 3,
             "output_tokens": 3,
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01CdrXcdgPDfuZDTLWbus5t8",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "parent_tool_use_id": "toolu_01SeYbHZ8FBi3v9EJNHqPGoG",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "type": "assistant",
-        "uuid": "56e7a1cd-b83c-4a54-833b-1533f1efd366"
+        "uuid": "2c9e2bd8-d4e3-460b-8e8a-468645880a5b"
       }
     },
     {
@@ -578,17 +578,17 @@
             {
               "content": "beta-bash-output",
               "is_error": false,
-              "tool_use_id": "toolu_011C3HZsnBJGYK6v67JF7bu4",
+              "tool_use_id": "toolu_01XFgRCz53Rqt5nxRaeyUmuJ",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01CdrXcdgPDfuZDTLWbus5t8",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
-        "timestamp": "2026-04-16T16:49:52.444Z",
+        "parent_tool_use_id": "toolu_01SeYbHZ8FBi3v9EJNHqPGoG",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
+        "timestamp": "2026-04-17T16:18:38.272Z",
         "type": "user",
-        "uuid": "e6700558-ae57-4707-8c8a-6d95abc68189"
+        "uuid": "25ffab4a-1954-4641-b54b-260e056aa30e"
       }
     },
     {
@@ -596,17 +596,17 @@
       "payload": {
         "description": "Reading beta.txt",
         "last_tool_name": "Read",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "subtype": "task_progress",
-        "task_id": "a78972a026caaf745",
-        "tool_use_id": "toolu_01CdrXcdgPDfuZDTLWbus5t8",
+        "task_id": "abfb3d0c6cb757568",
+        "tool_use_id": "toolu_01SeYbHZ8FBi3v9EJNHqPGoG",
         "type": "system",
         "usage": {
-          "duration_ms": 1968,
+          "duration_ms": 1418,
           "tool_uses": 2,
-          "total_tokens": 17499
+          "total_tokens": 17509
         },
-        "uuid": "4e8f87d0-2df1-44ac-9810-89a92135f829"
+        "uuid": "599d801c-3caa-4780-8e44-b70cb5e2984e"
       }
     },
     {
@@ -618,16 +618,16 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_0181GViKqcHr6Jdq7xjHfT4f",
+              "id": "toolu_01G6rMkMgH5PQ7mR57tJw3GQ",
               "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_interleaved_subagent_tool1/interleaved_parenting_workspace/beta.txt"
+                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-578/test_interleaved_subagent_tool1/interleaved_parenting_workspace/beta.txt"
               },
               "name": "Read",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01MqTKyCQ6YXdPpDGNgRYiwV",
+          "id": "msg_01SEzqoKDuzTj1Rb5w97mAPn",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -637,20 +637,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 434
+              "ephemeral_5m_input_tokens": 1074
             },
-            "cache_creation_input_tokens": 434,
-            "cache_read_input_tokens": 17053,
+            "cache_creation_input_tokens": 1074,
+            "cache_read_input_tokens": 16423,
             "inference_geo": "not_available",
             "input_tokens": 3,
             "output_tokens": 3,
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01CdrXcdgPDfuZDTLWbus5t8",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "parent_tool_use_id": "toolu_01SeYbHZ8FBi3v9EJNHqPGoG",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "type": "assistant",
-        "uuid": "ba1cdc76-f57b-40ea-b305-7a6f05bd0a0f"
+        "uuid": "a83f7d84-0add-4913-b717-014acb92bcdb"
       }
     },
     {
@@ -660,36 +660,36 @@
           "content": [
             {
               "content": "1\tbeta_file_contents\n2\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_0181GViKqcHr6Jdq7xjHfT4f",
+              "tool_use_id": "toolu_01G6rMkMgH5PQ7mR57tJw3GQ",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01CdrXcdgPDfuZDTLWbus5t8",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
-        "timestamp": "2026-04-16T16:49:52.759Z",
+        "parent_tool_use_id": "toolu_01SeYbHZ8FBi3v9EJNHqPGoG",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
+        "timestamp": "2026-04-17T16:18:38.352Z",
         "type": "user",
-        "uuid": "a90b84cb-09a6-4592-a63e-a6f28b7235cd"
+        "uuid": "84e0963a-afc1-4203-8ca3-849c662a4110"
       }
     },
     {
       "op": "read",
       "payload": {
         "output_file": "",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "status": "completed",
         "subtype": "task_notification",
-        "summary": "Run bash echo and read alpha.txt",
-        "task_id": "ae3d087a550001dcc",
-        "tool_use_id": "toolu_01446HHFKW9agaCaDV21AgbT",
+        "summary": "Run alpha bash command and read alpha.txt",
+        "task_id": "a97d9688370965216",
+        "tool_use_id": "toolu_016YKqSeabuKrCff6WFaiXfj",
         "type": "system",
         "usage": {
-          "duration_ms": 2611,
+          "duration_ms": 2907,
           "tool_uses": 2,
-          "total_tokens": 18665
+          "total_tokens": 18671
         },
-        "uuid": "3e6148a2-c8ba-45e7-988a-de39c4b2cf14"
+        "uuid": "e8f6cc09-e4e9-47ec-979f-8647ee644531"
       }
     },
     {
@@ -704,21 +704,21 @@
                   "type": "text"
                 },
                 {
-                  "text": "agentId: ae3d087a550001dcc (use SendMessage with to: 'ae3d087a550001dcc' to continue this agent)\n<usage>total_tokens: 18663\ntool_uses: 2\nduration_ms: 2612</usage>",
+                  "text": "agentId: a97d9688370965216 (use SendMessage with to: 'a97d9688370965216' to continue this agent)\n<usage>total_tokens: 18672\ntool_uses: 2\nduration_ms: 2908</usage>",
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01446HHFKW9agaCaDV21AgbT",
+              "tool_use_id": "toolu_016YKqSeabuKrCff6WFaiXfj",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
-        "timestamp": "2026-04-16T16:49:53.080Z",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
+        "timestamp": "2026-04-17T16:18:39.587Z",
         "tool_use_result": {
-          "agentId": "ae3d087a550001dcc",
+          "agentId": "a97d9688370965216",
           "agentType": "general-purpose",
           "content": [
             {
@@ -726,7 +726,7 @@
               "type": "text"
             }
           ],
-          "prompt": "Use Bash to run: echo alpha-bash-output\nThen use Read to read the file alpha.txt\nReturn only the contents of alpha.txt, nothing else.",
+          "prompt": "Run `echo alpha-bash-output` using Bash, then use the Read tool to read the contents of alpha.txt. After both tool calls complete, return only the file contents from alpha.txt - nothing else.",
           "status": "completed",
           "toolStats": {
             "bashCount": 1,
@@ -737,31 +737,19 @@
             "readCount": 1,
             "searchCount": 0
           },
-          "totalDurationMs": 2612,
-          "totalTokens": 18663,
+          "totalDurationMs": 2908,
+          "totalTokens": 18672,
           "totalToolUseCount": 2,
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1161
+              "ephemeral_5m_input_tokens": 2234
             },
-            "cache_creation_input_tokens": 1161,
-            "cache_read_input_tokens": 17487,
+            "cache_creation_input_tokens": 2234,
+            "cache_read_input_tokens": 16423,
             "inference_geo": "",
             "input_tokens": 7,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 1161
-                },
-                "cache_creation_input_tokens": 1161,
-                "cache_read_input_tokens": 17487,
-                "input_tokens": 7,
-                "output_tokens": 8,
-                "type": "message"
-              }
-            ],
+            "iterations": [],
             "output_tokens": 8,
             "server_tool_use": {
               "web_fetch_requests": 0,
@@ -772,26 +760,26 @@
           }
         },
         "type": "user",
-        "uuid": "47c90ac9-d15b-42a8-887c-338fb6d03b28"
+        "uuid": "4d72f7aa-535f-40e6-867f-96213fe03bb1"
       }
     },
     {
       "op": "read",
       "payload": {
         "output_file": "",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "status": "completed",
         "subtype": "task_notification",
-        "summary": "Run bash echo and read beta.txt",
-        "task_id": "a78972a026caaf745",
-        "tool_use_id": "toolu_01CdrXcdgPDfuZDTLWbus5t8",
+        "summary": "Run beta bash command and read beta.txt",
+        "task_id": "abfb3d0c6cb757568",
+        "tool_use_id": "toolu_01SeYbHZ8FBi3v9EJNHqPGoG",
         "type": "system",
         "usage": {
-          "duration_ms": 2743,
+          "duration_ms": 3095,
           "tool_uses": 2,
-          "total_tokens": 18665
+          "total_tokens": 18679
         },
-        "uuid": "4fd53d36-c85e-48fc-8bff-0518445cae84"
+        "uuid": "2376cbdb-9187-497d-9b26-467c88b0fa61"
       }
     },
     {
@@ -806,21 +794,21 @@
                   "type": "text"
                 },
                 {
-                  "text": "agentId: a78972a026caaf745 (use SendMessage with to: 'a78972a026caaf745' to continue this agent)\n<usage>total_tokens: 18663\ntool_uses: 2\nduration_ms: 2744</usage>",
+                  "text": "agentId: abfb3d0c6cb757568 (use SendMessage with to: 'abfb3d0c6cb757568' to continue this agent)\n<usage>total_tokens: 18677\ntool_uses: 2\nduration_ms: 3096</usage>",
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01CdrXcdgPDfuZDTLWbus5t8",
+              "tool_use_id": "toolu_01SeYbHZ8FBi3v9EJNHqPGoG",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
-        "timestamp": "2026-04-16T16:49:53.531Z",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
+        "timestamp": "2026-04-17T16:18:40.029Z",
         "tool_use_result": {
-          "agentId": "a78972a026caaf745",
+          "agentId": "abfb3d0c6cb757568",
           "agentType": "general-purpose",
           "content": [
             {
@@ -828,7 +816,7 @@
               "type": "text"
             }
           ],
-          "prompt": "Use Bash to run: echo beta-bash-output\nThen use Read to read the file beta.txt\nReturn only the contents of beta.txt, nothing else.",
+          "prompt": "Run `echo beta-bash-output` using Bash, then use the Read tool to read the contents of beta.txt. After both tool calls complete, return only the file contents from beta.txt - nothing else.",
           "status": "completed",
           "toolStats": {
             "bashCount": 1,
@@ -839,31 +827,19 @@
             "readCount": 1,
             "searchCount": 0
           },
-          "totalDurationMs": 2744,
-          "totalTokens": 18663,
+          "totalDurationMs": 3096,
+          "totalTokens": 18677,
           "totalToolUseCount": 2,
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1161
+              "ephemeral_5m_input_tokens": 1165
             },
-            "cache_creation_input_tokens": 1161,
-            "cache_read_input_tokens": 17487,
+            "cache_creation_input_tokens": 1165,
+            "cache_read_input_tokens": 17497,
             "inference_geo": "",
             "input_tokens": 7,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 1161
-                },
-                "cache_creation_input_tokens": 1161,
-                "cache_read_input_tokens": 17487,
-                "input_tokens": 7,
-                "output_tokens": 8,
-                "type": "message"
-              }
-            ],
+            "iterations": [],
             "output_tokens": 8,
             "server_tool_use": {
               "web_fetch_requests": 0,
@@ -874,7 +850,7 @@
           }
         },
         "type": "user",
-        "uuid": "229ae1e7-b58e-403e-9d78-fd1d95574ecb"
+        "uuid": "d5313b10-35e4-4f1f-a0fa-b1398de1db2b"
       }
     },
     {
@@ -884,12 +860,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "Great! Both agents have completed their tasks and returned their results:\n- First agent returned: \"alpha_file_contents\"\n- Second agent returned: \"beta_file_contents\"\n\nNow I need to reply with exactly two lines in order: alpha then beta.",
+              "thinking": "Perfect! Both agents have completed their tasks. I received the results:\n1. First agent returned: \"alpha_file_contents\"\n2. Second agent returned: \"beta_file_contents\"\n\nNow I need to reply with exactly two lines in order: alpha then beta. The output format should be:\nalpha_file_contents\nbeta_file_contents",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_011igSDn19ApHhtzgitzYXCH",
+          "id": "msg_01NR6MRGj2dk5XCHsF3akxBC",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -899,20 +875,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 734
+              "ephemeral_5m_input_tokens": 728
             },
-            "cache_creation_input_tokens": 734,
+            "cache_creation_input_tokens": 728,
             "cache_read_input_tokens": 23325,
             "inference_geo": "not_available",
             "input_tokens": 8,
-            "output_tokens": 1,
+            "output_tokens": 6,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "type": "assistant",
-        "uuid": "03df65a9-7902-43ea-9ad5-5a80f9a36a06"
+        "uuid": "109d4502-79e1-475a-97b9-c63547618f13"
       }
     },
     {
@@ -926,7 +902,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_011igSDn19ApHhtzgitzYXCH",
+          "id": "msg_01NR6MRGj2dk5XCHsF3akxBC",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -936,74 +912,62 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 734
+              "ephemeral_5m_input_tokens": 728
             },
-            "cache_creation_input_tokens": 734,
+            "cache_creation_input_tokens": 728,
             "cache_read_input_tokens": 23325,
             "inference_geo": "not_available",
             "input_tokens": 8,
-            "output_tokens": 1,
+            "output_tokens": 6,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "type": "assistant",
-        "uuid": "08ee26a9-1db7-43d0-a4e0-81d50d6827d7"
+        "uuid": "0ba9ce30-ba58-4576-9650-64ddd1c60840"
       }
     },
     {
       "op": "read",
       "payload": {
         "api_error_status": null,
-        "duration_api_ms": 11979,
-        "duration_ms": 8275,
+        "duration_api_ms": 13143,
+        "duration_ms": 9105,
         "fast_mode_state": "off",
         "is_error": false,
         "modelUsage": {
           "claude-haiku-4-5-20251001": {
-            "cacheCreationInputTokens": 4554,
-            "cacheReadInputTokens": 115100,
+            "cacheCreationInputTokens": 6275,
+            "cacheReadInputTokens": 113416,
             "contextWindow": 200000,
-            "costUSD": 0.022669499999999995,
+            "costUSD": 0.024717350000000003,
             "inputTokens": 522,
             "maxOutputTokens": 32000,
-            "outputTokens": 989,
+            "outputTokens": 1002,
             "webSearchRequests": 0
           }
         },
         "num_turns": 3,
         "permission_denials": [],
         "result": "alpha_file_contents\nbeta_file_contents",
-        "session_id": "ee0daae9-a0ed-4f53-be0f-85f333e72fc5",
+        "session_id": "def6cea8-925c-4098-9ace-9f5814a01458",
         "stop_reason": "end_turn",
         "subtype": "success",
         "terminal_reason": "completed",
-        "total_cost_usd": 0.022669499999999995,
+        "total_cost_usd": 0.024717350000000003,
         "type": "result",
         "usage": {
           "cache_creation": {
             "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 734
+            "ephemeral_5m_input_tokens": 728
           },
-          "cache_creation_input_tokens": 734,
+          "cache_creation_input_tokens": 728,
           "cache_read_input_tokens": 46650,
           "inference_geo": "",
           "input_tokens": 18,
-          "iterations": [
-            {
-              "cache_creation": {
-                "ephemeral_1h_input_tokens": 0,
-                "ephemeral_5m_input_tokens": 734
-              },
-              "cache_creation_input_tokens": 734,
-              "cache_read_input_tokens": 23325,
-              "input_tokens": 8,
-              "output_tokens": 78,
-              "type": "message"
-            }
-          ],
-          "output_tokens": 592,
+          "iterations": [],
+          "output_tokens": 603,
           "server_tool_use": {
             "web_fetch_requests": 0,
             "web_search_requests": 0
@@ -1011,9 +975,9 @@
           "service_tier": "standard",
           "speed": "standard"
         },
-        "uuid": "5f933791-b89a-43ce-8485-b797613687aa"
+        "uuid": "0c996a33-638e-447b-8f5f-7c16cdbab431"
       }
     }
   ],
-  "sdk_version": "0.1.60"
+  "sdk_version": "0.1.61"
 }

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_multiple_bundled_subagents_keep_outer_orchestration_separate.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_multiple_bundled_subagents_keep_outer_orchestration_separate.json
@@ -10,7 +10,7 @@
             "hooks": null,
             "subtype": "initialize"
           },
-          "request_id": "req_1_ec498772",
+          "request_id": "req_1_c32541c9",
           "type": "control_request"
         }
       }
@@ -19,7 +19,7 @@
       "op": "read",
       "payload": {
         "response": {
-          "request_id": "req_1_ec498772",
+          "request_id": "req_1_c32541c9",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
@@ -61,7 +61,7 @@
           "statusline-setup"
         ],
         "apiKeySource": "ANTHROPIC_API_KEY",
-        "claude_code_version": "2.1.111",
+        "claude_code_version": "2.1.112",
         "cwd": "<REDACTED_CWD>",
         "fast_mode_state": "off",
         "mcp_servers": [],
@@ -78,7 +78,7 @@
             "source": "rust-analyzer-lsp@claude-plugins-official"
           }
         ],
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
         "skills": [
           "update-config",
           "debug",
@@ -144,7 +144,7 @@
           "Write"
         ],
         "type": "system",
-        "uuid": "90181720-dda0-464c-b0c8-8c5fa693fafc"
+        "uuid": "2a1fdfbe-18de-4987-8894-f3909123ab33"
       }
     },
     {
@@ -154,12 +154,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The user wants me to launch two general-purpose subagents:\n1. First agent: Read release_notes_alpha.md using Bash/Read and return 'alpha:<version> | <owner>'\n2. Second agent: Read release_notes_beta.md using Bash/Read and return 'beta:<version> | <owner>'\n\nBoth agents should run independently, so I should make both Agent calls in a single message block.\n\nThen after both complete, I should reply with exactly two lines in the same order.\n\nLet me craft the prompts for each agent. They need to:\n1. Use Bash and Read tools to read the files\n2. Extract version and owner information\n3. Return ONLY the formatted string\n\nI'll use the general-purpose agent type since that's specified.",
+              "thinking": "The user wants me to launch two independent subagents (using the Agent tool) that will:\n1. First agent: Read release_notes_alpha.md and return 'alpha:<version> | <owner>'\n2. Second agent: Read release_notes_beta.md and return 'beta:<version> | <owner>'\n\nThen I need to report the results from both agents in exactly two lines.\n\nSince these are independent tasks, I should make both Agent calls in the same function_calls block. I'll use the general-purpose agent type for both, and give them specific instructions to use Bash and Read tools to extract the version and owner information.\n\nLet me structure the prompts clearly so each agent knows exactly what to do.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_019nX2CYZuqpKwWsp2Wp2zwZ",
+          "id": "msg_01YXXP1jUbVXJtTaKckyCeaD",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -180,9 +180,9 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
         "type": "assistant",
-        "uuid": "bb9ffb9b-7739-4a08-8f6a-77d8b24a40c6"
+        "uuid": "18d6a7a7-2df2-4c0a-9e0e-4e98929bb39b"
       }
     },
     {
@@ -194,17 +194,18 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01Xcs38SPGw9PZDGdHRNgFqg",
+              "id": "toolu_0134vWepDYu9KgwwaYL1oHzn",
               "input": {
                 "description": "Extract alpha version and owner from release notes",
-                "prompt": "Read the file release_notes_alpha.md using the Read tool. Extract the version number and the owner name from the file. Return ONLY the string in this exact format: alpha:<version> | <owner>\n\nDo not include any other text, explanation, or formatting. Just the single line output."
+                "prompt": "Read the file release_notes_alpha.md using the Read tool. Extract the version number and owner from the file. Return ONLY the result in this exact format: alpha:<version> | <owner>\n\nDo not include any other text in your response.",
+                "subagent_type": "general-purpose"
               },
               "name": "Agent",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_019nX2CYZuqpKwWsp2Wp2zwZ",
+          "id": "msg_01YXXP1jUbVXJtTaKckyCeaD",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -225,23 +226,23 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
         "type": "assistant",
-        "uuid": "83b870a1-d9c9-4da0-9bcd-3695d0be114c"
+        "uuid": "18ce549f-cd50-4929-a189-2189197ef38d"
       }
     },
     {
       "op": "read",
       "payload": {
         "description": "Extract alpha version and owner from release notes",
-        "prompt": "Read the file release_notes_alpha.md using the Read tool. Extract the version number and the owner name from the file. Return ONLY the string in this exact format: alpha:<version> | <owner>\n\nDo not include any other text, explanation, or formatting. Just the single line output.",
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
+        "prompt": "Read the file release_notes_alpha.md using the Read tool. Extract the version number and owner from the file. Return ONLY the result in this exact format: alpha:<version> | <owner>\n\nDo not include any other text in your response.",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
         "subtype": "task_started",
-        "task_id": "a7bb3d0e887fbbb2d",
+        "task_id": "adfd30aa7271a1476",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01Xcs38SPGw9PZDGdHRNgFqg",
+        "tool_use_id": "toolu_0134vWepDYu9KgwwaYL1oHzn",
         "type": "system",
-        "uuid": "86c3f40a-17fd-45e8-8b94-36f49f0c61a0"
+        "uuid": "0931a37e-8aa2-4014-9746-5ee8dfe92c18"
       }
     },
     {
@@ -250,17 +251,17 @@
         "message": {
           "content": [
             {
-              "text": "Read the file release_notes_alpha.md using the Read tool. Extract the version number and the owner name from the file. Return ONLY the string in this exact format: alpha:<version> | <owner>\n\nDo not include any other text, explanation, or formatting. Just the single line output.",
+              "text": "Read the file release_notes_alpha.md using the Read tool. Extract the version number and owner from the file. Return ONLY the result in this exact format: alpha:<version> | <owner>\n\nDo not include any other text in your response.",
               "type": "text"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01Xcs38SPGw9PZDGdHRNgFqg",
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
-        "timestamp": "2026-04-16T16:49:04.139Z",
+        "parent_tool_use_id": "toolu_0134vWepDYu9KgwwaYL1oHzn",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
+        "timestamp": "2026-04-17T16:17:51.715Z",
         "type": "user",
-        "uuid": "9cd80f20-0813-4385-8bbf-95a8902dbd10"
+        "uuid": "6c53e89a-dcef-4d16-9744-8a9a6fb357fa"
       }
     },
     {
@@ -272,17 +273,18 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01Vunci6oMrpxQ8jcCR8tKv7",
+              "id": "toolu_017cvA3q5wfSMsZEwAD2gNdf",
               "input": {
                 "description": "Extract beta version and owner from release notes",
-                "prompt": "Read the file release_notes_beta.md using the Read tool. Extract the version number and the owner name from the file. Return ONLY the string in this exact format: beta:<version> | <owner>\n\nDo not include any other text, explanation, or formatting. Just the single line output."
+                "prompt": "Read the file release_notes_beta.md using the Read tool. Extract the version number and owner from the file. Return ONLY the result in this exact format: beta:<version> | <owner>\n\nDo not include any other text in your response.",
+                "subagent_type": "general-purpose"
               },
               "name": "Agent",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_019nX2CYZuqpKwWsp2Wp2zwZ",
+          "id": "msg_01YXXP1jUbVXJtTaKckyCeaD",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -303,23 +305,23 @@
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
         "type": "assistant",
-        "uuid": "2637fba9-9a26-4386-a22e-95fa2f34bdeb"
+        "uuid": "9bfb42f3-fb31-4235-baf5-05b92e532a62"
       }
     },
     {
       "op": "read",
       "payload": {
         "description": "Extract beta version and owner from release notes",
-        "prompt": "Read the file release_notes_beta.md using the Read tool. Extract the version number and the owner name from the file. Return ONLY the string in this exact format: beta:<version> | <owner>\n\nDo not include any other text, explanation, or formatting. Just the single line output.",
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
+        "prompt": "Read the file release_notes_beta.md using the Read tool. Extract the version number and owner from the file. Return ONLY the result in this exact format: beta:<version> | <owner>\n\nDo not include any other text in your response.",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
         "subtype": "task_started",
-        "task_id": "a19c943cd5761522d",
+        "task_id": "a3c9cb881954f3aeb",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01Vunci6oMrpxQ8jcCR8tKv7",
+        "tool_use_id": "toolu_017cvA3q5wfSMsZEwAD2gNdf",
         "type": "system",
-        "uuid": "512b100b-8f40-41e8-a5fe-6bd88199fd1a"
+        "uuid": "a6cca5c7-168e-42f8-86bd-984d5a52dcd2"
       }
     },
     {
@@ -328,99 +330,17 @@
         "message": {
           "content": [
             {
-              "text": "Read the file release_notes_beta.md using the Read tool. Extract the version number and the owner name from the file. Return ONLY the string in this exact format: beta:<version> | <owner>\n\nDo not include any other text, explanation, or formatting. Just the single line output.",
+              "text": "Read the file release_notes_beta.md using the Read tool. Extract the version number and owner from the file. Return ONLY the result in this exact format: beta:<version> | <owner>\n\nDo not include any other text in your response.",
               "type": "text"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01Vunci6oMrpxQ8jcCR8tKv7",
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
-        "timestamp": "2026-04-16T16:49:04.539Z",
+        "parent_tool_use_id": "toolu_017cvA3q5wfSMsZEwAD2gNdf",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
+        "timestamp": "2026-04-17T16:17:52.109Z",
         "type": "user",
-        "uuid": "9d75e265-fe8b-4b15-b9a1-efb71f41aee2"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "description": "Reading release_notes_beta.md",
-        "last_tool_name": "Read",
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
-        "subtype": "task_progress",
-        "task_id": "a19c943cd5761522d",
-        "tool_use_id": "toolu_01Vunci6oMrpxQ8jcCR8tKv7",
-        "type": "system",
-        "usage": {
-          "duration_ms": 1296,
-          "tool_uses": 1,
-          "total_tokens": 17518
-        },
-        "uuid": "a7ab7134-296f-4755-9458-30ce44000711"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "caller": {
-                "type": "direct"
-              },
-              "id": "toolu_01TU56989wASQvsJjU3rUjf1",
-              "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_multiple_bundled_subagent0/subagent_multi_workspace/release_notes_beta.md"
-              },
-              "name": "Read",
-              "type": "tool_use"
-            }
-          ],
-          "context_management": null,
-          "id": "msg_01EfjU4iCtM7xcWK6Aw77NFL",
-          "model": "claude-haiku-4-5-20251001",
-          "role": "assistant",
-          "stop_details": null,
-          "stop_reason": null,
-          "stop_sequence": null,
-          "type": "message",
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1090
-            },
-            "cache_creation_input_tokens": 1090,
-            "cache_read_input_tokens": 16423,
-            "inference_geo": "not_available",
-            "input_tokens": 3,
-            "output_tokens": 1,
-            "service_tier": "standard"
-          }
-        },
-        "parent_tool_use_id": "toolu_01Vunci6oMrpxQ8jcCR8tKv7",
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
-        "type": "assistant",
-        "uuid": "3b78a891-c01d-44d8-98db-89d68e5b865d"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "content": "1\t# Beta Release Notes\n2\t\n3\tversion = 2026.03.11-beta\n4\towner = sdk-platform-beta\n5\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_01TU56989wASQvsJjU3rUjf1",
-              "type": "tool_result"
-            }
-          ],
-          "role": "user"
-        },
-        "parent_tool_use_id": "toolu_01Vunci6oMrpxQ8jcCR8tKv7",
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
-        "timestamp": "2026-04-16T16:49:05.847Z",
-        "type": "user",
-        "uuid": "3bc7bf95-2472-465c-951f-573f0d2ebd5a"
+        "uuid": "87be9db2-9b21-4be0-aee5-60bbfe8009a5"
       }
     },
     {
@@ -428,17 +348,17 @@
       "payload": {
         "description": "Reading release_notes_alpha.md",
         "last_tool_name": "Read",
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
         "subtype": "task_progress",
-        "task_id": "a7bb3d0e887fbbb2d",
-        "tool_use_id": "toolu_01Xcs38SPGw9PZDGdHRNgFqg",
+        "task_id": "adfd30aa7271a1476",
+        "tool_use_id": "toolu_0134vWepDYu9KgwwaYL1oHzn",
         "type": "system",
         "usage": {
-          "duration_ms": 2122,
+          "duration_ms": 1084,
           "tool_uses": 1,
-          "total_tokens": 17518
+          "total_tokens": 17522
         },
-        "uuid": "90e5e44e-ff30-458f-9307-6f96758ff0b2"
+        "uuid": "3bf2cd35-8551-44a6-89e7-437d47dc3d59"
       }
     },
     {
@@ -450,16 +370,16 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01ESqTM8nXNLSoJUX5rxNiH9",
+              "id": "toolu_01KGnvFw9qVs1nRmpP484tMV",
               "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-558/test_multiple_bundled_subagent0/subagent_multi_workspace/release_notes_alpha.md"
+                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-578/test_multiple_bundled_subagent0/subagent_multi_workspace/release_notes_alpha.md"
               },
               "name": "Read",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01C6R6YLPWSzCUUcuH2Ki9SG",
+          "id": "msg_017Wm3CoqxUKybDRW8oNP9QQ",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -469,20 +389,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1090
+              "ephemeral_5m_input_tokens": 1080
             },
-            "cache_creation_input_tokens": 1090,
+            "cache_creation_input_tokens": 1080,
             "cache_read_input_tokens": 16423,
             "inference_geo": "not_available",
             "input_tokens": 3,
-            "output_tokens": 1,
+            "output_tokens": 8,
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01Xcs38SPGw9PZDGdHRNgFqg",
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
+        "parent_tool_use_id": "toolu_0134vWepDYu9KgwwaYL1oHzn",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
         "type": "assistant",
-        "uuid": "d48727f9-d242-4e2d-aae8-b8953c3ad116"
+        "uuid": "1b01174a-3ac7-4055-8548-b82a12b541ef"
       }
     },
     {
@@ -492,138 +412,36 @@
           "content": [
             {
               "content": "1\t# Alpha Release Notes\n2\t\n3\tversion = 2026.03.11-alpha\n4\towner = sdk-platform-alpha\n5\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
-              "tool_use_id": "toolu_01ESqTM8nXNLSoJUX5rxNiH9",
+              "tool_use_id": "toolu_01KGnvFw9qVs1nRmpP484tMV",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01Xcs38SPGw9PZDGdHRNgFqg",
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
-        "timestamp": "2026-04-16T16:49:06.265Z",
+        "parent_tool_use_id": "toolu_0134vWepDYu9KgwwaYL1oHzn",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
+        "timestamp": "2026-04-17T16:17:52.802Z",
         "type": "user",
-        "uuid": "b907ad6d-bae1-4554-9170-d688b6af269e"
+        "uuid": "c03617ea-6c89-4dfa-bf9c-644a21b6114a"
       }
     },
     {
       "op": "read",
       "payload": {
         "output_file": "",
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
-        "status": "completed",
-        "subtype": "task_notification",
-        "summary": "Extract beta version and owner from release notes",
-        "task_id": "a19c943cd5761522d",
-        "tool_use_id": "toolu_01Vunci6oMrpxQ8jcCR8tKv7",
-        "type": "system",
-        "usage": {
-          "duration_ms": 2544,
-          "tool_uses": 1,
-          "total_tokens": 18621
-        },
-        "uuid": "5af5efbd-0998-454f-bb9d-23d43f971ae4"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "content": [
-                {
-                  "text": "beta:2026.03.11-beta | sdk-platform-beta",
-                  "type": "text"
-                },
-                {
-                  "text": "agentId: a19c943cd5761522d (use SendMessage with to: 'a19c943cd5761522d' to continue this agent)\n<usage>total_tokens: 18637\ntool_uses: 1\nduration_ms: 2546</usage>",
-                  "type": "text"
-                }
-              ],
-              "tool_use_id": "toolu_01Vunci6oMrpxQ8jcCR8tKv7",
-              "type": "tool_result"
-            }
-          ],
-          "role": "user"
-        },
-        "parent_tool_use_id": null,
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
-        "timestamp": "2026-04-16T16:49:07.084Z",
-        "tool_use_result": {
-          "agentId": "a19c943cd5761522d",
-          "agentType": "general-purpose",
-          "content": [
-            {
-              "text": "beta:2026.03.11-beta | sdk-platform-beta",
-              "type": "text"
-            }
-          ],
-          "prompt": "Read the file release_notes_beta.md using the Read tool. Extract the version number and the owner name from the file. Return ONLY the string in this exact format: beta:<version> | <owner>\n\nDo not include any other text, explanation, or formatting. Just the single line output.",
-          "status": "completed",
-          "toolStats": {
-            "bashCount": 0,
-            "editFileCount": 0,
-            "linesAdded": 0,
-            "linesRemoved": 0,
-            "otherToolCount": 0,
-            "readCount": 1,
-            "searchCount": 0
-          },
-          "totalDurationMs": 2546,
-          "totalTokens": 18637,
-          "totalToolUseCount": 1,
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1100
-            },
-            "cache_creation_input_tokens": 1100,
-            "cache_read_input_tokens": 17513,
-            "inference_geo": "",
-            "input_tokens": 5,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 1100
-                },
-                "cache_creation_input_tokens": 1100,
-                "cache_read_input_tokens": 17513,
-                "input_tokens": 5,
-                "output_tokens": 19,
-                "type": "message"
-              }
-            ],
-            "output_tokens": 19,
-            "server_tool_use": {
-              "web_fetch_requests": 0,
-              "web_search_requests": 0
-            },
-            "service_tier": "standard",
-            "speed": "standard"
-          }
-        },
-        "type": "user",
-        "uuid": "a2ac77d5-840a-4378-9013-9b33e01ad278"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "output_file": "",
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
         "status": "completed",
         "subtype": "task_notification",
         "summary": "Extract alpha version and owner from release notes",
-        "task_id": "a7bb3d0e887fbbb2d",
-        "tool_use_id": "toolu_01Xcs38SPGw9PZDGdHRNgFqg",
+        "task_id": "adfd30aa7271a1476",
+        "tool_use_id": "toolu_0134vWepDYu9KgwwaYL1oHzn",
         "type": "system",
         "usage": {
-          "duration_ms": 3474,
+          "duration_ms": 1922,
           "tool_uses": 1,
-          "total_tokens": 18619
+          "total_tokens": 18626
         },
-        "uuid": "729ffae4-c6ae-4af7-86ef-42dd0cb5776f"
+        "uuid": "30151a41-c8d6-4e40-924e-8ff63b26568d"
       }
     },
     {
@@ -638,21 +456,21 @@
                   "type": "text"
                 },
                 {
-                  "text": "agentId: a7bb3d0e887fbbb2d (use SendMessage with to: 'a7bb3d0e887fbbb2d' to continue this agent)\n<usage>total_tokens: 18635\ntool_uses: 1\nduration_ms: 3475</usage>",
+                  "text": "agentId: adfd30aa7271a1476 (use SendMessage with to: 'adfd30aa7271a1476' to continue this agent)\n<usage>total_tokens: 18628\ntool_uses: 1\nduration_ms: 1922</usage>",
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01Xcs38SPGw9PZDGdHRNgFqg",
+              "tool_use_id": "toolu_0134vWepDYu9KgwwaYL1oHzn",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
-        "timestamp": "2026-04-16T16:49:07.613Z",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
+        "timestamp": "2026-04-17T16:17:53.637Z",
         "tool_use_result": {
-          "agentId": "a7bb3d0e887fbbb2d",
+          "agentId": "adfd30aa7271a1476",
           "agentType": "general-purpose",
           "content": [
             {
@@ -660,7 +478,7 @@
               "type": "text"
             }
           ],
-          "prompt": "Read the file release_notes_alpha.md using the Read tool. Extract the version number and the owner name from the file. Return ONLY the string in this exact format: alpha:<version> | <owner>\n\nDo not include any other text, explanation, or formatting. Just the single line output.",
+          "prompt": "Read the file release_notes_alpha.md using the Read tool. Extract the version number and owner from the file. Return ONLY the result in this exact format: alpha:<version> | <owner>\n\nDo not include any other text in your response.",
           "status": "completed",
           "toolStats": {
             "bashCount": 0,
@@ -671,31 +489,19 @@
             "readCount": 1,
             "searchCount": 0
           },
-          "totalDurationMs": 3475,
-          "totalTokens": 18635,
+          "totalDurationMs": 1922,
+          "totalTokens": 18628,
           "totalToolUseCount": 1,
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 1098
+              "ephemeral_5m_input_tokens": 1553
             },
-            "cache_creation_input_tokens": 1098,
-            "cache_read_input_tokens": 17513,
+            "cache_creation_input_tokens": 1553,
+            "cache_read_input_tokens": 17051,
             "inference_geo": "",
             "input_tokens": 5,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 1098
-                },
-                "cache_creation_input_tokens": 1098,
-                "cache_read_input_tokens": 17513,
-                "input_tokens": 5,
-                "output_tokens": 19,
-                "type": "message"
-              }
-            ],
+            "iterations": [],
             "output_tokens": 19,
             "server_tool_use": {
               "web_fetch_requests": 0,
@@ -706,7 +512,25 @@
           }
         },
         "type": "user",
-        "uuid": "c0e03f24-1d15-4ee9-8b38-ac8a34624722"
+        "uuid": "caf26e95-44f5-406a-8a57-80834a902428"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "description": "Reading release_notes_beta.md",
+        "last_tool_name": "Read",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
+        "subtype": "task_progress",
+        "task_id": "a3c9cb881954f3aeb",
+        "tool_use_id": "toolu_017cvA3q5wfSMsZEwAD2gNdf",
+        "type": "system",
+        "usage": {
+          "duration_ms": 1654,
+          "tool_uses": 1,
+          "total_tokens": 17508
+        },
+        "uuid": "1ee70bd8-b102-4beb-a64d-f052e721c851"
       }
     },
     {
@@ -715,13 +539,19 @@
         "message": {
           "content": [
             {
-              "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "Perfect! Both agents have completed their tasks and returned the formatted strings:\n1. alpha:2026.03.11-alpha | sdk-platform-alpha\n2. beta:2026.03.11-beta | sdk-platform-beta\n\nNow I need to reply with exactly two lines in that same order, as the user requested.",
-              "type": "thinking"
+              "caller": {
+                "type": "direct"
+              },
+              "id": "toolu_01Mb2ghqC3hLQhKaFZC7Y2ci",
+              "input": {
+                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-578/test_multiple_bundled_subagent0/subagent_multi_workspace/release_notes_beta.md"
+              },
+              "name": "Read",
+              "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_01Gx9oZaXSi3aWtdBVmmwowq",
+          "id": "msg_01JbwrDfSiP93C3D8X9FMKFB",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -731,20 +561,168 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 572
+              "ephemeral_5m_input_tokens": 1080
             },
-            "cache_creation_input_tokens": 572,
+            "cache_creation_input_tokens": 1080,
+            "cache_read_input_tokens": 16423,
+            "inference_geo": "not_available",
+            "input_tokens": 3,
+            "output_tokens": 1,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": "toolu_017cvA3q5wfSMsZEwAD2gNdf",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
+        "type": "assistant",
+        "uuid": "6ac01c52-2fae-47a7-b9ec-8bb04cdf88b8"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": "1\t# Beta Release Notes\n2\t\n3\tversion = 2026.03.11-beta\n4\towner = sdk-platform-beta\n5\t\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n",
+              "tool_use_id": "toolu_01Mb2ghqC3hLQhKaFZC7Y2ci",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": "toolu_017cvA3q5wfSMsZEwAD2gNdf",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
+        "timestamp": "2026-04-17T16:17:53.764Z",
+        "type": "user",
+        "uuid": "ed08d98d-39c2-41d7-a578-bcf685a45bfe"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "output_file": "",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
+        "status": "completed",
+        "subtype": "task_notification",
+        "summary": "Extract beta version and owner from release notes",
+        "task_id": "a3c9cb881954f3aeb",
+        "tool_use_id": "toolu_017cvA3q5wfSMsZEwAD2gNdf",
+        "type": "system",
+        "usage": {
+          "duration_ms": 2995,
+          "tool_uses": 1,
+          "total_tokens": 18610
+        },
+        "uuid": "e87d77a3-0608-443e-8288-a8bd2c016607"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": [
+                {
+                  "text": "beta:2026.03.11-beta | sdk-platform-beta",
+                  "type": "text"
+                },
+                {
+                  "text": "agentId: a3c9cb881954f3aeb (use SendMessage with to: 'a3c9cb881954f3aeb' to continue this agent)\n<usage>total_tokens: 18626\ntool_uses: 1\nduration_ms: 2995</usage>",
+                  "type": "text"
+                }
+              ],
+              "tool_use_id": "toolu_017cvA3q5wfSMsZEwAD2gNdf",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
+        "timestamp": "2026-04-17T16:17:55.104Z",
+        "tool_use_result": {
+          "agentId": "a3c9cb881954f3aeb",
+          "agentType": "general-purpose",
+          "content": [
+            {
+              "text": "beta:2026.03.11-beta | sdk-platform-beta",
+              "type": "text"
+            }
+          ],
+          "prompt": "Read the file release_notes_beta.md using the Read tool. Extract the version number and owner from the file. Return ONLY the result in this exact format: beta:<version> | <owner>\n\nDo not include any other text in your response.",
+          "status": "completed",
+          "toolStats": {
+            "bashCount": 0,
+            "editFileCount": 0,
+            "linesAdded": 0,
+            "linesRemoved": 0,
+            "otherToolCount": 0,
+            "readCount": 1,
+            "searchCount": 0
+          },
+          "totalDurationMs": 2995,
+          "totalTokens": 18626,
+          "totalToolUseCount": 1,
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 1099
+            },
+            "cache_creation_input_tokens": 1099,
+            "cache_read_input_tokens": 17503,
+            "inference_geo": "",
+            "input_tokens": 5,
+            "iterations": [],
+            "output_tokens": 19,
+            "server_tool_use": {
+              "web_fetch_requests": 0,
+              "web_search_requests": 0
+            },
+            "service_tier": "standard",
+            "speed": "standard"
+          }
+        },
+        "type": "user",
+        "uuid": "b5ab52f8-fc60-4b1a-b872-31f1c40ad272"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "Great! Both agents have completed their tasks and returned the results in the exact format requested. Now I need to reply with exactly two lines in the same order (alpha first, then beta).\n\nThe results are:\n1. alpha:2026.03.11-alpha | sdk-platform-alpha\n2. beta:2026.03.11-beta | sdk-platform-beta\n\nI'll output these exactly as requested.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "id": "msg_01DvNtPYwBxh7TR6ndtDPBrw",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 698
+            },
+            "cache_creation_input_tokens": 698,
             "cache_read_input_tokens": 23309,
             "inference_geo": "not_available",
-            "input_tokens": 125,
-            "output_tokens": 6,
+            "input_tokens": 8,
+            "output_tokens": 1,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
         "type": "assistant",
-        "uuid": "a52649cf-a63f-4a81-8575-1ac07778e810"
+        "uuid": "e8baa736-f795-4f14-b60c-a3b7297fe3d0"
       }
     },
     {
@@ -758,7 +736,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_01Gx9oZaXSi3aWtdBVmmwowq",
+          "id": "msg_01DvNtPYwBxh7TR6ndtDPBrw",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -768,74 +746,62 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 572
+              "ephemeral_5m_input_tokens": 698
             },
-            "cache_creation_input_tokens": 572,
+            "cache_creation_input_tokens": 698,
             "cache_read_input_tokens": 23309,
             "inference_geo": "not_available",
-            "input_tokens": 125,
-            "output_tokens": 6,
+            "input_tokens": 8,
+            "output_tokens": 1,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
         "type": "assistant",
-        "uuid": "53a6ab56-0212-4eef-8e12-8b0ac67b54cb"
+        "uuid": "15dcab42-f897-41f6-b39f-cc9f67697415"
       }
     },
     {
       "op": "read",
       "payload": {
         "api_error_status": null,
-        "duration_api_ms": 12881,
-        "duration_ms": 8599,
+        "duration_api_ms": 11693,
+        "duration_ms": 8788,
         "fast_mode_state": "off",
         "is_error": false,
         "modelUsage": {
           "claude-haiku-4-5-20251001": {
-            "cacheCreationInputTokens": 6479,
-            "cacheReadInputTokens": 112961,
+            "cacheCreationInputTokens": 7039,
+            "cacheReadInputTokens": 112489,
             "contextWindow": 200000,
-            "costUSD": 0.024513849999999997,
-            "inputTokens": 619,
+            "costUSD": 0.025199649999999997,
+            "inputTokens": 502,
             "maxOutputTokens": 32000,
-            "outputTokens": 900,
+            "outputTokens": 930,
             "webSearchRequests": 0
           }
         },
         "num_turns": 3,
         "permission_denials": [],
         "result": "alpha:2026.03.11-alpha | sdk-platform-alpha\nbeta:2026.03.11-beta | sdk-platform-beta",
-        "session_id": "ba7cb36a-146a-4a41-8296-5b08da43bfdf",
+        "session_id": "affb6aed-a584-4c3b-a88a-06c4a3744dac",
         "stop_reason": "end_turn",
         "subtype": "success",
         "terminal_reason": "completed",
-        "total_cost_usd": 0.024513849999999997,
+        "total_cost_usd": 0.025199649999999997,
         "type": "result",
         "usage": {
           "cache_creation": {
             "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 2101
+            "ephemeral_5m_input_tokens": 2227
           },
-          "cache_creation_input_tokens": 2101,
+          "cache_creation_input_tokens": 2227,
           "cache_read_input_tokens": 45089,
           "inference_geo": "",
-          "input_tokens": 135,
-          "iterations": [
-            {
-              "cache_creation": {
-                "ephemeral_1h_input_tokens": 0,
-                "ephemeral_5m_input_tokens": 572
-              },
-              "cache_creation_input_tokens": 572,
-              "cache_read_input_tokens": 23309,
-              "input_tokens": 125,
-              "output_tokens": 116,
-              "type": "message"
-            }
-          ],
-          "output_tokens": 555,
+          "input_tokens": 18,
+          "iterations": [],
+          "output_tokens": 583,
           "server_tool_use": {
             "web_fetch_requests": 0,
             "web_search_requests": 0
@@ -843,9 +809,9 @@
           "service_tier": "standard",
           "speed": "standard"
         },
-        "uuid": "43829aeb-ef01-4b57-b43c-3fd45697ffd4"
+        "uuid": "aa16580b-1434-4338-a683-3f709346558e"
       }
     }
   ],
-  "sdk_version": "0.1.60"
+  "sdk_version": "0.1.61"
 }

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_tool_hooks_create_function_spans.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_tool_hooks_create_function_spans.json
@@ -27,7 +27,7 @@
             },
             "subtype": "initialize"
           },
-          "request_id": "req_1_e47dcc91",
+          "request_id": "req_1_517528e0",
           "type": "control_request"
         }
       }
@@ -36,7 +36,7 @@
       "op": "read",
       "payload": {
         "response": {
-          "request_id": "req_1_e47dcc91",
+          "request_id": "req_1_517528e0",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
@@ -78,7 +78,7 @@
           "statusline-setup"
         ],
         "apiKeySource": "ANTHROPIC_API_KEY",
-        "claude_code_version": "2.1.111",
+        "claude_code_version": "2.1.112",
         "cwd": "<REDACTED_CWD>",
         "fast_mode_state": "off",
         "mcp_servers": [
@@ -104,7 +104,7 @@
             "source": "rust-analyzer-lsp@claude-plugins-official"
           }
         ],
-        "session_id": "1c8de48e-a28b-4053-9960-294bab9d5fc3",
+        "session_id": "6fc3f11f-e1c8-4d29-8ca1-d9deffcf638a",
         "skills": [
           "update-config",
           "debug",
@@ -231,7 +231,7 @@
           "mcp__linear-server__update_document"
         ],
         "type": "system",
-        "uuid": "bf6d2a61-963b-4eb1-b1aa-1a104a6f7509"
+        "uuid": "a0d68350-48bb-409b-848c-0b1dca3eee04"
       }
     },
     {
@@ -241,12 +241,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The user is asking me to run a specific bash command: `echo 'braintrust hook tracing'`\n\nThis is straightforward - I just need to execute this command using the Bash tool.",
+              "thinking": "The user is asking me to run a specific bash command: `echo 'braintrust hook tracing'`\n\nThey want me to run \"exactly this Bash command and nothing else\". This is a straightforward request - I should use the Bash tool to execute this command.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_015ctuK54Y4gF5nTTmVUSBzf",
+          "id": "msg_0172UqTYMfETN1KYzcsJjRaE",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -259,17 +259,17 @@
               "ephemeral_5m_input_tokens": 5763
             },
             "cache_creation_input_tokens": 5763,
-            "cache_read_input_tokens": 35611,
+            "cache_read_input_tokens": 35723,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 8,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "1c8de48e-a28b-4053-9960-294bab9d5fc3",
+        "session_id": "6fc3f11f-e1c8-4d29-8ca1-d9deffcf638a",
         "type": "assistant",
-        "uuid": "480ff803-4709-43e0-85ce-4ffe33b1b487"
+        "uuid": "f883ea07-bf56-4c5a-836f-9535b3cb5502"
       }
     },
     {
@@ -281,17 +281,17 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01KXtjaHMtaozYYwfEoWZp5M",
+              "id": "toolu_01AfgXxCNT9jfgCmk1ZUQ5WG",
               "input": {
                 "command": "echo 'braintrust hook tracing'",
-                "description": "Run the specified echo command"
+                "description": "Execute the echo command"
               },
               "name": "Bash",
               "type": "tool_use"
             }
           ],
           "context_management": null,
-          "id": "msg_015ctuK54Y4gF5nTTmVUSBzf",
+          "id": "msg_0172UqTYMfETN1KYzcsJjRaE",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -304,17 +304,17 @@
               "ephemeral_5m_input_tokens": 5763
             },
             "cache_creation_input_tokens": 5763,
-            "cache_read_input_tokens": 35611,
+            "cache_read_input_tokens": 35723,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 8,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "1c8de48e-a28b-4053-9960-294bab9d5fc3",
+        "session_id": "6fc3f11f-e1c8-4d29-8ca1-d9deffcf638a",
         "type": "assistant",
-        "uuid": "b7713572-30e3-4948-9018-ccfd354d6abf"
+        "uuid": "75476503-9870-4d77-9dc2-49d7d56fc339"
       }
     },
     {
@@ -326,19 +326,19 @@
             "cwd": "<REDACTED_CWD>",
             "hook_event_name": "PreToolUse",
             "permission_mode": "bypassPermissions",
-            "session_id": "1c8de48e-a28b-4053-9960-294bab9d5fc3",
+            "session_id": "6fc3f11f-e1c8-4d29-8ca1-d9deffcf638a",
             "tool_input": {
               "command": "echo 'braintrust hook tracing'",
-              "description": "Run the specified echo command"
+              "description": "Execute the echo command"
             },
             "tool_name": "Bash",
-            "tool_use_id": "toolu_01KXtjaHMtaozYYwfEoWZp5M",
+            "tool_use_id": "toolu_01AfgXxCNT9jfgCmk1ZUQ5WG",
             "transcript_path": "<REDACTED_PATH>"
           },
           "subtype": "hook_callback",
-          "tool_use_id": "toolu_01KXtjaHMtaozYYwfEoWZp5M"
+          "tool_use_id": "toolu_01AfgXxCNT9jfgCmk1ZUQ5WG"
         },
-        "request_id": "88e9ad0d-9b69-465f-90fd-05411acdc88c",
+        "request_id": "4699d15c-ff71-4342-afda-24532fa58dd6",
         "type": "control_request"
       }
     },
@@ -348,7 +348,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "88e9ad0d-9b69-465f-90fd-05411acdc88c",
+            "request_id": "4699d15c-ff71-4342-afda-24532fa58dd6",
             "response": {
               "hookSpecificOutput": {
                 "additionalContext": "The hook observed the pending Bash command.",
@@ -372,10 +372,10 @@
             "cwd": "<REDACTED_CWD>",
             "hook_event_name": "PostToolUse",
             "permission_mode": "bypassPermissions",
-            "session_id": "1c8de48e-a28b-4053-9960-294bab9d5fc3",
+            "session_id": "6fc3f11f-e1c8-4d29-8ca1-d9deffcf638a",
             "tool_input": {
               "command": "echo 'braintrust hook tracing'",
-              "description": "Run the specified echo command"
+              "description": "Execute the echo command"
             },
             "tool_name": "Bash",
             "tool_response": {
@@ -385,13 +385,13 @@
               "stderr": "",
               "stdout": "braintrust hook tracing"
             },
-            "tool_use_id": "toolu_01KXtjaHMtaozYYwfEoWZp5M",
+            "tool_use_id": "toolu_01AfgXxCNT9jfgCmk1ZUQ5WG",
             "transcript_path": "<REDACTED_PATH>"
           },
           "subtype": "hook_callback",
-          "tool_use_id": "toolu_01KXtjaHMtaozYYwfEoWZp5M"
+          "tool_use_id": "toolu_01AfgXxCNT9jfgCmk1ZUQ5WG"
         },
-        "request_id": "f8c85ba3-0f6a-4877-b87a-7f990c3c9b4a",
+        "request_id": "d859d714-a042-43b0-bebd-380fbf3f5fa9",
         "type": "control_request"
       }
     },
@@ -401,7 +401,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "f8c85ba3-0f6a-4877-b87a-7f990c3c9b4a",
+            "request_id": "d859d714-a042-43b0-bebd-380fbf3f5fa9",
             "response": {
               "hookSpecificOutput": {
                 "additionalContext": "The hook observed the completed Bash command.",
@@ -422,15 +422,15 @@
             {
               "content": "braintrust hook tracing",
               "is_error": false,
-              "tool_use_id": "toolu_01KXtjaHMtaozYYwfEoWZp5M",
+              "tool_use_id": "toolu_01AfgXxCNT9jfgCmk1ZUQ5WG",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "1c8de48e-a28b-4053-9960-294bab9d5fc3",
-        "timestamp": "2026-04-16T16:47:13.419Z",
+        "session_id": "6fc3f11f-e1c8-4d29-8ca1-d9deffcf638a",
+        "timestamp": "2026-04-17T16:15:09.396Z",
         "tool_use_result": {
           "interrupted": false,
           "isImage": false,
@@ -439,7 +439,7 @@
           "stdout": "braintrust hook tracing"
         },
         "type": "user",
-        "uuid": "092be132-f8d2-4d70-adc5-573ae7708fbd"
+        "uuid": "107182df-31ed-442c-a668-c51abd56abc0"
       }
     },
     {
@@ -449,12 +449,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The command has been executed successfully and returned the output \"braintrust hook tracing\". The system reminders indicate that hooks were triggered before and after the Bash command execution, which is normal behavior in this system.\n\nThe task was simply to run the echo command, which I've done.",
+              "thinking": "The user ran a command through me and the system is showing that hooks are observing the Bash commands. The command executed successfully and output \"braintrust hook tracing\".\n\nThe system reminders are showing:\n- PreToolUse:Bash hook - observed the pending command\n- PostToolUse:Bash hook - observed the completed command\n\nThis appears to be testing or demonstrating hook tracing functionality for the Braintrust system. The command executed as requested and the hooks are tracking the execution.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01AACLu3Uhi1FdDCKQP2mS8C",
+          "id": "msg_016KDPyUjQPJGg2FmsfeyrGn",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -464,20 +464,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 228
+              "ephemeral_5m_input_tokens": 6006
             },
-            "cache_creation_input_tokens": 228,
-            "cache_read_input_tokens": 41374,
+            "cache_creation_input_tokens": 6006,
+            "cache_read_input_tokens": 35723,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 2,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "1c8de48e-a28b-4053-9960-294bab9d5fc3",
+        "session_id": "6fc3f11f-e1c8-4d29-8ca1-d9deffcf638a",
         "type": "assistant",
-        "uuid": "3cdd4d8a-4ab2-4ab6-8af5-66abb8706ef1"
+        "uuid": "d1a6680d-2a51-4a74-a60c-f26722061ab5"
       }
     },
     {
@@ -486,12 +486,12 @@
         "message": {
           "content": [
             {
-              "text": "Done! The command `echo 'braintrust hook tracing'` has been executed and output the string \"braintrust hook tracing\".",
+              "text": "Done. The command executed successfully and output: `braintrust hook tracing`",
               "type": "text"
             }
           ],
           "context_management": null,
-          "id": "msg_01AACLu3Uhi1FdDCKQP2mS8C",
+          "id": "msg_016KDPyUjQPJGg2FmsfeyrGn",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -501,74 +501,62 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 228
+              "ephemeral_5m_input_tokens": 6006
             },
-            "cache_creation_input_tokens": 228,
-            "cache_read_input_tokens": 41374,
+            "cache_creation_input_tokens": 6006,
+            "cache_read_input_tokens": 35723,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 2,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "1c8de48e-a28b-4053-9960-294bab9d5fc3",
+        "session_id": "6fc3f11f-e1c8-4d29-8ca1-d9deffcf638a",
         "type": "assistant",
-        "uuid": "4772b860-a940-4e05-817a-cf98cfb403ee"
+        "uuid": "889fb40e-865e-4984-8fa8-a841fd63f960"
       }
     },
     {
       "op": "read",
       "payload": {
         "api_error_status": null,
-        "duration_api_ms": 8100,
-        "duration_ms": 7128,
+        "duration_api_ms": 4895,
+        "duration_ms": 4268,
         "fast_mode_state": "off",
         "is_error": false,
         "modelUsage": {
           "claude-haiku-4-5-20251001": {
-            "cacheCreationInputTokens": 5991,
-            "cacheReadInputTokens": 76985,
+            "cacheCreationInputTokens": 11769,
+            "cacheReadInputTokens": 71446,
             "contextWindow": 200000,
-            "costUSD": 0.01680025,
+            "costUSD": 0.02373385,
             "inputTokens": 378,
             "maxOutputTokens": 32000,
-            "outputTokens": 247,
+            "outputTokens": 300,
             "webSearchRequests": 0
           }
         },
         "num_turns": 2,
         "permission_denials": [],
-        "result": "Done! The command `echo 'braintrust hook tracing'` has been executed and output the string \"braintrust hook tracing\".",
-        "session_id": "1c8de48e-a28b-4053-9960-294bab9d5fc3",
+        "result": "Done. The command executed successfully and output: `braintrust hook tracing`",
+        "session_id": "6fc3f11f-e1c8-4d29-8ca1-d9deffcf638a",
         "stop_reason": "end_turn",
         "subtype": "success",
         "terminal_reason": "completed",
-        "total_cost_usd": 0.01680025,
+        "total_cost_usd": 0.02373385,
         "type": "result",
         "usage": {
           "cache_creation": {
             "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 5991
+            "ephemeral_5m_input_tokens": 11769
           },
-          "cache_creation_input_tokens": 5991,
-          "cache_read_input_tokens": 76985,
+          "cache_creation_input_tokens": 11769,
+          "cache_read_input_tokens": 71446,
           "inference_geo": "",
           "input_tokens": 20,
-          "iterations": [
-            {
-              "cache_creation": {
-                "ephemeral_1h_input_tokens": 0,
-                "ephemeral_5m_input_tokens": 228
-              },
-              "cache_creation_input_tokens": 228,
-              "cache_read_input_tokens": 41374,
-              "input_tokens": 10,
-              "output_tokens": 102,
-              "type": "message"
-            }
-          ],
-          "output_tokens": 235,
+          "iterations": [],
+          "output_tokens": 284,
           "server_tool_use": {
             "web_fetch_requests": 0,
             "web_search_requests": 0
@@ -576,9 +564,9 @@
           "service_tier": "standard",
           "speed": "standard"
         },
-        "uuid": "745738f6-bf87-4731-9d5f-1c1d7bff4bbc"
+        "uuid": "3e12abdb-58b5-453b-af4d-eb015a93b39c"
       }
     }
   ],
-  "sdk_version": "0.1.60"
+  "sdk_version": "0.1.61"
 }

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_user_prompt_submit_hook_creates_function_span.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_user_prompt_submit_hook_creates_function_span.json
@@ -19,7 +19,7 @@
             },
             "subtype": "initialize"
           },
-          "request_id": "req_1_d388cbad",
+          "request_id": "req_1_4a6398e3",
           "type": "control_request"
         }
       }
@@ -28,7 +28,7 @@
       "op": "read",
       "payload": {
         "response": {
-          "request_id": "req_1_d388cbad",
+          "request_id": "req_1_4a6398e3",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
@@ -70,13 +70,13 @@
             "hook_event_name": "UserPromptSubmit",
             "permission_mode": "bypassPermissions",
             "prompt": "Say hello in one short sentence.",
-            "session_id": "b0173426-7b4c-46cf-b726-f8a7cd7c3eee",
+            "session_id": "b8690cb9-042e-4aa2-94d9-6f5fc74e22cf",
             "transcript_path": "<REDACTED_PATH>"
           },
           "subtype": "hook_callback",
-          "tool_use_id": "95f46f4b-1229-42d9-8157-f0dc89afb119"
+          "tool_use_id": "e02f4ebb-8944-4d30-90fa-496ca4a1209b"
         },
-        "request_id": "f9a54896-f51e-48ab-bd4b-4f28022e3a81",
+        "request_id": "2db90060-7c60-4f9f-a3ad-772e975f7cf0",
         "type": "control_request"
       }
     },
@@ -86,7 +86,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "f9a54896-f51e-48ab-bd4b-4f28022e3a81",
+            "request_id": "2db90060-7c60-4f9f-a3ad-772e975f7cf0",
             "response": {
               "hookSpecificOutput": {
                 "additionalContext": "Remember the answer should stay concise.",
@@ -109,7 +109,7 @@
           "statusline-setup"
         ],
         "apiKeySource": "ANTHROPIC_API_KEY",
-        "claude_code_version": "2.1.111",
+        "claude_code_version": "2.1.112",
         "cwd": "<REDACTED_CWD>",
         "fast_mode_state": "off",
         "mcp_servers": [
@@ -135,7 +135,7 @@
             "source": "rust-analyzer-lsp@claude-plugins-official"
           }
         ],
-        "session_id": "b0173426-7b4c-46cf-b726-f8a7cd7c3eee",
+        "session_id": "b8690cb9-042e-4aa2-94d9-6f5fc74e22cf",
         "skills": [
           "update-config",
           "debug",
@@ -262,7 +262,7 @@
           "mcp__linear-server__update_document"
         ],
         "type": "system",
-        "uuid": "b1680d6c-0c0b-4b95-b010-f16874fec54e"
+        "uuid": "887386d9-2888-448d-9841-687cee4ec0e6"
       }
     },
     {
@@ -272,12 +272,12 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The user is asking me to say hello in one short sentence. This is a simple greeting request. I should keep it brief and friendly.",
+              "thinking": "The user is asking me to say hello in one short sentence. This is a simple greeting request. I should keep it concise and friendly.",
               "type": "thinking"
             }
           ],
           "context_management": null,
-          "id": "msg_01R7PEqdt2TzUfTEU5WJjxjN",
+          "id": "msg_01GhaRAcK7D4RwrD4pu3jY1u",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -287,20 +287,20 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 41389
+              "ephemeral_5m_input_tokens": 41501
             },
-            "cache_creation_input_tokens": 41389,
+            "cache_creation_input_tokens": 41501,
             "cache_read_input_tokens": 0,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 7,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "b0173426-7b4c-46cf-b726-f8a7cd7c3eee",
+        "session_id": "b8690cb9-042e-4aa2-94d9-6f5fc74e22cf",
         "type": "assistant",
-        "uuid": "dbcdb0cf-f818-49b2-b8b7-6fce6aedf5a3"
+        "uuid": "943dd8f2-65eb-4445-970c-c048eea36aa1"
       }
     },
     {
@@ -309,12 +309,12 @@
         "message": {
           "content": [
             {
-              "text": "Hello! \ud83d\udc4b I'm ready to help you with the Braintrust SDK Python repository.",
+              "text": "Hey there! \ud83d\udc4b Ready to help you with the Braintrust SDK or anything else you need.",
               "type": "text"
             }
           ],
           "context_management": null,
-          "id": "msg_01R7PEqdt2TzUfTEU5WJjxjN",
+          "id": "msg_01GhaRAcK7D4RwrD4pu3jY1u",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -324,74 +324,62 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 41389
+              "ephemeral_5m_input_tokens": 41501
             },
-            "cache_creation_input_tokens": 41389,
+            "cache_creation_input_tokens": 41501,
             "cache_read_input_tokens": 0,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 7,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "b0173426-7b4c-46cf-b726-f8a7cd7c3eee",
+        "session_id": "b8690cb9-042e-4aa2-94d9-6f5fc74e22cf",
         "type": "assistant",
-        "uuid": "5f2c8481-c1a5-4bb6-8e7e-7c40c213063a"
+        "uuid": "f7239c28-2c07-4584-910b-dabd4e98ef61"
       }
     },
     {
       "op": "read",
       "payload": {
         "api_error_status": null,
-        "duration_api_ms": 2859,
-        "duration_ms": 1504,
+        "duration_api_ms": 1660,
+        "duration_ms": 1682,
         "fast_mode_state": "off",
         "is_error": false,
         "modelUsage": {
           "claude-haiku-4-5-20251001": {
-            "cacheCreationInputTokens": 41389,
+            "cacheCreationInputTokens": 41501,
             "cacheReadInputTokens": 0,
             "contextWindow": 200000,
-            "costUSD": 0.052466250000000006,
-            "inputTokens": 355,
+            "costUSD": 0.05220625,
+            "inputTokens": 10,
             "maxOutputTokens": 32000,
-            "outputTokens": 75,
+            "outputTokens": 64,
             "webSearchRequests": 0
           }
         },
         "num_turns": 1,
         "permission_denials": [],
-        "result": "Hello! \ud83d\udc4b I'm ready to help you with the Braintrust SDK Python repository.",
-        "session_id": "b0173426-7b4c-46cf-b726-f8a7cd7c3eee",
+        "result": "Hey there! \ud83d\udc4b Ready to help you with the Braintrust SDK or anything else you need.",
+        "session_id": "b8690cb9-042e-4aa2-94d9-6f5fc74e22cf",
         "stop_reason": "end_turn",
         "subtype": "success",
         "terminal_reason": "completed",
-        "total_cost_usd": 0.052466250000000006,
+        "total_cost_usd": 0.05220625,
         "type": "result",
         "usage": {
           "cache_creation": {
             "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 41389
+            "ephemeral_5m_input_tokens": 41501
           },
-          "cache_creation_input_tokens": 41389,
+          "cache_creation_input_tokens": 41501,
           "cache_read_input_tokens": 0,
           "inference_geo": "",
           "input_tokens": 10,
-          "iterations": [
-            {
-              "cache_creation": {
-                "ephemeral_1h_input_tokens": 0,
-                "ephemeral_5m_input_tokens": 41389
-              },
-              "cache_creation_input_tokens": 41389,
-              "cache_read_input_tokens": 0,
-              "input_tokens": 10,
-              "output_tokens": 61,
-              "type": "message"
-            }
-          ],
-          "output_tokens": 61,
+          "iterations": [],
+          "output_tokens": 64,
           "server_tool_use": {
             "web_fetch_requests": 0,
             "web_search_requests": 0
@@ -399,9 +387,9 @@
           "service_tier": "standard",
           "speed": "standard"
         },
-        "uuid": "501c6e60-2d04-425e-8a6c-913c2fa3f19b"
+        "uuid": "cef71806-f32e-40ec-9ed2-1c31880e2f6e"
       }
     }
   ],
-  "sdk_version": "0.1.60"
+  "sdk_version": "0.1.61"
 }

--- a/py/src/braintrust/integrations/claude_agent_sdk/test_claude_agent_sdk.py
+++ b/py/src/braintrust/integrations/claude_agent_sdk/test_claude_agent_sdk.py
@@ -28,6 +28,7 @@ from braintrust.integrations.anthropic._utils import extract_anthropic_usage
 from braintrust.integrations.claude_agent_sdk import setup_claude_agent_sdk
 from braintrust.integrations.claude_agent_sdk._test_transport import make_cassette_transport
 from braintrust.integrations.claude_agent_sdk.tracing import (
+    ContextTracker,
     ToolSpanTracker,
     _build_llm_input,
     _create_client_wrapper_class,
@@ -2727,3 +2728,106 @@ def test_dispatch_queue_assigns_identical_tool_spans_in_fifo_order(memory_logger
         llm_beta.end()
 
     memory_logger.pop()  # consume spans
+
+
+def test_context_tracker_preserves_bash_output_when_next_tool_use_arrives_before_result(memory_logger):
+    """Regression for claude-agent-sdk 0.1.61 interleaved subagent event stream.
+
+    In 0.1.61 a subagent can emit two ``tool_use`` AssistantMessages back-to-back
+    (e.g. Bash then Read) before either ``tool_result`` arrives. The first
+    tool span must not be closed when the second AssistantMessage arrives for
+    the same subagent context, so its ``tool_result`` can still be attached.
+    """
+    assert not memory_logger.pop()
+
+    with start_span(name="Claude Agent", type=SpanTypeAttribute.TASK) as root_span:
+        tracker = ContextTracker(root_span=root_span, prompt="go")
+        try:
+            # Parent orchestrator dispatches one Agent subagent tool call.
+            tracker.add(
+                AssistantMessage(
+                    content=[ToolUseBlock(id="call-alpha", name="Agent", input={"prompt": "do stuff"})],
+                    parent_tool_use_id=None,
+                )
+            )
+            tracker.add(
+                TaskStartedMessage(
+                    subtype="task_started",
+                    data={},
+                    task_id="task-alpha",
+                    description="alpha task",
+                    uuid="uuid-alpha",
+                    session_id="session-1",
+                    tool_use_id="call-alpha",
+                )
+            )
+            # Alpha's subagent issues Bash tool_use, then Read tool_use, WITHOUT
+            # any tool_result between them (new behavior in claude-agent-sdk 0.1.61).
+            tracker.add(
+                AssistantMessage(
+                    content=[
+                        ToolUseBlock(
+                            id="bash-alpha",
+                            name="Bash",
+                            input={"command": "echo alpha-bash-output"},
+                        )
+                    ],
+                    parent_tool_use_id="call-alpha",
+                )
+            )
+            tracker.add(
+                AssistantMessage(
+                    content=[
+                        ToolUseBlock(
+                            id="read-alpha",
+                            name="Read",
+                            input={"file_path": "/tmp/alpha.txt"},
+                        )
+                    ],
+                    parent_tool_use_id="call-alpha",
+                )
+            )
+            # Tool results arrive in reverse order (Read first, then Bash).
+            tracker.add(
+                UserMessage(
+                    content=[
+                        ToolResultBlock(
+                            tool_use_id="read-alpha",
+                            content=[TextBlock("alpha_file_contents")],
+                        )
+                    ],
+                    parent_tool_use_id="call-alpha",
+                )
+            )
+            tracker.add(
+                UserMessage(
+                    content=[
+                        ToolResultBlock(
+                            tool_use_id="bash-alpha",
+                            content=[TextBlock("alpha-bash-output")],
+                        )
+                    ],
+                    parent_tool_use_id="call-alpha",
+                )
+            )
+        finally:
+            tracker.cleanup()
+
+    spans = memory_logger.pop()
+    tool_spans = find_spans_by_type(spans, SpanTypeAttribute.TOOL)
+    bash_spans = [s for s in tool_spans if s["span_attributes"]["name"] == "Bash"]
+    read_spans = [s for s in tool_spans if s["span_attributes"]["name"] == "Read"]
+
+    assert len(bash_spans) == 1, f"Expected exactly one Bash span, got {len(bash_spans)}"
+    assert len(read_spans) == 1, f"Expected exactly one Read span, got {len(read_spans)}"
+
+    bash_output = bash_spans[0].get("output")
+    assert bash_output is not None, (
+        "Bash tool output was dropped when a second tool_use arrived before its tool_result. "
+        "cleanup_context must not close active tool spans while the LLM turn is still ongoing."
+    )
+    assert bash_output["content"] == "alpha-bash-output"
+
+    read_output = read_spans[0].get("output")
+    assert read_output is not None
+    assert read_output["content"] == "alpha_file_contents"

--- a/py/src/braintrust/integrations/claude_agent_sdk/tracing.py
+++ b/py/src/braintrust/integrations/claude_agent_sdk/tracing.py
@@ -680,10 +680,17 @@ class ContextTracker:
         ctx = self._get_context(incoming_parent)
 
         # Close dangling tool spans from the previous turn in this context.
-        if ctx.llm_span and self._tool_tracker.has_active_spans:
+        #
+        # Only run cleanup when a user tool_result has advanced the clock
+        # (``ctx.next_llm_start`` is set), which marks a real turn boundary.
+        # Starting in claude-agent-sdk 0.1.61, a subagent may emit multiple
+        # ``tool_use`` AssistantMessages back-to-back (merged into one LLM
+        # turn) before any ``tool_result`` arrives. In that case the earlier
+        # tool spans are still awaiting their results and must not be closed.
+        if ctx.llm_span and ctx.next_llm_start is not None and self._tool_tracker.has_active_spans:
             self._tool_tracker.cleanup_context(
                 incoming_parent,
-                end_time=ctx.next_llm_start or time.time(),
+                end_time=ctx.next_llm_start,
                 exclude_ids=self._live_agent_tool_use_ids(),
             )
 


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk-python/issues/318

## AI Summary

In claude-agent-sdk 0.1.61 a delegated subagent can emit multiple tool_use AssistantMessages (e.g. Bash then Read) inside one LLM turn before any tool_result arrives. ContextTracker._handle_assistant was unconditionally calling cleanup_context whenever the context already had an llm_span, which closed the in-flight Bash tool span with no output. When the matching tool_result finally arrived two events later, the span was already gone and its output was dropped (issue #318).

Only run cleanup_context when ctx.next_llm_start is set, which is the real LLM-turn boundary (set in _handle_user when a tool_result arrives). Back-to- back tool_use messages now merge into the existing LLM span without closing sibling tool spans.

- Red/green regression: new ContextTracker unit test simulating the 0.1.61 event stream (Bash tool_use -> Read tool_use -> Read tool_result -> Bash tool_result, all under one subagent parent).
- Re-records cassettes under claude-agent-sdk 0.1.61 and bumps the matrix latest pin to 0.1.61. test_interleaved_subagent_tool_spans_preserve_output and test_interleaved_subagent_tool_spans_parent_to_correct_llm now pass.
- Full test_claude_agent_sdk(latest) and test_claude_agent_sdk(0.1.10) sessions green.