### PR TITLE
feat(litellm): instrument rerank and arerank

### DIFF
--- a/py/src/braintrust/integrations/litellm/__init__.py
+++ b/py/src/braintrust/integrations/litellm/__init__.py
@@ -10,9 +10,9 @@ def patch_litellm() -> bool:
     This wraps litellm.completion, litellm.acompletion, litellm.responses,
     litellm.aresponses, litellm.image_generation, litellm.aimage_generation,
     litellm.embedding, litellm.aembedding, litellm.moderation,
-    litellm.speech, litellm.aspeech, litellm.transcription, and
-    litellm.atranscription to automatically create Braintrust spans with
-    detailed token metrics, timing, and costs.
+    litellm.speech, litellm.aspeech, litellm.transcription,
+    litellm.atranscription, litellm.rerank, and litellm.arerank to automatically
+    create Braintrust spans with detailed token metrics, timing, and costs.
 
     Returns:
         True if LiteLLM was patched (or already patched), False if LiteLLM is not installed.

--- a/py/src/braintrust/integrations/litellm/cassettes/1.74.0/test_litellm_arerank.yaml
+++ b/py/src/braintrust/integrations/litellm/cassettes/1.74.0/test_litellm_arerank.yaml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: '{"model": "rerank-english-v3.0", "query": "What is the capital of France?",
+      "top_n": 2, "documents": ["Paris is the capital of France.", "Berlin is the
+      capital of Germany.", "Madrid is the capital of Spain."]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '209'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.com
+      user-agent:
+      - litellm/1.74.0
+    method: POST
+    uri: https://api.cohere.com/v2/rerank
+  response:
+    body:
+      string: '{"id":"e38c517d-0707-49b8-ab1a-b0a43fec4e56","results":[{"index":0,"relevance_score":0.99914074},{"index":1,"relevance_score":0.00090044667}],"meta":{"api_version":{"version":"2"},"billed_units":{"search_units":1}}}'
+    headers:
+      Access-Control-Expose-Headers:
+      - X-Debug-Trace-ID
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 16:43:22 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - envoy
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin,Accept-Encoding
+      Via:
+      - 1.1 google
+      content-length:
+      - '215'
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - 1f986766371c39aa1748d236c7d008ff
+      x-endpoint-monthly-call-limit:
+      - '1000'
+      x-envoy-upstream-service-time:
+      - '59'
+      x-trial-endpoint-call-limit:
+      - '10'
+      x-trial-endpoint-call-remaining:
+      - '6'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/litellm/cassettes/1.74.0/test_litellm_rerank.yaml
+++ b/py/src/braintrust/integrations/litellm/cassettes/1.74.0/test_litellm_rerank.yaml
@@ -1,0 +1,69 @@
+interactions:
+- request:
+    body: '{"model": "rerank-english-v3.0", "query": "What is the capital of France?",
+      "top_n": 2, "documents": ["Paris is the capital of France.", "Berlin is the
+      capital of Germany.", "Madrid is the capital of Spain."], "return_documents":
+      true}'
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '235'
+      Host:
+      - api.cohere.com
+      User-Agent:
+      - litellm/1.74.0
+      accept:
+      - application/json
+      content-type:
+      - application/json
+    method: POST
+    uri: https://api.cohere.com/v2/rerank
+  response:
+    body:
+      string: '{"id":"bd2ffb0d-cd14-42b7-b965-ab82102c52e0","results":[{"document":{"text":"Paris
+        is the capital of France."},"index":0,"relevance_score":0.99914074},{"document":{"text":"Berlin
+        is the capital of Germany."},"index":1,"relevance_score":0.00090044667}],"meta":{"api_version":{"version":"2"},"billed_units":{"search_units":1}}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 google
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-length:
+      - '325'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Apr 2026 16:43:22 GMT
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      pragma:
+      - no-cache
+      server:
+      - envoy
+      vary:
+      - Origin,Accept-Encoding
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - 59996465b49810f59a7c2f5da2745364
+      x-endpoint-monthly-call-limit:
+      - '1000'
+      x-envoy-upstream-service-time:
+      - '59'
+      x-trial-endpoint-call-limit:
+      - '10'
+      x-trial-endpoint-call-remaining:
+      - '7'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/litellm/cassettes/latest/test_litellm_arerank.yaml
+++ b/py/src/braintrust/integrations/litellm/cassettes/latest/test_litellm_arerank.yaml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: '{"model": "rerank-english-v3.0", "query": "What is the capital of France?",
+      "top_n": 2, "documents": ["Paris is the capital of France.", "Berlin is the
+      capital of Germany.", "Madrid is the capital of Spain."]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '209'
+      content-type:
+      - application/json
+      host:
+      - api.cohere.com
+      user-agent:
+      - litellm/1.83.9
+    method: POST
+    uri: https://api.cohere.com/v2/rerank
+  response:
+    body:
+      string: '{"id":"b4fc3614-84e1-45dd-b25b-0df18ac97c42","results":[{"index":0,"relevance_score":0.99914074},{"index":1,"relevance_score":0.00090044667}],"meta":{"api_version":{"version":"2"},"billed_units":{"search_units":1}}}'
+    headers:
+      Access-Control-Expose-Headers:
+      - X-Debug-Trace-ID
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 16:42:57 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - envoy
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin,Accept-Encoding
+      Via:
+      - 1.1 google
+      content-length:
+      - '215'
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - f5289934ddbfbfd8159d196057195750
+      x-endpoint-monthly-call-limit:
+      - '1000'
+      x-envoy-upstream-service-time:
+      - '52'
+      x-trial-endpoint-call-limit:
+      - '10'
+      x-trial-endpoint-call-remaining:
+      - '8'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/litellm/cassettes/latest/test_litellm_rerank.yaml
+++ b/py/src/braintrust/integrations/litellm/cassettes/latest/test_litellm_rerank.yaml
@@ -1,0 +1,69 @@
+interactions:
+- request:
+    body: '{"model": "rerank-english-v3.0", "query": "What is the capital of France?",
+      "top_n": 2, "documents": ["Paris is the capital of France.", "Berlin is the
+      capital of Germany.", "Madrid is the capital of Spain."], "return_documents":
+      true}'
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '235'
+      Host:
+      - api.cohere.com
+      User-Agent:
+      - litellm/1.83.9
+      accept:
+      - application/json
+      content-type:
+      - application/json
+    method: POST
+    uri: https://api.cohere.com/v2/rerank
+  response:
+    body:
+      string: '{"id":"fde09c2d-737b-4dad-85e8-2b45117bfda9","results":[{"document":{"text":"Paris
+        is the capital of France."},"index":0,"relevance_score":0.99914074},{"document":{"text":"Berlin
+        is the capital of Germany."},"index":1,"relevance_score":0.00090044667}],"meta":{"api_version":{"version":"2"},"billed_units":{"search_units":1}}}'
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 google
+      access-control-expose-headers:
+      - X-Debug-Trace-ID
+      cache-control:
+      - no-cache, no-store, no-transform, must-revalidate, private, max-age=0
+      content-length:
+      - '325'
+      content-type:
+      - application/json
+      date:
+      - Fri, 17 Apr 2026 16:42:57 GMT
+      expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      pragma:
+      - no-cache
+      server:
+      - envoy
+      vary:
+      - Origin,Accept-Encoding
+      x-accel-expires:
+      - '0'
+      x-debug-trace-id:
+      - ebee84a767d62a871bf19f9a5dbbe14f
+      x-endpoint-monthly-call-limit:
+      - '1000'
+      x-envoy-upstream-service-time:
+      - '62'
+      x-trial-endpoint-call-limit:
+      - '10'
+      x-trial-endpoint-call-remaining:
+      - '9'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/litellm/patchers.py
+++ b/py/src/braintrust/integrations/litellm/patchers.py
@@ -8,6 +8,7 @@ from .tracing import (
     _acompletion_wrapper_async,
     _aembedding_wrapper_async,
     _aimage_generation_wrapper_async,
+    _arerank_wrapper_async,
     _aresponses_wrapper_async,
     _aspeech_wrapper_async,
     _atranscription_wrapper_async,
@@ -15,6 +16,7 @@ from .tracing import (
     _embedding_wrapper,
     _image_generation_wrapper,
     _moderation_wrapper,
+    _rerank_wrapper,
     _responses_wrapper,
     _speech_wrapper,
     _transcription_wrapper,
@@ -104,6 +106,18 @@ class LiteLLMATranscriptionPatcher(FunctionWrapperPatcher):
     wrapper = _atranscription_wrapper_async
 
 
+class LiteLLMRerankPatcher(FunctionWrapperPatcher):
+    name = "litellm.rerank"
+    target_path = "rerank"
+    wrapper = _rerank_wrapper
+
+
+class LiteLLMArerankPatcher(FunctionWrapperPatcher):
+    name = "litellm.arerank"
+    target_path = "arerank"
+    wrapper = _arerank_wrapper_async
+
+
 # ---------------------------------------------------------------------------
 # All patchers, in declaration order
 # ---------------------------------------------------------------------------
@@ -122,6 +136,8 @@ _ALL_LITELLM_PATCHERS = (
     LiteLLMAspeechPatcher,
     LiteLLMTranscriptionPatcher,
     LiteLLMATranscriptionPatcher,
+    LiteLLMRerankPatcher,
+    LiteLLMArerankPatcher,
 )
 
 
@@ -138,8 +154,8 @@ def wrap_litellm(litellm: Any) -> Any:
     that exposes the same top-level callables such as ``completion``,
     ``acompletion``, ``responses``, ``aresponses``, ``image_generation``,
     ``aimage_generation``, ``embedding``, ``aembedding``, ``moderation``,
-    ``speech``, ``aspeech``, ``transcription``, and ``atranscription``).
-    Each patcher is applied idempotently — calling
+    ``speech``, ``aspeech``, ``transcription``, ``atranscription``,
+    ``rerank``, and ``arerank``). Each patcher is applied idempotently — calling
     ``wrap_litellm`` twice on the same object is safe.
 
     Args:

--- a/py/src/braintrust/integrations/litellm/test_litellm.py
+++ b/py/src/braintrust/integrations/litellm/test_litellm.py
@@ -17,6 +17,14 @@ TEST_PROMPT = "What's 12 + 12?"
 TEST_SYSTEM_PROMPT = "You are a helpful assistant that only responds with numbers."
 TEST_AUDIO_FILE = os.path.join(os.path.dirname(__file__), "..", "..", "fixtures", "test_audio.wav")
 
+RERANK_MODEL = "cohere/rerank-english-v3.0"
+RERANK_QUERY = "What is the capital of France?"
+RERANK_DOCUMENTS = [
+    "Paris is the capital of France.",
+    "Berlin is the capital of Germany.",
+    "Madrid is the capital of Spain.",
+]
+
 
 def _assert_speech_output_attachment(span) -> None:
     assert span["output"]["type"] == "audio"
@@ -790,6 +798,140 @@ def test_litellm_openrouter_no_booleans_in_metrics(memory_logger):
     for key, value in metrics.items():
         assert not isinstance(value, bool)
     assert "is_byok" not in metrics
+
+
+@pytest.mark.vcr
+def test_litellm_rerank(memory_logger):
+    assert not memory_logger.pop()
+
+    start = time.time()
+    response = litellm.rerank(
+        model=RERANK_MODEL,
+        query=RERANK_QUERY,
+        documents=RERANK_DOCUMENTS,
+        top_n=2,
+    )
+    end = time.time()
+
+    assert response
+    assert response.results
+    assert len(response.results) == 2
+    # Paris should rank first for "capital of France".
+    assert response.results[0]["index"] == 0
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span["span_attributes"]["name"] == "Rerank"
+    assert span["span_attributes"]["type"] == "llm"
+    assert span["metadata"]["provider"] == "litellm"
+    assert span["metadata"]["model"] == RERANK_MODEL
+    assert span["metadata"]["top_n"] == 2
+    assert span["metadata"]["document_count"] == 3
+    assert span["input"] == {"query": RERANK_QUERY, "documents": RERANK_DOCUMENTS}
+
+    assert isinstance(span["output"], list)
+    assert len(span["output"]) == 2
+    assert span["output"][0]["index"] == 0
+    assert isinstance(span["output"][0]["relevance_score"], float)
+    # Document payload must not leak into the span output.
+    for entry in span["output"]:
+        assert set(entry.keys()) == {"index", "relevance_score"}
+
+    metrics = span["metrics"]
+    assert metrics["start"] >= start
+    assert metrics["end"] <= end
+    assert metrics["end"] >= metrics["start"]
+    assert metrics["duration"] >= 0
+    # Cohere rerank bills in search_units.
+    assert metrics.get("search_units") == 1
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_litellm_arerank(memory_logger):
+    assert not memory_logger.pop()
+
+    start = time.time()
+    response = await litellm.arerank(
+        model=RERANK_MODEL,
+        query=RERANK_QUERY,
+        documents=RERANK_DOCUMENTS,
+        top_n=2,
+    )
+    end = time.time()
+
+    assert response
+    assert response.results
+    assert len(response.results) == 2
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span["span_attributes"]["name"] == "Rerank"
+    assert span["metadata"]["provider"] == "litellm"
+    assert span["metadata"]["model"] == RERANK_MODEL
+    assert span["metadata"]["top_n"] == 2
+    assert span["metadata"]["document_count"] == 3
+    assert span["input"] == {"query": RERANK_QUERY, "documents": RERANK_DOCUMENTS}
+    assert isinstance(span["output"], list)
+    assert len(span["output"]) == 2
+
+    metrics = span["metrics"]
+    assert metrics["start"] >= start
+    assert metrics["end"] <= end
+    assert metrics.get("search_units") == 1
+
+
+def test_litellm_parse_rerank_metrics_from_meta():
+    """Unit-level sanity check for ``_parse_rerank_metrics``.
+
+    LiteLLM rerank responses follow Cohere's shape: usage lives under
+    ``meta.billed_units`` and ``meta.tokens``.  ``billed_units`` wins when
+    both are present.
+    """
+    from braintrust.integrations.litellm.tracing import _parse_rerank_metrics
+
+    response = {
+        "meta": {
+            "billed_units": {
+                "input_tokens": 7,
+                "output_tokens": 3,
+                "search_units": 1,
+            },
+            "tokens": {
+                "input_tokens": 999,
+                "output_tokens": 999,
+            },
+        }
+    }
+    metrics = _parse_rerank_metrics(response)
+    # billed_units overrides the matching fields in tokens.
+    assert metrics["prompt_tokens"] == 7
+    assert metrics["completion_tokens"] == 3
+    assert metrics["search_units"] == 1
+    # derived total when no total_tokens is reported.
+    assert metrics["tokens"] == 10
+
+    # meta.billed_units alone also yields a derived total.
+    metrics2 = _parse_rerank_metrics({"meta": {"billed_units": {"search_units": 1}}})
+    assert metrics2 == {"search_units": 1}
+
+
+def test_litellm_extract_rerank_output_drops_document():
+    from braintrust.integrations.litellm.tracing import _extract_rerank_output
+
+    response = {
+        "results": [
+            {"index": 0, "relevance_score": 0.9, "document": {"text": "private"}},
+            {"index": 1, "relevance_score": 0.1, "document": {"text": "also private"}},
+        ]
+    }
+    out = _extract_rerank_output(response)
+    assert out == [
+        {"index": 0, "relevance_score": 0.9},
+        {"index": 1, "relevance_score": 0.1},
+    ]
 
 
 class TestAutoInstrumentLiteLLM:

--- a/py/src/braintrust/integrations/litellm/tracing.py
+++ b/py/src/braintrust/integrations/litellm/tracing.py
@@ -16,7 +16,7 @@ from braintrust.integrations.utils import (
 )
 from braintrust.logger import Span, start_span
 from braintrust.span_types import SpanTypeAttribute
-from braintrust.util import clean_nones, merge_dicts
+from braintrust.util import clean_nones, is_numeric, merge_dicts
 
 
 # LiteLLM's representation to Braintrust's representation
@@ -482,6 +482,44 @@ async def _aspeech_wrapper_async(wrapped, instance, args, kwargs):
         return speech_response
 
 
+def _rerank_wrapper(wrapped, instance, args, kwargs):
+    """wrapt wrapper for litellm.rerank."""
+    updated_span_payload = _update_rerank_span_payload_from_params(kwargs)
+
+    with start_span(
+        **merge_dicts(dict(name="Rerank", span_attributes={"type": SpanTypeAttribute.LLM}), updated_span_payload)
+    ) as span:
+        start = time.time()
+        rerank_response = wrapped(*args, **kwargs)
+        log_response = _try_to_dict(rerank_response)
+        metrics = _timing_metrics(start, time.time())
+        metrics.update(_parse_rerank_metrics(log_response))
+        span.log(
+            metrics=metrics,
+            output=_extract_rerank_output(log_response),
+        )
+        return rerank_response
+
+
+async def _arerank_wrapper_async(wrapped, instance, args, kwargs):
+    """wrapt wrapper for litellm.arerank."""
+    updated_span_payload = _update_rerank_span_payload_from_params(kwargs)
+
+    with start_span(
+        **merge_dicts(dict(name="Rerank", span_attributes={"type": SpanTypeAttribute.LLM}), updated_span_payload)
+    ) as span:
+        start = time.time()
+        rerank_response = await wrapped(*args, **kwargs)
+        log_response = _try_to_dict(rerank_response)
+        metrics = _timing_metrics(start, time.time())
+        metrics.update(_parse_rerank_metrics(log_response))
+        span.log(
+            metrics=metrics,
+            output=_extract_rerank_output(log_response),
+        )
+        return rerank_response
+
+
 def _transcription_wrapper(wrapped, instance, args, kwargs):
     """wrapt wrapper for litellm.transcription."""
     updated_span_payload = _update_audio_span_payload_from_params(kwargs)
@@ -662,6 +700,32 @@ def _update_span_payload_from_params(params: dict[str, Any], input_key: str = "i
     )
 
 
+def _update_rerank_span_payload_from_params(params: dict[str, Any]) -> dict[str, Any]:
+    """Build the span payload for a LiteLLM rerank/arerank call.
+
+    The request shape is modeled after Cohere's rerank API: ``query`` plus a
+    list of ``documents``.  The span input captures both, metadata records the
+    model and reranker-specific request parameters, and ``document_count`` is
+    derived for convenience.
+    """
+    params = params.copy()
+    span_info_d = params.pop("span_info", {})
+
+    params = _prettify_response_params(params)
+    query = params.pop("query", None)
+    documents = params.pop("documents", None)
+    model = params.pop("model", None)
+
+    metadata: dict[str, Any] = {**params, "provider": "litellm", "model": model}
+    if isinstance(documents, (list, tuple)):
+        metadata["document_count"] = len(documents)
+
+    return merge_dicts(
+        span_info_d,
+        {"input": {"query": query, "documents": documents}, "metadata": metadata},
+    )
+
+
 def _update_audio_span_payload_from_params(params: dict[str, Any]) -> dict[str, Any]:
     """Update the span payload for audio transcription calls."""
     params = params.copy()
@@ -695,3 +759,87 @@ def _parse_metrics_from_usage(usage: Any) -> dict[str, Any]:
         token_name_map=TOKEN_NAME_MAP,
         token_prefix_map=TOKEN_PREFIX_MAP,
     )
+
+
+_RERANK_BILLED_UNITS_MAP: dict[str, str] = {
+    "input_tokens": "prompt_tokens",
+    "output_tokens": "completion_tokens",
+    "search_units": "search_units",
+    "classifications": "classifications",
+    "total_tokens": "tokens",
+}
+
+_RERANK_TOKENS_MAP: dict[str, str] = {
+    "input_tokens": "prompt_tokens",
+    "output_tokens": "completion_tokens",
+    "total_tokens": "tokens",
+}
+
+
+def _parse_rerank_metrics(response: Any) -> dict[str, Any]:
+    """Parse token / billed-unit metrics from a LiteLLM rerank response.
+
+    LiteLLM follows Cohere's rerank response shape: usage lives under
+    ``meta.billed_units`` (the authoritative billing counter) and
+    ``meta.tokens``.  ``billed_units`` wins when both are present.
+    """
+    metrics: dict[str, Any] = {}
+    response_dict = _try_to_dict(response)
+    if not isinstance(response_dict, dict):
+        return metrics
+
+    meta = _try_to_dict(response_dict.get("meta"))
+    if not isinstance(meta, dict):
+        return metrics
+
+    tokens_block = _try_to_dict(meta.get("tokens"))
+    if isinstance(tokens_block, dict):
+        for src_key, dst_key in _RERANK_TOKENS_MAP.items():
+            value = tokens_block.get(src_key)
+            if is_numeric(value):
+                metrics[dst_key] = value
+
+    # ``billed_units`` is Cohere's authoritative billing counter and
+    # intentionally overrides values from ``tokens`` when both are present.
+    billed = _try_to_dict(meta.get("billed_units"))
+    if isinstance(billed, dict):
+        for src_key, dst_key in _RERANK_BILLED_UNITS_MAP.items():
+            value = billed.get(src_key)
+            if is_numeric(value):
+                metrics[dst_key] = value
+
+    if "tokens" not in metrics and "prompt_tokens" in metrics and "completion_tokens" in metrics:
+        metrics["tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
+
+    return metrics
+
+
+def _extract_rerank_output(response: Any) -> list[dict[str, Any]] | None:
+    """Return the ranked ``{index, relevance_score}`` list from a rerank response.
+
+    The document payload (returned when ``return_documents=True``) is dropped
+    on purpose to keep the span compact and avoid logging the raw corpus.
+    Results are capped at 100 entries.
+    """
+    response_dict = _try_to_dict(response)
+    if not isinstance(response_dict, dict):
+        return None
+
+    results = response_dict.get("results")
+    if not isinstance(results, list):
+        return None
+
+    out: list[dict[str, Any]] = []
+    for item in results[:100]:
+        if item is None:
+            continue
+        item_dict = _try_to_dict(item)
+        if not isinstance(item_dict, dict):
+            continue
+        out.append(
+            {
+                "index": item_dict.get("index"),
+                "relevance_score": item_dict.get("relevance_score"),
+            }
+        )
+    return out


### PR DESCRIPTION
Add LiteLLM `rerank()` / `arerank()` tracing, following the Cohere integration pattern. Both `patch_litellm()` (via `_ALL_LITELLM_PATCHERS`) and `wrap_litellm()` now produce a "Rerank" LLM span.

Tests are VCR-backed against `cohere/rerank-english-v3.0`, with cassettes for both the `latest` and `1.74.0` matrix entries. Adds unit coverage for the metrics-precedence and output-sanitization helpers.

Closes #266