### PR TITLE
fix(mistral): instrument beta conversations api

### DIFF
--- a/py/src/braintrust/integrations/mistral/cassettes/1.12.4/test_mistral_integration_setup_instruments_beta_conversations.yaml
+++ b/py/src/braintrust/integrations/mistral/cassettes/1.12.4/test_mistral_integration_setup_instruments_beta_conversations.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: '{"inputs":"What is 4+4? Reply with just the number.","stream":false,"model":"mistral-small-latest"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/1.12.4
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations
+  response:
+    body:
+      string: '{"object":"conversation.response","conversation_id":"conv_019d9d49ecb373428ac739585b3543ad","outputs":[{"object":"entry","type":"message.output","created_at":"2026-04-17T21:12:41.070743Z","completed_at":"2026-04-17T21:12:41.070743Z","model":"mistral-small-latest","id":"msg_019d9d49ed6e7757b61d28512b25d4b0","role":"assistant","content":"8"}],"usage":{"prompt_tokens":16,"completion_tokens":2,"total_tokens":18},"guardrails":null}'
+    headers:
+      CF-RAY:
+      - 9ede6de6e9e8ac4e-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 21:12:41 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '430'
+      mistral-correlation-id:
+      - 019d9d49-ec9b-73df-b016-f400c9f6c02a
+      set-cookie:
+      - __cf_bm=urgOUix4LFR3_573igkAsuF8r2VaU7n7jxOBA__cu4s-1776460360.7896147-1.0.1.1-CE2.sDKjSCwKJN7MApEk7pmY7uV7enPMwblU4x9ehi97bTEQurOHWqM5_4E8.g2M537HlLRGnu4cxULE2lO6LyNeb3OfohZ5pYE4zETGnmoanX2nHNvs0dAmIZw08_kX;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:42:41
+        GMT
+      - _cfuvid=TyRm2V_n_kS.71yr5zIKq5G_MyOOgbYu9LOWoAXF.JM-1776460360.7896147-1.0.1.1-bPoyNr1swGONJROJsF66C6V8ZERwjEZZZVRjbIf7ctM;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '227'
+      x-kong-proxy-latency:
+      - '16'
+      x-kong-request-id:
+      - 019d9d49-ec9b-73df-b016-f400c9f6c02a
+      x-kong-upstream-latency:
+      - '230'
+      x-ratelimit-limit-tokens-minute:
+      - '500000'
+      x-ratelimit-limit-tokens-month:
+      - '1000000000'
+      x-ratelimit-remaining-tokens-minute:
+      - '499674'
+      x-ratelimit-remaining-tokens-month:
+      - '999999534'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/mistral/cassettes/1.12.4/test_wrap_mistral_beta_conversations_append_async.yaml
+++ b/py/src/braintrust/integrations/mistral/cassettes/1.12.4/test_wrap_mistral_beta_conversations_append_async.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: '{"inputs":"What is 1+1? Reply with just the number.","stream":false,"model":"mistral-small-latest"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/1.12.4
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations
+  response:
+    body:
+      string: '{"object":"conversation.response","conversation_id":"conv_019d9d49e1da73a7a0f7bcc4c9650c2e","outputs":[{"object":"entry","type":"message.output","created_at":"2026-04-17T21:12:38.296379Z","completed_at":"2026-04-17T21:12:38.296379Z","model":"mistral-small-latest","id":"msg_019d9d49e2987416ad2bec3dc5cc743a","role":"assistant","content":"2"}],"usage":{"prompt_tokens":16,"completion_tokens":2,"total_tokens":18},"guardrails":null}'
+    headers:
+      CF-RAY:
+      - 9ede6dd41d857117-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 21:12:38 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '430'
+      mistral-correlation-id:
+      - 019d9d49-e1ca-79ae-9a1d-ed58b98974a0
+      set-cookie:
+      - __cf_bm=12xPunmembgAvGM2acjI949kYhEwlF33cFG8_IExlHo-1776460357.7809439-1.0.1.1-ohH02HVJ_dLpFjH3DQHxcyKiLWlQcuxUm87RIqUy0iGVWbLz2nV1FRwe.rrKOw.5bR9.yaAnolRJsZFw8zdBFUjX8QlA1KtqceQ.CnTiohGOVb7_6RCVIvpkLBSijvov;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:42:38
+        GMT
+      - _cfuvid=ii1njpIfteejYH_bMnqTgK5kKmYonYMYw3H3CudQdUk-1776460357.7809439-1.0.1.1-.DYbfx1Nyv97uVXe51zHm62BRYgJV_VcFvTkcU8_sSM;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '228'
+      x-kong-proxy-latency:
+      - '10'
+      x-kong-request-id:
+      - 019d9d49-e1ca-79ae-9a1d-ed58b98974a0
+      x-kong-upstream-latency:
+      - '229'
+      x-ratelimit-limit-tokens-minute:
+      - '500000'
+      x-ratelimit-limit-tokens-month:
+      - '1000000000'
+      x-ratelimit-remaining-tokens-minute:
+      - '499801'
+      x-ratelimit-remaining-tokens-month:
+      - '999999661'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"inputs":"What is 2+3? Reply with just the number.","stream":false,"store":true,"handoff_execution":"server"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/1.12.4
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations/conv_019d9d49e1da73a7a0f7bcc4c9650c2e
+  response:
+    body:
+      string: '{"object":"conversation.response","conversation_id":"conv_019d9d49e1da73a7a0f7bcc4c9650c2e","outputs":[{"object":"entry","type":"message.output","created_at":"2026-04-17T21:12:38.892167Z","completed_at":"2026-04-17T21:12:38.892167Z","model":"mistral-small-latest","id":"msg_019d9d49e4ec77aa9b8ef7d5c0ef4a54","role":"assistant","content":"5"}],"usage":{"prompt_tokens":33,"completion_tokens":2,"total_tokens":35},"guardrails":null}'
+    headers:
+      CF-RAY:
+      - 9ede6dd8f91864a6-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 21:12:38 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '430'
+      mistral-correlation-id:
+      - 019d9d49-e3dc-7f5f-a144-7804fd933d5c
+      set-cookie:
+      - __cf_bm=0COnrjBYsyOv.Lo5qFVPNqQJr1DKM64ThRTxZ4cwyFs-1776460358.558665-1.0.1.1-7t41JHwmq2IinCXMNHIjQS6j9NZpOz3feTJhgcjVwusX55QoLUXs6z39NXm1eaEnq_iDUT94e9il5D7ymfvHVmYEvao1jlBkd0rJOtD2whUTClGuxN0bwlcI3wCK_0A0;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:42:38
+        GMT
+      - _cfuvid=2lAPiwdhYDVSXvRfRf6PNJ8CFUqTo5dDmaW4prA5KUg-1776460358.558665-1.0.1.1-FrZQysKiHAgWp5Wox2fOEUSpGx8U.azCBJYrdFnMBbw;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '301'
+      x-kong-proxy-latency:
+      - '14'
+      x-kong-request-id:
+      - 019d9d49-e3dc-7f5f-a144-7804fd933d5c
+      x-kong-upstream-latency:
+      - '302'
+      x-ratelimit-limit-tokens-minute:
+      - '500000'
+      x-ratelimit-limit-tokens-month:
+      - '1000000000'
+      x-ratelimit-remaining-tokens-minute:
+      - '499766'
+      x-ratelimit-remaining-tokens-month:
+      - '999999626'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/mistral/cassettes/1.12.4/test_wrap_mistral_beta_conversations_restart_sync.yaml
+++ b/py/src/braintrust/integrations/mistral/cassettes/1.12.4/test_wrap_mistral_beta_conversations_restart_sync.yaml
@@ -1,0 +1,147 @@
+interactions:
+- request:
+    body: '{"inputs":"What is 9+1? Reply with just the number.","stream":false,"model":"mistral-small-latest"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/1.12.4
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations
+  response:
+    body:
+      string: '{"object":"conversation.response","conversation_id":"conv_019d9d49e86573829520ad10adbdb2ae","outputs":[{"object":"entry","type":"message.output","created_at":"2026-04-17T21:12:39.978536Z","completed_at":"2026-04-17T21:12:39.991921Z","model":"mistral-small-latest","id":"msg_019d9d49e92a71d5a23d7592a570149c","role":"assistant","content":"10"}],"usage":{"prompt_tokens":16,"completion_tokens":3,"total_tokens":19},"guardrails":null}'
+    headers:
+      CF-RAY:
+      - 9ede6de01e6ddf5a-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 21:12:40 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '431'
+      mistral-correlation-id:
+      - 019d9d49-e852-7d78-aa76-09a673ca1a92
+      set-cookie:
+      - __cf_bm=H_3yVS30aYJU6QfRlLxEBZRSqQy80W7NpzPZORYY8Jo-1776460359.6941855-1.0.1.1-toPS8orFkUXOyyYfxIb4dgtJuTJdbYISsxL.EHrh4Koen9Fs0woodDFyvDwAeslD8WWn4YQ09O3Ee31uXx8uI5HxIEkO_h6mhBkRSYgfHqWHEdE9aQOGl8mKpVIN_kKF;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:42:40
+        GMT
+      - _cfuvid=B0oHIvVaJxM3lTvM8PDKkITthcu0xYCGOJ8Y1WGvy.4-1776460359.6941855-1.0.1.1-1eXWhpI.ddhDE0z8weO6K6xpaUOIKo2YjBEAIOfyKn4;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '241'
+      x-kong-proxy-latency:
+      - '12'
+      x-kong-request-id:
+      - 019d9d49-e852-7d78-aa76-09a673ca1a92
+      x-kong-upstream-latency:
+      - '241'
+      x-ratelimit-limit-tokens-minute:
+      - '500000'
+      x-ratelimit-limit-tokens-month:
+      - '1000000000'
+      x-ratelimit-remaining-tokens-minute:
+      - '499729'
+      x-ratelimit-remaining-tokens-month:
+      - '999999589'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"inputs":"What is 6+6? Reply with just the number.","from_entry_id":"msg_019d9d49e92a71d5a23d7592a570149c","stream":false,"store":true,"handoff_execution":"server"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '165'
+      Cookie:
+      - __cf_bm=H_3yVS30aYJU6QfRlLxEBZRSqQy80W7NpzPZORYY8Jo-1776460359.6941855-1.0.1.1-toPS8orFkUXOyyYfxIb4dgtJuTJdbYISsxL.EHrh4Koen9Fs0woodDFyvDwAeslD8WWn4YQ09O3Ee31uXx8uI5HxIEkO_h6mhBkRSYgfHqWHEdE9aQOGl8mKpVIN_kKF;
+        _cfuvid=B0oHIvVaJxM3lTvM8PDKkITthcu0xYCGOJ8Y1WGvy.4-1776460359.6941855-1.0.1.1-1eXWhpI.ddhDE0z8weO6K6xpaUOIKo2YjBEAIOfyKn4
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/1.12.4
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations/conv_019d9d49e86573829520ad10adbdb2ae/restart
+  response:
+    body:
+      string: '{"object":"conversation.response","conversation_id":"conv_019d9d49ea9f773b81fa3ed2cf5b56ad","outputs":[{"object":"entry","type":"message.output","created_at":"2026-04-17T21:12:40.557743Z","completed_at":"2026-04-17T21:12:40.582376Z","model":"mistral-small-latest","id":"msg_019d9d49eb6d758887d89ae8a06272aa","role":"assistant","content":"12"}],"usage":{"prompt_tokens":34,"completion_tokens":3,"total_tokens":37},"guardrails":null}'
+    headers:
+      CF-RAY:
+      - 9ede6de379aef4cc-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 21:12:40 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '431'
+      mistral-correlation-id:
+      - 019d9d49-ea6c-773d-bec0-6232df811388
+      x-envoy-upstream-service-time:
+      - '282'
+      x-kong-proxy-latency:
+      - '23'
+      x-kong-request-id:
+      - 019d9d49-ea6c-773d-bec0-6232df811388
+      x-kong-upstream-latency:
+      - '285'
+      x-ratelimit-limit-tokens-minute:
+      - '500000'
+      x-ratelimit-limit-tokens-month:
+      - '1000000000'
+      x-ratelimit-remaining-tokens-minute:
+      - '499692'
+      x-ratelimit-remaining-tokens-month:
+      - '999999552'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/mistral/cassettes/1.12.4/test_wrap_mistral_beta_conversations_start_stream_sync.yaml
+++ b/py/src/braintrust/integrations/mistral/cassettes/1.12.4/test_wrap_mistral_beta_conversations_start_stream_sync.yaml
@@ -1,0 +1,81 @@
+interactions:
+- request:
+    body: '{"inputs":"What is 3+4? Reply with just the number.","stream":true,"model":"mistral-small-latest"}'
+    headers:
+      Accept:
+      - text/event-stream
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/1.12.4
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations
+  response:
+    body:
+      string: 'event: conversation.response.started
+
+        data: {"type":"conversation.response.started","created_at":"2026-04-17T21:12:39.424587Z","conversation_id":"conv_019d9d49e63672389192a2241f42bc18"}
+
+
+        event: message.output.delta
+
+        data: {"type":"message.output.delta","created_at":"2026-04-17T21:12:39.427191Z","output_index":0,"id":"msg_019d9d49e70374cc9c22c37276a4c5c9","content_index":0,"model":"mistral-small-latest","role":"assistant","content":"7"}
+
+
+        event: conversation.response.done
+
+        data: {"type":"conversation.response.done","created_at":"2026-04-17T21:12:39.457233Z","usage":{"prompt_tokens":16,"completion_tokens":2,"total_tokens":18}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9ede6ddca9dcab28-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Fri, 17 Apr 2026 21:12:39 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      mistral-correlation-id:
+      - 019d9d49-e623-7cda-8f52-e6f3bc8e2c3e
+      set-cookie:
+      - __cf_bm=g_N3a8J4C1Bs1nnqFbXuoGbeM1alGGAe_dcryqTWM_4-1776460359.1437535-1.0.1.1-e3rpIfd0WjrU2WLjAR5EaXsBJ5mw1VTcqw4cSRSdhNFsBFUe6OrpBC5ATpUfCvQVp4IOMdgiYOLYj.IAxljryNd6X.jXgJF9DaDLYRzoJF91frdu0ZOqS_3Z5SiqYChx;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:42:39
+        GMT
+      - _cfuvid=swlCdwbymM31jXt4zL2m30fagNgds.OxAuZXn.dnC6I-1776460359.1437535-1.0.1.1-uJhZBtgxfVNp0tJM6D.5XUVTTNxQ5l8BnFhHdSXzx9I;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '211'
+      x-kong-proxy-latency:
+      - '14'
+      x-kong-request-id:
+      - 019d9d49-e623-7cda-8f52-e6f3bc8e2c3e
+      x-kong-upstream-latency:
+      - '211'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/mistral/cassettes/1.12.4/test_wrap_mistral_beta_conversations_start_sync.yaml
+++ b/py/src/braintrust/integrations/mistral/cassettes/1.12.4/test_wrap_mistral_beta_conversations_start_sync.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: '{"inputs":"What is 2+2? Reply with just the number.","stream":false,"model":"mistral-small-latest"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/1.12.4
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations
+  response:
+    body:
+      string: '{"object":"conversation.response","conversation_id":"conv_019d9d49df1d700c8d3769af441b2e36","outputs":[{"object":"entry","type":"message.output","created_at":"2026-04-17T21:12:37.590281Z","completed_at":"2026-04-17T21:12:37.590281Z","model":"mistral-small-latest","id":"msg_019d9d49dfd675f1b395b82f886a055b","role":"assistant","content":"4"}],"usage":{"prompt_tokens":16,"completion_tokens":2,"total_tokens":18},"guardrails":null}'
+    headers:
+      CF-RAY:
+      - 9ede6dd12b9e4c9b-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 21:12:37 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '430'
+      mistral-correlation-id:
+      - 019d9d49-defa-7ed2-88dc-5568395290f8
+      set-cookie:
+      - __cf_bm=Rxq7K7cHW2S2MuIK3IZFOEvRgWcT_cTUq2hd2CwFKUw-1776460357.307613-1.0.1.1-mYgLKiEZSH7Cr1fLq2U8i1NuU7omFlByf8kecryz8.Pz5aS8no9flSOcb7WLCmoS_xyzvwS5OCN5OjsuRNKZOGXA9Bt5KwWCExJOH7O3saU_ryLhGIg0XgHTxXYq3PYn;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:42:37
+        GMT
+      - _cfuvid=2TALA9019Gvedgg8cfqHilxHeYgRf2resNCF7EF0F2Q-1776460357.307613-1.0.1.1-Oz2UypVveNGNLlrobusbwinGiFnz8AmGK8YwZr2J8W4;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '244'
+      x-kong-proxy-latency:
+      - '15'
+      x-kong-request-id:
+      - 019d9d49-defa-7ed2-88dc-5568395290f8
+      x-kong-upstream-latency:
+      - '245'
+      x-ratelimit-limit-tokens-minute:
+      - '500000'
+      x-ratelimit-limit-tokens-month:
+      - '1000000000'
+      x-ratelimit-remaining-tokens-minute:
+      - '499819'
+      x-ratelimit-remaining-tokens-month:
+      - '999999679'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/mistral/cassettes/latest/test_mistral_integration_setup_instruments_beta_conversations.yaml
+++ b/py/src/braintrust/integrations/mistral/cassettes/latest/test_mistral_integration_setup_instruments_beta_conversations.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: '{"inputs":"What is 4+4? Reply with just the number.","stream":false,"model":"mistral-small-latest"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.4.0
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations
+  response:
+    body:
+      string: '{"object":"conversation.response","conversation_id":"conv_019d9d49b9bf765697e6a8277d0bf391","outputs":[{"object":"entry","type":"message.output","created_at":"2026-04-17T21:12:28.383882Z","completed_at":"2026-04-17T21:12:28.383882Z","model":"mistral-small-latest","id":"msg_019d9d49bbdf76fcb71be6f586bcd5be","role":"assistant","content":"8"}],"usage":{"prompt_tokens":16,"completion_tokens":2,"total_tokens":18},"guardrails":null}'
+    headers:
+      CF-RAY:
+      - 9ede6d9569ce39f8-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 21:12:28 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '430'
+      mistral-correlation-id:
+      - 019d9d49-b9aa-78fa-82e3-b5e9f098b61d
+      set-cookie:
+      - __cf_bm=7NX4NhNumFtMfJBvqXrf2Tiy0gbWGSXfxIsfQH_UBTM-1776460347.748033-1.0.1.1-ZBxFsHj2OipyQpXKF8Bc4cMHX9PO..QKCq7vh1Gx9OLbfaKxOuH6dFapik7P2RvhmcWL5v9KfILqFpHMhTUl3jgOZyOiyGAuBo3KBF59165XmpsiOAoFKblxzxiE.43J;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:42:28
+        GMT
+      - _cfuvid=8.BKyQ8tw7_Pfgxb4BEOZVQQ8_j5a82g_0GhPrGefh0-1776460347.748033-1.0.1.1-jcjtMkIp7ppgrAI92oy2bbEM2Rmrx_Bvbpv7CA94m7A;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '579'
+      x-kong-proxy-latency:
+      - '14'
+      x-kong-request-id:
+      - 019d9d49-b9aa-78fa-82e3-b5e9f098b61d
+      x-kong-upstream-latency:
+      - '580'
+      x-ratelimit-limit-tokens-minute:
+      - '500000'
+      x-ratelimit-limit-tokens-month:
+      - '1000000000'
+      x-ratelimit-remaining-tokens-minute:
+      - '499837'
+      x-ratelimit-remaining-tokens-month:
+      - '999999697'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/mistral/cassettes/latest/test_wrap_mistral_beta_conversations_append_async.yaml
+++ b/py/src/braintrust/integrations/mistral/cassettes/latest/test_wrap_mistral_beta_conversations_append_async.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: '{"inputs":"What is 1+1? Reply with just the number.","stream":false,"model":"mistral-small-latest"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.4.0
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations
+  response:
+    body:
+      string: '{"object":"conversation.response","conversation_id":"conv_019d9d49a11d75648007cd94ba7086f5","outputs":[{"object":"entry","type":"message.output","created_at":"2026-04-17T21:12:24.803308Z","completed_at":"2026-04-17T21:12:24.803308Z","model":"mistral-small-latest","id":"msg_019d9d49ade37408b93056cacf1fa3a1","role":"assistant","content":"2"}],"usage":{"prompt_tokens":16,"completion_tokens":2,"total_tokens":18},"guardrails":null}'
+    headers:
+      CF-RAY:
+      - 9ede6d6e1e12aa71-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 21:12:24 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '430'
+      mistral-correlation-id:
+      - 019d9d49-a106-7140-9682-25e2181d2c79
+      set-cookie:
+      - __cf_bm=N3IcgP3Sml9QG2QPEC.6FzkJOP3g0afeLWPBmpO8DDQ-1776460341.4511206-1.0.1.1-Suc0QadXXFhDNxaP4VqDxgspBV4V6Ka9f6lr6KrZppYZgr.X8bWkkiSAWj71QGkzrWUHcXK53eXK8aCPoZJF5Qdlv5W2_QdKP5xv_5GjmUrQwx9fIfJgKYr9MNEOuSxr;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:42:24
+        GMT
+      - _cfuvid=n8B8.L7TQ_CBER2cUktaKHfz1QiRY0Zyipv.MafGb80-1776460341.4511206-1.0.1.1-2GXhS3ehCSJpQWOPHNVJCX6NiInKHvPWB_kH_7iDryY;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '3317'
+      x-kong-proxy-latency:
+      - '17'
+      x-kong-request-id:
+      - 019d9d49-a106-7140-9682-25e2181d2c79
+      x-kong-upstream-latency:
+      - '3318'
+      x-ratelimit-limit-tokens-minute:
+      - '500000'
+      x-ratelimit-limit-tokens-month:
+      - '1000000000'
+      x-ratelimit-remaining-tokens-minute:
+      - '499964'
+      x-ratelimit-remaining-tokens-month:
+      - '999999824'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"inputs":"What is 2+3? Reply with just the number.","stream":false,"store":true,"handoff_execution":"server"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.4.0
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations/conv_019d9d49a11d75648007cd94ba7086f5
+  response:
+    body:
+      string: '{"object":"conversation.response","conversation_id":"conv_019d9d49a11d75648007cd94ba7086f5","outputs":[{"object":"entry","type":"message.output","created_at":"2026-04-17T21:12:25.297272Z","completed_at":"2026-04-17T21:12:25.297272Z","model":"mistral-small-latest","id":"msg_019d9d49afd171159a188cb3c60e3ace","role":"assistant","content":"5"}],"usage":{"prompt_tokens":33,"completion_tokens":2,"total_tokens":35},"guardrails":null}'
+    headers:
+      CF-RAY:
+      - 9ede6d842953dc46-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 21:12:25 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '430'
+      mistral-correlation-id:
+      - 019d9d49-aed7-741a-82e0-d3a6258495b1
+      set-cookie:
+      - __cf_bm=39okB9FTHGQuHLE7gjyNFWHCfMfmUsXot5vW8o3iNE8-1776460344.9851687-1.0.1.1-us7EVuubh6VDv6v67p2F2D6iO3xLngRizL.0FmvTLE9nVEjr5El.Cq9PkBuwoigKuzaC3weiOC3MaEdp2y0uJlVuir7KfTmjNGuKDvGNWxsvua4G1p9JTXhwH0s7UWPo;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:42:25
+        GMT
+      - _cfuvid=U.yu0yN_o716thbs32gyLw4MK9BP.KTZUt27TYRoZTQ-1776460344.9851687-1.0.1.1-yXYUf8Lu_X3MlbNdGXTvwOTHpOwbi1.fMjrggFI0TZU;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '283'
+      x-kong-proxy-latency:
+      - '17'
+      x-kong-request-id:
+      - 019d9d49-aed7-741a-82e0-d3a6258495b1
+      x-kong-upstream-latency:
+      - '283'
+      x-ratelimit-limit-tokens-minute:
+      - '500000'
+      x-ratelimit-limit-tokens-month:
+      - '1000000000'
+      x-ratelimit-remaining-tokens-minute:
+      - '499929'
+      x-ratelimit-remaining-tokens-month:
+      - '999999789'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/mistral/cassettes/latest/test_wrap_mistral_beta_conversations_restart_sync.yaml
+++ b/py/src/braintrust/integrations/mistral/cassettes/latest/test_wrap_mistral_beta_conversations_restart_sync.yaml
@@ -1,0 +1,154 @@
+interactions:
+- request:
+    body: '{"inputs":"What is 9+1? Reply with just the number.","stream":false,"model":"mistral-small-latest"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.4.0
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations
+  response:
+    body:
+      string: '{"object":"conversation.response","conversation_id":"conv_019d9d49b2e876a9884f4598dbcd7091","outputs":[{"object":"entry","type":"message.output","created_at":"2026-04-17T21:12:27.020173Z","completed_at":"2026-04-17T21:12:27.021446Z","model":"mistral-small-latest","id":"msg_019d9d49b68c732f97e73c285a1fecae","role":"assistant","content":"10"}],"usage":{"prompt_tokens":16,"completion_tokens":3,"total_tokens":19},"guardrails":null}'
+    headers:
+      CF-RAY:
+      - 9ede6d8a8844dde5-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 21:12:27 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '431'
+      mistral-correlation-id:
+      - 019d9d49-b2d5-7cdc-be67-aa8da3f2bb69
+      set-cookie:
+      - __cf_bm=hGJwzpNtbaNm9mmAtlDWsKPgK_GhtoASJDZO9qhnQRM-1776460346.002783-1.0.1.1-5Go.pbGrxYUFWeXHWtoPKSSjTkta0w79LEPzl.cA8BSN1ilTrJW99CvhKCORkLdN0TBPUl09iswFCH3EKdfdR4tF821uNAxYAPSddYqKmYkPivBCjpMVkpY3ECwkgiCr;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:42:27
+        GMT
+      - _cfuvid=nciN_nroncfNBVYDkf3FdHINrZ5WA.GD7j6Y04BQ3eU-1776460346.002783-1.0.1.1-rG02bOuntv2Mo7mr9HrCLBZXpIrKul_Pu_BrJWQiHgY;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '969'
+      x-kong-proxy-latency:
+      - '11'
+      x-kong-request-id:
+      - 019d9d49-b2d5-7cdc-be67-aa8da3f2bb69
+      x-kong-upstream-latency:
+      - '970'
+      x-ratelimit-limit-tokens-minute:
+      - '500000'
+      x-ratelimit-limit-tokens-month:
+      - '1000000000'
+      x-ratelimit-remaining-tokens-minute:
+      - '499892'
+      x-ratelimit-remaining-tokens-month:
+      - '999999752'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"from_entry_id":"msg_019d9d49b68c732f97e73c285a1fecae","inputs":"What
+      is 6+6? Reply with just the number.","stream":false,"store":true,"handoff_execution":"server"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '165'
+      Cookie:
+      - __cf_bm=hGJwzpNtbaNm9mmAtlDWsKPgK_GhtoASJDZO9qhnQRM-1776460346.002783-1.0.1.1-5Go.pbGrxYUFWeXHWtoPKSSjTkta0w79LEPzl.cA8BSN1ilTrJW99CvhKCORkLdN0TBPUl09iswFCH3EKdfdR4tF821uNAxYAPSddYqKmYkPivBCjpMVkpY3ECwkgiCr;
+        _cfuvid=nciN_nroncfNBVYDkf3FdHINrZ5WA.GD7j6Y04BQ3eU-1776460346.002783-1.0.1.1-rG02bOuntv2Mo7mr9HrCLBZXpIrKul_Pu_BrJWQiHgY
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.4.0
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations/conv_019d9d49b2e876a9884f4598dbcd7091/restart
+  response:
+    body:
+      string: '{"object":"conversation.response","conversation_id":"conv_019d9d49b79f75dfa6e9e699f49cf8f1","outputs":[{"object":"entry","type":"message.output","created_at":"2026-04-17T21:12:27.564014Z","completed_at":"2026-04-17T21:12:27.570387Z","model":"mistral-small-latest","id":"msg_019d9d49b8ab76469ebfc3e68779486b","role":"assistant","content":"12"}],"usage":{"prompt_tokens":34,"completion_tokens":3,"total_tokens":37},"guardrails":null}'
+    headers:
+      CF-RAY:
+      - 9ede6d91fd21dde5-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 21:12:27 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '431'
+      mistral-correlation-id:
+      - 019d9d49-b779-7718-a2ef-030449db6f98
+      set-cookie:
+      - __cf_bm=Oj5XN9nn8WxdSGduwsZC.884J5KNtXop3YFkXehyEJc-1776460347.19627-1.0.1.1-OywVZrHIJcda6k9TeznH4A2ENOYt_qfp0CGiqc6WrCsUImQRD.SwD3j2g8s0Oj5Gl7qV_aqafFPWsHetxMRvvqtnp0q65lYwnL9liiuVS6p2dwAAbzvW.e6H9BLFoDt3;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:42:27
+        GMT
+      - _cfuvid=6oe8NWTaDkJ8gLtN5Ti7z2KfC1u3bAqyYIkdgaPFVqI-1776460347.19627-1.0.1.1-9a6F6ASdeewSnmrhyRTj5wgGSYAcz_ruBW6vGuA137U;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '321'
+      x-kong-proxy-latency:
+      - '14'
+      x-kong-request-id:
+      - 019d9d49-b779-7718-a2ef-030449db6f98
+      x-kong-upstream-latency:
+      - '322'
+      x-ratelimit-limit-tokens-minute:
+      - '500000'
+      x-ratelimit-limit-tokens-month:
+      - '1000000000'
+      x-ratelimit-remaining-tokens-minute:
+      - '499855'
+      x-ratelimit-remaining-tokens-month:
+      - '999999715'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/mistral/cassettes/latest/test_wrap_mistral_beta_conversations_start_stream_sync.yaml
+++ b/py/src/braintrust/integrations/mistral/cassettes/latest/test_wrap_mistral_beta_conversations_start_stream_sync.yaml
@@ -1,0 +1,81 @@
+interactions:
+- request:
+    body: '{"inputs":"What is 3+4? Reply with just the number.","stream":true,"model":"mistral-small-latest"}'
+    headers:
+      Accept:
+      - text/event-stream
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.4.0
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations
+  response:
+    body:
+      string: 'event: conversation.response.started
+
+        data: {"type":"conversation.response.started","created_at":"2026-04-17T21:12:25.791348Z","conversation_id":"conv_019d9d49b0e2700f9a363ecd4565bbbf"}
+
+
+        event: message.output.delta
+
+        data: {"type":"message.output.delta","created_at":"2026-04-17T21:12:25.794369Z","output_index":0,"id":"msg_019d9d49b1c277e89ece47f4375fa054","content_index":0,"model":"mistral-small-latest","role":"assistant","content":"7"}
+
+
+        event: conversation.response.done
+
+        data: {"type":"conversation.response.done","created_at":"2026-04-17T21:12:25.823510Z","usage":{"prompt_tokens":16,"completion_tokens":2,"total_tokens":18}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9ede6d875fec180e-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Fri, 17 Apr 2026 21:12:25 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      mistral-correlation-id:
+      - 019d9d49-b0d0-7bec-a2c7-6728e9a36d05
+      set-cookie:
+      - __cf_bm=p1CWlY5m4cxrD7Zaav8OCxXcEnCEfcaNVRHEI_eluwU-1776460345.49227-1.0.1.1-KUwjhVB_n0EDvD0VrnRufaUNTqUmsi8J3HuxCHxuurdJNzx81X.0bf3z0bxPJxsEn4eTaVN_dxCZpXk74t1tzqhkb1Pn2p0sk6zqaT7STXZuhZA.j3n0u9IUPRkh_HSY;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:42:25
+        GMT
+      - _cfuvid=0SsnmlKKyEDqFQXO43CbPRSXtrw.EgVonv7816.W1ow-1776460345.49227-1.0.1.1-jA6.IvzRh7obdKLgyLR1B8QzcGXY3JeiqnMRrUXi_kA;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '232'
+      x-kong-proxy-latency:
+      - '12'
+      x-kong-request-id:
+      - 019d9d49-b0d0-7bec-a2c7-6728e9a36d05
+      x-kong-upstream-latency:
+      - '233'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/mistral/cassettes/latest/test_wrap_mistral_beta_conversations_start_sync.yaml
+++ b/py/src/braintrust/integrations/mistral/cassettes/latest/test_wrap_mistral_beta_conversations_start_sync.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: '{"inputs":"What is 2+2? Reply with just the number.","stream":false,"model":"mistral-small-latest"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.4.0
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations
+  response:
+    body:
+      string: '{"object":"conversation.response","conversation_id":"conv_019d9d44d5cc7024a34dca44a1f460e0","outputs":[{"object":"entry","type":"message.output","created_at":"2026-04-17T21:07:08.060946Z","completed_at":"2026-04-17T21:07:08.060946Z","model":"mistral-small-latest","id":"msg_019d9d44d89c758197c5a5eabf45ac6a","role":"assistant","content":"4"}],"usage":{"prompt_tokens":16,"completion_tokens":2,"total_tokens":18},"guardrails":null}'
+    headers:
+      CF-RAY:
+      - 9ede65c25e21ac76-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 21:07:08 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '430'
+      mistral-correlation-id:
+      - 019d9d44-d5b6-746c-9d58-b3e6af41fc32
+      set-cookie:
+      - __cf_bm=hTRqR5BY0bTDOJJLl3FS1uE6gUdnIuJXz8tA30oozeY-1776460027.2539275-1.0.1.1-pZQ1ux.7f4k4wypbEYXTRNIHtGllkhxi_vPgTNTLATkN0i_2kUNluxWqEWvVgWMMjMO.PaVeZBdRLNUHMMQXAFqPLCrBPe8.3MgS9NFmWNU7H8p_Dr86TrRaZ5i4g6Ta;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:37:08
+        GMT
+      - _cfuvid=mVcULDvy8ctYPZn5hThbL_iK686x5cd4B1FItiSuUTA-1776460027.2539275-1.0.1.1-QUlPd8sYsSrcy4Qs8Y03qi9uFtbZhliqmiYFzRWbLtA;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '764'
+      x-kong-proxy-latency:
+      - '15'
+      x-kong-request-id:
+      - 019d9d44-d5b6-746c-9d58-b3e6af41fc32
+      x-kong-upstream-latency:
+      - '765'
+      x-ratelimit-limit-tokens-minute:
+      - '500000'
+      x-ratelimit-limit-tokens-month:
+      - '1000000000'
+      x-ratelimit-remaining-tokens-minute:
+      - '499982'
+      x-ratelimit-remaining-tokens-month:
+      - '999999894'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"inputs":"What is 2+2? Reply with just the number.","stream":false,"model":"mistral-small-latest"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Host:
+      - api.mistral.ai
+      content-type:
+      - application/json
+      user-agent:
+      - mistral-client-python/2.4.0
+    method: POST
+    uri: https://api.mistral.ai/v1/conversations
+  response:
+    body:
+      string: '{"object":"conversation.response","conversation_id":"conv_019d9d499d917244aa2d6a3295c3f00b","outputs":[{"object":"entry","type":"message.output","created_at":"2026-04-17T21:12:21.118315Z","completed_at":"2026-04-17T21:12:21.118315Z","model":"mistral-small-latest","id":"msg_019d9d499f7e73cbb5bba80a769c3e14","role":"assistant","content":"4"}],"usage":{"prompt_tokens":16,"completion_tokens":2,"total_tokens":18},"guardrails":null}'
+    headers:
+      CF-RAY:
+      - 9ede6d686fe73b8e-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 17 Apr 2026 21:12:21 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '430'
+      mistral-correlation-id:
+      - 019d9d49-9d7b-72aa-a169-53347234d66d
+      set-cookie:
+      - __cf_bm=nNAaUdpyvjDzZAsap_qAHnAYypN2tA4nG4A8Bajrung-1776460340.5414417-1.0.1.1-IESYv.paAQKheIOXjK.bZmkFk8l5.jCxytxgmJap1_pp9kq1FkDfIzVkfUleY20omTCjHcIxttMyrWd6WPk4jg670g_fuW2IKJwF7NYXwUg6MbqaWodViqVNynyOiBTJ;
+        HttpOnly; Secure; Path=/; Domain=mistral.ai; Expires=Fri, 17 Apr 2026 21:42:21
+        GMT
+      - _cfuvid=eucpCIMg5SLCfms_sA.n9aMRDzTcR5OLnJh8CmqE7x0-1776460340.5414417-1.0.1.1-EfayOhzXVss01mtg03AGy3TEQZ6uhcgPQyWCtGJwHG0;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=mistral.ai
+      x-envoy-upstream-service-time:
+      - '535'
+      x-kong-proxy-latency:
+      - '14'
+      x-kong-request-id:
+      - 019d9d49-9d7b-72aa-a169-53347234d66d
+      x-kong-upstream-latency:
+      - '536'
+      x-ratelimit-limit-tokens-minute:
+      - '500000'
+      x-ratelimit-limit-tokens-month:
+      - '1000000000'
+      x-ratelimit-remaining-tokens-minute:
+      - '499982'
+      x-ratelimit-remaining-tokens-month:
+      - '999999842'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/mistral/integration.py
+++ b/py/src/braintrust/integrations/mistral/integration.py
@@ -5,6 +5,7 @@ from braintrust.integrations.base import BaseIntegration
 from .patchers import (
     AgentsPatcher,
     ChatPatcher,
+    ConversationsPatcher,
     EmbeddingsPatcher,
     FimPatcher,
     OcrPatcher,
@@ -24,6 +25,7 @@ class MistralIntegration(BaseIntegration):
         EmbeddingsPatcher,
         FimPatcher,
         AgentsPatcher,
+        ConversationsPatcher,
         OcrPatcher,
         TranscriptionsPatcher,
         SpeechPatcher,

--- a/py/src/braintrust/integrations/mistral/patchers.py
+++ b/py/src/braintrust/integrations/mistral/patchers.py
@@ -11,6 +11,18 @@ from .tracing import (
     _chat_complete_wrapper,
     _chat_stream_async_wrapper,
     _chat_stream_wrapper,
+    _conversations_append_async_wrapper,
+    _conversations_append_stream_async_wrapper,
+    _conversations_append_stream_wrapper,
+    _conversations_append_wrapper,
+    _conversations_restart_async_wrapper,
+    _conversations_restart_stream_async_wrapper,
+    _conversations_restart_stream_wrapper,
+    _conversations_restart_wrapper,
+    _conversations_start_async_wrapper,
+    _conversations_start_stream_async_wrapper,
+    _conversations_start_stream_wrapper,
+    _conversations_start_wrapper,
     _embeddings_create_async_wrapper,
     _embeddings_create_wrapper,
     _fim_complete_async_wrapper,
@@ -383,6 +395,216 @@ class AgentsPatcher(CompositeFunctionWrapperPatcher):
         _AgentsStreamV1Patcher,
         _AgentsStreamAsyncV2Patcher,
         _AgentsStreamAsyncV1Patcher,
+    )
+
+
+class _ConversationsStartV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.start.v2"
+    target_module = "mistralai.client.conversations"
+    target_path = "Conversations.start"
+    wrapper = _conversations_start_wrapper
+
+
+class _ConversationsStartV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.start.v1"
+    target_module = "mistralai.conversations"
+    target_path = "Conversations.start"
+    wrapper = _conversations_start_wrapper
+    superseded_by = (_ConversationsStartV2Patcher,)
+
+
+class _ConversationsStartAsyncV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.start_async.v2"
+    target_module = "mistralai.client.conversations"
+    target_path = "Conversations.start_async"
+    wrapper = _conversations_start_async_wrapper
+
+
+class _ConversationsStartAsyncV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.start_async.v1"
+    target_module = "mistralai.conversations"
+    target_path = "Conversations.start_async"
+    wrapper = _conversations_start_async_wrapper
+    superseded_by = (_ConversationsStartAsyncV2Patcher,)
+
+
+class _ConversationsStartStreamV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.start_stream.v2"
+    target_module = "mistralai.client.conversations"
+    target_path = "Conversations.start_stream"
+    wrapper = _conversations_start_stream_wrapper
+
+
+class _ConversationsStartStreamV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.start_stream.v1"
+    target_module = "mistralai.conversations"
+    target_path = "Conversations.start_stream"
+    wrapper = _conversations_start_stream_wrapper
+    superseded_by = (_ConversationsStartStreamV2Patcher,)
+
+
+class _ConversationsStartStreamAsyncV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.start_stream_async.v2"
+    target_module = "mistralai.client.conversations"
+    target_path = "Conversations.start_stream_async"
+    wrapper = _conversations_start_stream_async_wrapper
+
+
+class _ConversationsStartStreamAsyncV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.start_stream_async.v1"
+    target_module = "mistralai.conversations"
+    target_path = "Conversations.start_stream_async"
+    wrapper = _conversations_start_stream_async_wrapper
+    superseded_by = (_ConversationsStartStreamAsyncV2Patcher,)
+
+
+class _ConversationsAppendV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.append.v2"
+    target_module = "mistralai.client.conversations"
+    target_path = "Conversations.append"
+    wrapper = _conversations_append_wrapper
+
+
+class _ConversationsAppendV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.append.v1"
+    target_module = "mistralai.conversations"
+    target_path = "Conversations.append"
+    wrapper = _conversations_append_wrapper
+    superseded_by = (_ConversationsAppendV2Patcher,)
+
+
+class _ConversationsAppendAsyncV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.append_async.v2"
+    target_module = "mistralai.client.conversations"
+    target_path = "Conversations.append_async"
+    wrapper = _conversations_append_async_wrapper
+
+
+class _ConversationsAppendAsyncV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.append_async.v1"
+    target_module = "mistralai.conversations"
+    target_path = "Conversations.append_async"
+    wrapper = _conversations_append_async_wrapper
+    superseded_by = (_ConversationsAppendAsyncV2Patcher,)
+
+
+class _ConversationsAppendStreamV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.append_stream.v2"
+    target_module = "mistralai.client.conversations"
+    target_path = "Conversations.append_stream"
+    wrapper = _conversations_append_stream_wrapper
+
+
+class _ConversationsAppendStreamV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.append_stream.v1"
+    target_module = "mistralai.conversations"
+    target_path = "Conversations.append_stream"
+    wrapper = _conversations_append_stream_wrapper
+    superseded_by = (_ConversationsAppendStreamV2Patcher,)
+
+
+class _ConversationsAppendStreamAsyncV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.append_stream_async.v2"
+    target_module = "mistralai.client.conversations"
+    target_path = "Conversations.append_stream_async"
+    wrapper = _conversations_append_stream_async_wrapper
+
+
+class _ConversationsAppendStreamAsyncV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.append_stream_async.v1"
+    target_module = "mistralai.conversations"
+    target_path = "Conversations.append_stream_async"
+    wrapper = _conversations_append_stream_async_wrapper
+    superseded_by = (_ConversationsAppendStreamAsyncV2Patcher,)
+
+
+class _ConversationsRestartV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.restart.v2"
+    target_module = "mistralai.client.conversations"
+    target_path = "Conversations.restart"
+    wrapper = _conversations_restart_wrapper
+
+
+class _ConversationsRestartV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.restart.v1"
+    target_module = "mistralai.conversations"
+    target_path = "Conversations.restart"
+    wrapper = _conversations_restart_wrapper
+    superseded_by = (_ConversationsRestartV2Patcher,)
+
+
+class _ConversationsRestartAsyncV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.restart_async.v2"
+    target_module = "mistralai.client.conversations"
+    target_path = "Conversations.restart_async"
+    wrapper = _conversations_restart_async_wrapper
+
+
+class _ConversationsRestartAsyncV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.restart_async.v1"
+    target_module = "mistralai.conversations"
+    target_path = "Conversations.restart_async"
+    wrapper = _conversations_restart_async_wrapper
+    superseded_by = (_ConversationsRestartAsyncV2Patcher,)
+
+
+class _ConversationsRestartStreamV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.restart_stream.v2"
+    target_module = "mistralai.client.conversations"
+    target_path = "Conversations.restart_stream"
+    wrapper = _conversations_restart_stream_wrapper
+
+
+class _ConversationsRestartStreamV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.restart_stream.v1"
+    target_module = "mistralai.conversations"
+    target_path = "Conversations.restart_stream"
+    wrapper = _conversations_restart_stream_wrapper
+    superseded_by = (_ConversationsRestartStreamV2Patcher,)
+
+
+class _ConversationsRestartStreamAsyncV2Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.restart_stream_async.v2"
+    target_module = "mistralai.client.conversations"
+    target_path = "Conversations.restart_stream_async"
+    wrapper = _conversations_restart_stream_async_wrapper
+
+
+class _ConversationsRestartStreamAsyncV1Patcher(FunctionWrapperPatcher):
+    name = "mistral.beta.conversations.restart_stream_async.v1"
+    target_module = "mistralai.conversations"
+    target_path = "Conversations.restart_stream_async"
+    wrapper = _conversations_restart_stream_async_wrapper
+    superseded_by = (_ConversationsRestartStreamAsyncV2Patcher,)
+
+
+class ConversationsPatcher(CompositeFunctionWrapperPatcher):
+    name = "mistral.beta.conversations"
+    sub_patchers = (
+        _ConversationsStartV2Patcher,
+        _ConversationsStartV1Patcher,
+        _ConversationsStartAsyncV2Patcher,
+        _ConversationsStartAsyncV1Patcher,
+        _ConversationsStartStreamV2Patcher,
+        _ConversationsStartStreamV1Patcher,
+        _ConversationsStartStreamAsyncV2Patcher,
+        _ConversationsStartStreamAsyncV1Patcher,
+        _ConversationsAppendV2Patcher,
+        _ConversationsAppendV1Patcher,
+        _ConversationsAppendAsyncV2Patcher,
+        _ConversationsAppendAsyncV1Patcher,
+        _ConversationsAppendStreamV2Patcher,
+        _ConversationsAppendStreamV1Patcher,
+        _ConversationsAppendStreamAsyncV2Patcher,
+        _ConversationsAppendStreamAsyncV1Patcher,
+        _ConversationsRestartV2Patcher,
+        _ConversationsRestartV1Patcher,
+        _ConversationsRestartAsyncV2Patcher,
+        _ConversationsRestartAsyncV1Patcher,
+        _ConversationsRestartStreamV2Patcher,
+        _ConversationsRestartStreamV1Patcher,
+        _ConversationsRestartStreamAsyncV2Patcher,
+        _ConversationsRestartStreamAsyncV1Patcher,
     )
 
 

--- a/py/src/braintrust/integrations/mistral/test_mistral.py
+++ b/py/src/braintrust/integrations/mistral/test_mistral.py
@@ -13,9 +13,12 @@ from braintrust.integrations.mistral.tracing import (
     _aggregate_completion_events,
     _chat_complete_async_wrapper,
     _chat_complete_wrapper,
-    sanitize_mistral_logged_value,
+    _conversations_start_wrapper,
+    _normalize_mistral_multimodal_value,
+    _ocr_process_wrapper,
 )
 from braintrust.integrations.test_utils import assert_metrics_are_valid, verify_autoinstrument_script
+from braintrust.span_types import SpanTypeAttribute
 from braintrust.test_helpers import init_test_logger
 
 
@@ -31,6 +34,7 @@ try:
     Embeddings = importlib.import_module("mistralai.client.embeddings").Embeddings
     Fim = importlib.import_module("mistralai.client.fim").Fim
     Agents = importlib.import_module("mistralai.client.agents").Agents
+    Conversations = importlib.import_module("mistralai.client.conversations").Conversations
     Ocr = importlib.import_module("mistralai.client.ocr").Ocr
     Transcriptions = importlib.import_module("mistralai.client.transcriptions").Transcriptions
     models = importlib.import_module("mistralai.client.models")
@@ -39,6 +43,7 @@ except ImportError:
     Embeddings = importlib.import_module("mistralai.embeddings").Embeddings
     Fim = importlib.import_module("mistralai.fim").Fim
     Agents = importlib.import_module("mistralai.agents").Agents
+    Conversations = importlib.import_module("mistralai.conversations").Conversations
     Ocr = importlib.import_module("mistralai.ocr").Ocr
     Transcriptions = importlib.import_module("mistralai.transcriptions").Transcriptions
     models = importlib.import_module("mistralai.models")
@@ -111,6 +116,20 @@ def _assert_speech_complete_span(span, start, end):
     assert span["metrics"]["duration"] >= 0
 
 
+def _assert_conversation_span(span, expected_input, start, end, *, expected_content, stream=False):
+    assert span["input"] == expected_input
+    assert span["span_attributes"]["type"] == SpanTypeAttribute.TASK
+    assert span["metadata"]["provider"] == "mistral"
+    assert span["metadata"]["model"] == CHAT_MODEL
+    assert span["metadata"]["conversation_id"]
+    assert span["output"][0]["type"] == "message.output"
+    assert expected_content in span["output"][0]["content"]
+    if stream:
+        assert span["metadata"]["stream"] == True
+        assert span["metrics"]["time_to_first_token"] >= 0
+    assert_metrics_are_valid(span["metrics"], start, end)
+
+
 def _audio_method_refs():
     refs = {}
     for cls, methods in (
@@ -121,6 +140,26 @@ def _audio_method_refs():
             continue
         for method in methods:
             refs[(cls, method)] = inspect.getattr_static(cls, method)
+    return refs
+
+
+def _conversation_method_refs():
+    refs = {}
+    for method in (
+        "start",
+        "start_async",
+        "start_stream",
+        "start_stream_async",
+        "append",
+        "append_async",
+        "append_stream",
+        "append_stream_async",
+        "restart",
+        "restart_async",
+        "restart_stream",
+        "restart_stream_async",
+    ):
+        refs[(Conversations, method)] = inspect.getattr_static(Conversations, method)
     return refs
 
 
@@ -248,6 +287,128 @@ async def test_wrap_mistral_chat_complete_async(memory_logger):
     assert span["metadata"]["model"] == CHAT_MODEL
     assert "6" in str(span["output"])
     assert_metrics_are_valid(span["metrics"], start, end)
+
+
+@pytest.mark.vcr
+def test_wrap_mistral_beta_conversations_start_sync(memory_logger):
+    assert not memory_logger.pop()
+
+    client = wrap_mistral(_get_client())
+    start = time.time()
+    response = client.beta.conversations.start(
+        model=CHAT_MODEL,
+        inputs="What is 2+2? Reply with just the number.",
+    )
+    end = time.time()
+
+    assert response.outputs
+    assert response.outputs[0].type == "message.output"
+    assert "4" in str(response.outputs[0].content)
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    _assert_conversation_span(
+        spans[0],
+        "What is 2+2? Reply with just the number.",
+        start,
+        end,
+        expected_content="4",
+    )
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_wrap_mistral_beta_conversations_append_async(memory_logger):
+    assert not memory_logger.pop()
+
+    client = _get_client()
+    initial_response = client.beta.conversations.start(
+        model=CHAT_MODEL,
+        inputs="What is 1+1? Reply with just the number.",
+    )
+
+    wrapped_client = wrap_mistral(client)
+    start = time.time()
+    response = await wrapped_client.beta.conversations.append_async(
+        conversation_id=initial_response.conversation_id,
+        inputs="What is 2+3? Reply with just the number.",
+    )
+    end = time.time()
+
+    assert response.outputs
+    assert response.outputs[0].type == "message.output"
+    assert "5" in str(response.outputs[0].content)
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    _assert_conversation_span(
+        spans[0],
+        "What is 2+3? Reply with just the number.",
+        start,
+        end,
+        expected_content="5",
+    )
+
+
+@pytest.mark.vcr
+def test_wrap_mistral_beta_conversations_start_stream_sync(memory_logger):
+    assert not memory_logger.pop()
+
+    client = wrap_mistral(_get_client())
+    start = time.time()
+    with client.beta.conversations.start_stream(
+        model=CHAT_MODEL,
+        inputs="What is 3+4? Reply with just the number.",
+    ) as stream:
+        events = list(stream)
+    end = time.time()
+
+    assert events
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    _assert_conversation_span(
+        spans[0],
+        "What is 3+4? Reply with just the number.",
+        start,
+        end,
+        expected_content="7",
+        stream=True,
+    )
+
+
+@pytest.mark.vcr
+def test_wrap_mistral_beta_conversations_restart_sync(memory_logger):
+    assert not memory_logger.pop()
+
+    client = _get_client()
+    initial_response = client.beta.conversations.start(
+        model=CHAT_MODEL,
+        inputs="What is 9+1? Reply with just the number.",
+    )
+
+    wrapped_client = wrap_mistral(client)
+    start = time.time()
+    response = wrapped_client.beta.conversations.restart(
+        conversation_id=initial_response.conversation_id,
+        from_entry_id=initial_response.outputs[0].id,
+        inputs="What is 6+6? Reply with just the number.",
+    )
+    end = time.time()
+
+    assert response.outputs
+    assert response.outputs[0].type == "message.output"
+    assert "12" in str(response.outputs[0].content)
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    _assert_conversation_span(
+        spans[0],
+        "What is 6+6? Reply with just the number.",
+        start,
+        end,
+        expected_content="12",
+    )
 
 
 @pytest.mark.vcr
@@ -745,6 +906,38 @@ def test_mistral_integration_setup_instruments_audio_transcriptions(memory_logge
 
 
 @pytest.mark.vcr
+def test_mistral_integration_setup_instruments_beta_conversations(memory_logger, monkeypatch):
+    assert not memory_logger.pop()
+
+    original_conversation_methods = _conversation_method_refs()
+
+    assert MistralIntegration.setup()
+    client = _get_client()
+    try:
+        start = time.time()
+        response = client.beta.conversations.start(
+            model=CHAT_MODEL,
+            inputs="What is 4+4? Reply with just the number.",
+        )
+        end = time.time()
+    finally:
+        _restore_method_refs(monkeypatch, original_conversation_methods)
+
+    assert response.outputs
+    assert "8" in str(response.outputs[0].content)
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    _assert_conversation_span(
+        spans[0],
+        "What is 4+4? Reply with just the number.",
+        start,
+        end,
+        expected_content="8",
+    )
+
+
+@pytest.mark.vcr
 def test_mistral_integration_setup_creates_spans(memory_logger, monkeypatch):
     assert not memory_logger.pop()
 
@@ -822,6 +1015,7 @@ def test_mistral_integration_setup_is_idempotent(monkeypatch):
     first_agents_stream_async = inspect.getattr_static(Agents, "stream_async")
     first_ocr_process = inspect.getattr_static(Ocr, "process")
     first_ocr_process_async = inspect.getattr_static(Ocr, "process_async")
+    first_conversation_methods = _conversation_method_refs()
     first_audio_methods = _audio_method_refs()
 
     assert MistralIntegration.setup()
@@ -841,6 +1035,7 @@ def test_mistral_integration_setup_is_idempotent(monkeypatch):
     patched_agents_stream_async = inspect.getattr_static(Agents, "stream_async")
     patched_ocr_process = inspect.getattr_static(Ocr, "process")
     patched_ocr_process_async = inspect.getattr_static(Ocr, "process_async")
+    patched_conversation_methods = _conversation_method_refs()
     patched_audio_methods = _audio_method_refs()
 
     assert MistralIntegration.setup()
@@ -860,6 +1055,8 @@ def test_mistral_integration_setup_is_idempotent(monkeypatch):
     assert inspect.getattr_static(Agents, "stream_async") is patched_agents_stream_async
     assert inspect.getattr_static(Ocr, "process") is patched_ocr_process
     assert inspect.getattr_static(Ocr, "process_async") is patched_ocr_process_async
+    for key, method in patched_conversation_methods.items():
+        assert inspect.getattr_static(*key) is method
     for key, method in patched_audio_methods.items():
         assert inspect.getattr_static(*key) is method
 
@@ -879,6 +1076,7 @@ def test_mistral_integration_setup_is_idempotent(monkeypatch):
     monkeypatch.setattr(Agents, "stream_async", first_agents_stream_async)
     monkeypatch.setattr(Ocr, "process", first_ocr_process)
     monkeypatch.setattr(Ocr, "process_async", first_ocr_process_async)
+    _restore_method_refs(monkeypatch, first_conversation_methods)
     _restore_method_refs(monkeypatch, first_audio_methods)
 
 
@@ -935,8 +1133,8 @@ async def test_chat_complete_async_wrapper_logs_errors(memory_logger):
     assert "async boom" in span["error"]
 
 
-def test_sanitize_mistral_logged_value_converts_image_url_data_uri_to_attachment():
-    sanitized = sanitize_mistral_logged_value(
+def test_normalize_mistral_multimodal_value_converts_image_url_data_uri_to_attachment():
+    sanitized = _normalize_mistral_multimodal_value(
         {
             "type": "image_url",
             "image_url": {"url": "data:image/png;base64,aGVsbG8="},
@@ -947,8 +1145,8 @@ def test_sanitize_mistral_logged_value_converts_image_url_data_uri_to_attachment
     assert sanitized["image_url"]["url"].reference["content_type"] == "image/png"
 
 
-def test_sanitize_mistral_logged_value_converts_image_url_string_data_uri_to_attachment():
-    sanitized = sanitize_mistral_logged_value(
+def test_normalize_mistral_multimodal_value_converts_image_url_string_data_uri_to_attachment():
+    sanitized = _normalize_mistral_multimodal_value(
         {
             "type": "image_url",
             "image_url": "data:image/png;base64,aGVsbG8=",
@@ -959,8 +1157,8 @@ def test_sanitize_mistral_logged_value_converts_image_url_string_data_uri_to_att
     assert sanitized["image_url"]["url"].reference["content_type"] == "image/png"
 
 
-def test_sanitize_mistral_logged_value_converts_document_url_data_uri_to_attachment():
-    sanitized = sanitize_mistral_logged_value(
+def test_normalize_mistral_multimodal_value_converts_document_url_data_uri_to_attachment():
+    sanitized = _normalize_mistral_multimodal_value(
         {
             "type": "document_url",
             "document_url": TEST_PDF_DATA_URL,
@@ -974,8 +1172,8 @@ def test_sanitize_mistral_logged_value_converts_document_url_data_uri_to_attachm
     assert sanitized["file"]["filename"] == "test.pdf"
 
 
-def test_sanitize_mistral_logged_value_converts_large_base64_input_audio_to_attachment():
-    sanitized = sanitize_mistral_logged_value(
+def test_normalize_mistral_multimodal_value_converts_large_base64_input_audio_to_attachment():
+    sanitized = _normalize_mistral_multimodal_value(
         {
             "type": "input_audio",
             "input_audio": base64.b64encode(b"hello" * 16).decode("ascii"),
@@ -986,12 +1184,67 @@ def test_sanitize_mistral_logged_value_converts_large_base64_input_audio_to_atta
     assert sanitized["input_audio"].reference["filename"] == "input_audio.bin"
 
 
-def test_sanitize_mistral_logged_value_leaves_non_base64_input_audio_unchanged():
+def test_normalize_mistral_multimodal_value_leaves_non_base64_input_audio_unchanged():
     original = {"type": "input_audio", "input_audio": "not base64"}
 
-    sanitized = sanitize_mistral_logged_value(original)
+    sanitized = _normalize_mistral_multimodal_value(original)
 
     assert sanitized == original
+
+
+class _UnsupportedUsageResponse:
+    def __init__(self, **attrs):
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+
+@pytest.mark.parametrize(
+    ("wrapper", "kwargs", "response", "missing_metric_keys"),
+    [
+        (
+            _chat_complete_wrapper,
+            {
+                "model": CHAT_MODEL,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+            _UnsupportedUsageResponse(usage={"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}),
+            {"tokens", "prompt_tokens", "completion_tokens"},
+        ),
+        (
+            _conversations_start_wrapper,
+            {
+                "model": CHAT_MODEL,
+                "inputs": [{"role": "user", "content": "hello"}],
+            },
+            _UnsupportedUsageResponse(usage={"prompt_tokens": 4, "completion_tokens": 1, "total_tokens": 5}),
+            {"tokens", "prompt_tokens", "completion_tokens"},
+        ),
+        (
+            _ocr_process_wrapper,
+            {
+                "model": OCR_MODEL,
+                "document": {"type": "document_url", "document_url": TEST_PDF_DATA_URL},
+            },
+            _UnsupportedUsageResponse(usage_info={"pages_processed": 1, "doc_size_bytes": 70}),
+            {"pages_processed", "doc_size_bytes"},
+        ),
+    ],
+)
+def test_wrappers_ignore_usage_when_response_normalization_fails(
+    memory_logger, wrapper, kwargs, response, missing_metric_keys
+):
+    assert not memory_logger.pop()
+
+    result = wrapper(lambda *args, **kwargs: response, None, (), kwargs)
+
+    assert result is response
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    for key in missing_metric_keys:
+        assert key not in span["metrics"]
+    assert span["metrics"]["duration"] >= 0
 
 
 def test_aggregate_completion_events_merges_tool_calls_and_content():

--- a/py/src/braintrust/integrations/mistral/tracing.py
+++ b/py/src/braintrust/integrations/mistral/tracing.py
@@ -6,7 +6,6 @@ import time
 from collections.abc import AsyncIterator, Iterator
 from typing import Any
 
-from braintrust.bt_json import bt_safe_deep_copy
 from braintrust.integrations.utils import (
     _camel_to_snake,
     _infer_audio_mime_type,
@@ -60,6 +59,36 @@ _AGENTS_METADATA_KEYS = (
     "prediction",
     "parallel_tool_calls",
     "prompt_mode",
+)
+_CONVERSATION_START_METADATA_KEYS = (
+    "conversation_id",
+    "store",
+    "handoff_execution",
+    "instructions",
+    "tools",
+    "completion_args",
+    "guardrails",
+    "name",
+    "description",
+    "agent_id",
+    "agent_version",
+    "model",
+)
+_CONVERSATION_APPEND_METADATA_KEYS = (
+    "conversation_id",
+    "store",
+    "handoff_execution",
+    "completion_args",
+    "tool_confirmations",
+)
+_CONVERSATION_RESTART_METADATA_KEYS = (
+    "conversation_id",
+    "from_entry_id",
+    "store",
+    "handoff_execution",
+    "completion_args",
+    "guardrails",
+    "agent_version",
 )
 _EMBEDDINGS_METADATA_KEYS = (
     "model",
@@ -185,33 +214,28 @@ def _normalize_special_payloads(value: Any) -> Any:
     return value
 
 
-def sanitize_mistral_logged_value(value: Any) -> Any:
-    if _is_unset(value):
-        return None
-
+def _normalize_mistral_multimodal_value(value: Any) -> Any:
+    """Normalize Mistral multimodal payloads into Braintrust-friendly shapes."""
     if hasattr(value, "model_dump"):
         try:
-            value = value.model_dump(mode="json", by_alias=True)
+            value = value.model_dump(mode="python", by_alias=True)
         except TypeError:
             value = value.model_dump()
 
-    safe = bt_safe_deep_copy(value)
-    safe = _normalize_special_payloads(safe)
+    if isinstance(value, list):
+        return [_normalize_mistral_multimodal_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_normalize_mistral_multimodal_value(item) for item in value]
+    if isinstance(value, dict):
+        return _normalize_special_payloads(
+            {key: _normalize_mistral_multimodal_value(entry) for key, entry in value.items()}
+        )
+    return value
 
-    if callable(safe):
-        return "[Function]"
-    if isinstance(safe, list):
-        return [sanitize_mistral_logged_value(item) for item in safe]
-    if isinstance(safe, tuple):
-        return [sanitize_mistral_logged_value(item) for item in safe]
-    if isinstance(safe, dict):
-        sanitized = {}
-        for key, entry in safe.items():
-            if _is_unset(entry):
-                continue
-            sanitized[key] = sanitize_mistral_logged_value(entry)
-        return sanitized
-    return safe
+
+def _normalized_mistral_dict(value: Any) -> dict[str, Any] | None:
+    sanitized = _normalize_mistral_multimodal_value(value)
+    return sanitized if isinstance(sanitized, dict) else None
 
 
 def _build_request_metadata(
@@ -223,11 +247,11 @@ def _build_request_metadata(
         value = kwargs.get(key)
         if value is None or _is_unset(value):
             continue
-        metadata[key] = sanitize_mistral_logged_value(value)
+        metadata[key] = _normalize_mistral_multimodal_value(value)
 
     request_metadata = kwargs.get("metadata")
     if request_metadata is not None and not _is_unset(request_metadata):
-        metadata["request_metadata"] = sanitize_mistral_logged_value(request_metadata)
+        metadata["request_metadata"] = _normalize_mistral_multimodal_value(request_metadata)
 
     if stream is not None:
         metadata["stream"] = stream
@@ -241,6 +265,18 @@ def _build_chat_metadata(kwargs: dict[str, Any], *, stream: bool | None = None) 
 
 def _build_agents_metadata(kwargs: dict[str, Any], *, stream: bool | None = None) -> dict[str, Any]:
     return _build_request_metadata(kwargs, _AGENTS_METADATA_KEYS, stream=stream)
+
+
+def _build_conversation_start_metadata(kwargs: dict[str, Any], *, stream: bool | None = None) -> dict[str, Any]:
+    return _build_request_metadata(kwargs, _CONVERSATION_START_METADATA_KEYS, stream=stream)
+
+
+def _build_conversation_append_metadata(kwargs: dict[str, Any], *, stream: bool | None = None) -> dict[str, Any]:
+    return _build_request_metadata(kwargs, _CONVERSATION_APPEND_METADATA_KEYS, stream=stream)
+
+
+def _build_conversation_restart_metadata(kwargs: dict[str, Any], *, stream: bool | None = None) -> dict[str, Any]:
+    return _build_request_metadata(kwargs, _CONVERSATION_RESTART_METADATA_KEYS, stream=stream)
 
 
 def _build_embeddings_metadata(kwargs: dict[str, Any]) -> dict[str, Any]:
@@ -343,18 +379,28 @@ def _ocr_input(kwargs: dict[str, Any]) -> dict[str, Any]:
     return {"document": kwargs.get("document")}
 
 
-def _start_span(name: str, span_input: Any, metadata: dict[str, Any]):
+def _conversation_input(kwargs: dict[str, Any]) -> Any:
+    return kwargs.get("inputs")
+
+
+def _start_span(
+    name: str,
+    span_input: Any,
+    metadata: dict[str, Any],
+    *,
+    span_type: SpanTypeAttribute = SpanTypeAttribute.LLM,
+):
     return start_span(
         name=name,
-        type=SpanTypeAttribute.LLM,
-        input=sanitize_mistral_logged_value(span_input),
+        type=span_type,
+        input=_normalize_mistral_multimodal_value(span_input),
         metadata=metadata,
     )
 
 
 def _parse_usage_metrics(usage: Any) -> dict[str, float]:
-    usage_data = sanitize_mistral_logged_value(usage)
-    if not isinstance(usage_data, dict):
+    usage_data = _normalized_mistral_dict(usage)
+    if usage_data is None:
         return {}
 
     metrics = {}
@@ -379,8 +425,8 @@ def _merge_metrics(start_time: float, usage: Any, first_token_time: float | None
 
 
 def _parse_ocr_usage_metrics(usage: Any) -> dict[str, float]:
-    usage_data = sanitize_mistral_logged_value(usage)
-    if not isinstance(usage_data, dict):
+    usage_data = _normalized_mistral_dict(usage)
+    if usage_data is None:
         return {}
 
     return {
@@ -392,9 +438,8 @@ def _merge_ocr_metrics(start_time: float, usage: Any) -> dict[str, Any]:
     return _merge_timing_and_usage_metrics(start_time, usage, _parse_ocr_usage_metrics)
 
 
-def _response_to_metadata(response: Any) -> dict[str, Any]:
-    data = sanitize_mistral_logged_value(response)
-    if not isinstance(data, dict):
+def _response_data_to_metadata(data: dict[str, Any] | None) -> dict[str, Any]:
+    if data is None:
         return {}
 
     metadata = {}
@@ -405,11 +450,40 @@ def _response_to_metadata(response: Any) -> dict[str, Any]:
     return metadata
 
 
-def _completion_response_to_output(response: Any) -> Any:
-    data = sanitize_mistral_logged_value(response)
-    if isinstance(data, dict):
-        return data.get("choices")
-    return None
+def _response_to_metadata(response: Any) -> dict[str, Any]:
+    return _response_data_to_metadata(_normalized_mistral_dict(response))
+
+
+def _conversation_outputs_data(data: dict[str, Any] | None) -> list[Any]:
+    if data is None:
+        return []
+
+    outputs = data.get("outputs")
+    return outputs if isinstance(outputs, list) else []
+
+
+def _conversation_response_data_to_metadata(data: dict[str, Any] | None) -> dict[str, Any]:
+    if data is None:
+        return {}
+
+    metadata = {}
+    conversation_id = data.get("conversation_id")
+    if conversation_id is not None:
+        metadata["conversation_id"] = conversation_id
+
+    object_type = data.get("object")
+    if object_type is not None:
+        metadata["object"] = object_type
+
+    for output in _conversation_outputs_data(data):
+        if not isinstance(output, dict):
+            continue
+        model = output.get("model")
+        if model is not None:
+            metadata["model"] = model
+            break
+
+    return metadata
 
 
 def _embeddings_output(response: Any) -> dict[str, Any]:
@@ -426,9 +500,8 @@ def _embeddings_output(response: Any) -> dict[str, Any]:
     return output
 
 
-def _ocr_output(response: Any) -> dict[str, Any]:
-    data = sanitize_mistral_logged_value(response)
-    if not isinstance(data, dict):
+def _ocr_output_data(data: dict[str, Any] | None) -> dict[str, Any]:
+    if data is None:
         return {"pages": []}
 
     output = {
@@ -438,21 +511,6 @@ def _ocr_output(response: Any) -> dict[str, Any]:
     if document_annotation is not None:
         output["document_annotation"] = document_annotation
     return output
-
-
-def _ocr_response_to_metadata(response: Any) -> dict[str, Any]:
-    data = sanitize_mistral_logged_value(response)
-    if not isinstance(data, dict):
-        return {}
-
-    pages = data.get("pages")
-    return {
-        "page_count": len(pages) if isinstance(pages, list) else 0,
-    }
-
-
-def _transcription_output(response: Any) -> str | None:
-    return _get_value(response, "text")
 
 
 def _transcription_response_to_metadata(response: Any) -> dict[str, Any]:
@@ -515,7 +573,7 @@ def _append_delta_content(message: dict[str, Any], delta_content: Any) -> None:
     if delta_content is None:
         return
 
-    content = sanitize_mistral_logged_value(delta_content)
+    content = _normalize_mistral_multimodal_value(delta_content)
     existing = message.get("content")
 
     if isinstance(content, str):
@@ -526,7 +584,7 @@ def _append_delta_content(message: dict[str, Any], delta_content: Any) -> None:
         elif existing is None:
             message["content"] = content
         else:
-            message["content"] = sanitize_mistral_logged_value(existing)
+            message["content"] = _normalize_mistral_multimodal_value(existing)
         return
 
     if isinstance(content, list):
@@ -544,7 +602,7 @@ def _merge_tool_calls(message: dict[str, Any], tool_calls: Any) -> None:
 
     accumulated = message.setdefault("tool_calls", [])
     for tool_call in tool_calls:
-        call = sanitize_mistral_logged_value(tool_call)
+        call = _normalize_mistral_multimodal_value(tool_call)
         if not isinstance(call, dict):
             continue
 
@@ -647,11 +705,11 @@ def _aggregate_transcription_events(items: list[Any]) -> dict[str, Any]:
     if model is not None:
         result["model"] = model
     if usage is not None:
-        result["usage"] = sanitize_mistral_logged_value(usage)
+        result["usage"] = _normalize_mistral_multimodal_value(usage)
     if language is not None:
         result["language"] = language
     if isinstance(segments, list):
-        result["segments"] = sanitize_mistral_logged_value(segments)
+        result["segments"] = _normalize_mistral_multimodal_value(segments)
     if finish_reason is not None:
         result["finish_reason"] = finish_reason
     return result
@@ -682,7 +740,7 @@ def _aggregate_speech_events(items: list[Any]) -> dict[str, Any]:
 
     result = {"audio_data": "".join(audio_parts)}
     if usage is not None:
-        result["usage"] = sanitize_mistral_logged_value(usage)
+        result["usage"] = _normalize_mistral_multimodal_value(usage)
     return result
 
 
@@ -742,16 +800,179 @@ def _aggregate_completion_events(items: list[Any]) -> dict[str, Any]:
     if created is not None:
         result["created"] = created
     if usage is not None:
-        result["usage"] = sanitize_mistral_logged_value(usage)
+        result["usage"] = _normalize_mistral_multimodal_value(usage)
+    return result
+
+
+def _conversation_output_index(data: Any) -> int:
+    output_index = _get_value(data, "output_index")
+    if isinstance(output_index, int) and output_index >= 0:
+        return output_index
+    return 0
+
+
+def _append_string_field(entry: dict[str, Any], key: str, value: Any) -> None:
+    if not isinstance(value, str) or not value:
+        return
+
+    existing = entry.get(key)
+    entry[key] = f"{existing}{value}" if isinstance(existing, str) else value
+
+
+def _set_normalized_field(entry: dict[str, Any], key: str, value: Any) -> None:
+    if value is None or _is_unset(value):
+        return
+    entry[key] = _normalize_mistral_multimodal_value(value)
+
+
+def _set_normalized_fields(entry: dict[str, Any], data: Any, *keys: str) -> None:
+    for key in keys:
+        _set_normalized_field(entry, key, _get_value(data, key))
+
+
+def _accumulate_message_output(outputs: dict[int, dict[str, Any]], data: Any) -> None:
+    output = outputs.setdefault(
+        _conversation_output_index(data),
+        {
+            "object": "entry",
+            "type": "message.output",
+            "role": "assistant",
+            "content": "",
+        },
+    )
+    _set_normalized_fields(output, data, "id", "model", "agent_id", "role")
+    _append_delta_content(output, _get_value(data, "content"))
+
+
+def _accumulate_function_call_output(outputs: dict[int, dict[str, Any]], data: Any) -> None:
+    output = outputs.setdefault(
+        _conversation_output_index(data),
+        {
+            "object": "entry",
+            "type": "function.call",
+            "name": "",
+            "arguments": "",
+        },
+    )
+    _set_normalized_fields(output, data, "id", "model", "agent_id", "tool_call_id", "confirmation_status")
+    _append_string_field(output, "name", _get_value(data, "name"))
+
+    arguments = _get_value(data, "arguments")
+    if isinstance(arguments, dict):
+        output["arguments"] = {
+            **(output.get("arguments") if isinstance(output.get("arguments"), dict) else {}),
+            **_normalize_mistral_multimodal_value(arguments),
+        }
+    else:
+        _append_string_field(output, "arguments", arguments)
+
+
+def _accumulate_tool_execution_output(outputs: dict[int, dict[str, Any]], data: Any, event: str | None) -> None:
+    output = outputs.setdefault(
+        _conversation_output_index(data),
+        {
+            "object": "entry",
+            "type": "tool.execution",
+            "arguments": "",
+        },
+    )
+    _set_normalized_fields(output, data, "id", "model", "agent_id", "name")
+    _append_string_field(output, "arguments", _get_value(data, "arguments"))
+    if event == "tool.execution.done":
+        _set_normalized_field(output, "info", _get_value(data, "info"))
+
+
+def _accumulate_agent_handoff_output(outputs: dict[int, dict[str, Any]], data: Any) -> None:
+    output = outputs.setdefault(
+        _conversation_output_index(data),
+        {
+            "object": "entry",
+            "type": "agent.handoff",
+        },
+    )
+    _set_normalized_fields(
+        output,
+        data,
+        "id",
+        "previous_agent_id",
+        "previous_agent_name",
+        "next_agent_id",
+        "next_agent_name",
+    )
+
+
+def _conversation_chunk_has_output(item: Any) -> bool:
+    event = getattr(item, "event", None)
+    return event in {
+        "message.output.delta",
+        "function.call.delta",
+        "tool.execution.started",
+        "tool.execution.delta",
+        "tool.execution.done",
+        "agent.handoff.started",
+        "agent.handoff.done",
+    }
+
+
+def _aggregate_conversation_events(items: list[Any]) -> dict[str, Any]:
+    conversation_id = None
+    usage = None
+    outputs: dict[int, dict[str, Any]] = {}
+
+    for item in items:
+        data = getattr(item, "data", item)
+        event = getattr(item, "event", None)
+
+        if event == "conversation.response.started":
+            conversation_id = _get_value(data, "conversation_id") or conversation_id
+            continue
+        if event == "conversation.response.done":
+            usage = _get_value(data, "usage") or usage
+            continue
+        if event == "message.output.delta":
+            _accumulate_message_output(outputs, data)
+            continue
+        if event == "function.call.delta":
+            _accumulate_function_call_output(outputs, data)
+            continue
+        if event in {"tool.execution.started", "tool.execution.delta", "tool.execution.done"}:
+            _accumulate_tool_execution_output(outputs, data, event)
+            continue
+        if event in {"agent.handoff.started", "agent.handoff.done"}:
+            _accumulate_agent_handoff_output(outputs, data)
+
+    result: dict[str, Any] = {
+        "object": "conversation.response",
+        "outputs": [outputs[idx] for idx in sorted(outputs)],
+    }
+    if conversation_id is not None:
+        result["conversation_id"] = conversation_id
+    if usage is not None:
+        result["usage"] = _normalize_mistral_multimodal_value(usage)
     return result
 
 
 def _finalize_completion_response(span: Any, request_metadata: dict[str, Any], response: Any, start_time: float):
-    response_metadata = _response_to_metadata(response)
+    response_data = _normalized_mistral_dict(response)
+    response_metadata = _response_data_to_metadata(response_data)
+    usage = response_data.get("usage") if response_data else None
+
     _log_and_end_span(
         span,
-        output=_completion_response_to_output(response),
-        metrics=_merge_metrics(start_time, getattr(response, "usage", None)),
+        output=response_data.get("choices") if response_data else None,
+        metrics=_merge_metrics(start_time, usage),
+        metadata={**request_metadata, **response_metadata},
+    )
+
+
+def _finalize_conversation_response(span: Any, request_metadata: dict[str, Any], response: Any, start_time: float):
+    response_data = _normalized_mistral_dict(response)
+    response_metadata = _conversation_response_data_to_metadata(response_data)
+    usage = response_data.get("usage") if response_data else None
+    _log_and_end_span(
+        span,
+        output=_conversation_outputs_data(response_data),
+        metrics=_merge_metrics(start_time, usage),
         metadata={**request_metadata, **response_metadata},
     )
 
@@ -767,11 +988,14 @@ def _finalize_embeddings_response(span: Any, request_metadata: dict[str, Any], r
 
 
 def _finalize_ocr_response(span: Any, request_metadata: dict[str, Any], response: Any, start_time: float):
-    response_metadata = _ocr_response_to_metadata(response)
+    response_data = _normalized_mistral_dict(response)
+    pages = response_data.get("pages") if response_data else None
+    response_metadata = {"page_count": len(pages)} if isinstance(pages, list) else {}
+    usage_info = response_data.get("usage_info") if response_data else None
     _log_and_end_span(
         span,
-        output=_ocr_output(response),
-        metrics=_merge_ocr_metrics(start_time, getattr(response, "usage_info", None)),
+        output=_ocr_output_data(response_data),
+        metrics=_merge_ocr_metrics(start_time, usage_info),
         metadata={**request_metadata, **response_metadata},
     )
 
@@ -780,7 +1004,7 @@ def _finalize_transcription_response(span: Any, request_metadata: dict[str, Any]
     response_metadata = _transcription_response_to_metadata(response)
     _log_and_end_span(
         span,
-        output=_transcription_output(response),
+        output=_get_value(response, "text"),
         metrics=_merge_metrics(start_time, _get_value(response, "usage")),
         metadata={**request_metadata, **response_metadata},
     )
@@ -803,11 +1027,29 @@ def _finalize_completion_stream(
     first_token_time: float | None,
 ):
     response = _aggregate_completion_events(items)
+    response_metadata = _response_data_to_metadata(response)
     _log_and_end_span(
         span,
         output=response.get("choices"),
         metrics=_merge_metrics(start_time, response.get("usage"), first_token_time),
-        metadata={**metadata, **_response_to_metadata(response)},
+        metadata={**metadata, **response_metadata},
+    )
+
+
+def _finalize_conversation_stream(
+    span: Any,
+    metadata: dict[str, Any],
+    items: list[Any],
+    start_time: float,
+    first_token_time: float | None,
+):
+    response = _aggregate_conversation_events(items)
+    response_metadata = _conversation_response_data_to_metadata(response)
+    _log_and_end_span(
+        span,
+        output=response.get("outputs"),
+        metrics=_merge_metrics(start_time, response.get("usage"), first_token_time),
+        metadata={**metadata, **response_metadata},
     )
 
 
@@ -1077,6 +1319,282 @@ async def _agents_stream_async_wrapper(wrapped, instance, args, kwargs):
     return _TracedMistralAsyncStream(result, span, request_metadata, start_time)
 
 
+def _conversations_start_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_conversation_start_metadata(kwargs, stream=bool(kwargs.get("stream")))
+    span = _start_span(
+        "mistral.beta.conversations.start",
+        _conversation_input(kwargs),
+        request_metadata,
+        span_type=SpanTypeAttribute.TASK,
+    )
+    start_time = time.time()
+    result = _call_with_error_logging(span, wrapped, args, kwargs)
+
+    if kwargs.get("stream"):
+        return _TracedMistralSyncStream(
+            result,
+            span,
+            request_metadata,
+            start_time,
+            chunk_has_output=_conversation_chunk_has_output,
+            finalize_stream=_finalize_conversation_stream,
+        )
+
+    _finalize_conversation_response(span, request_metadata, result, start_time)
+    return result
+
+
+async def _conversations_start_async_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_conversation_start_metadata(kwargs, stream=bool(kwargs.get("stream")))
+    span = _start_span(
+        "mistral.beta.conversations.start",
+        _conversation_input(kwargs),
+        request_metadata,
+        span_type=SpanTypeAttribute.TASK,
+    )
+    start_time = time.time()
+    result = await _call_async_with_error_logging(span, wrapped, args, kwargs)
+
+    if kwargs.get("stream"):
+        return _TracedMistralAsyncStream(
+            result,
+            span,
+            request_metadata,
+            start_time,
+            chunk_has_output=_conversation_chunk_has_output,
+            finalize_stream=_finalize_conversation_stream,
+        )
+
+    _finalize_conversation_response(span, request_metadata, result, start_time)
+    return result
+
+
+def _conversations_start_stream_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_conversation_start_metadata(kwargs, stream=True)
+    span = _start_span(
+        "mistral.beta.conversations.start_stream",
+        _conversation_input(kwargs),
+        request_metadata,
+        span_type=SpanTypeAttribute.TASK,
+    )
+    start_time = time.time()
+    result = _call_with_error_logging(span, wrapped, args, kwargs)
+
+    return _TracedMistralSyncStream(
+        result,
+        span,
+        request_metadata,
+        start_time,
+        chunk_has_output=_conversation_chunk_has_output,
+        finalize_stream=_finalize_conversation_stream,
+    )
+
+
+async def _conversations_start_stream_async_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_conversation_start_metadata(kwargs, stream=True)
+    span = _start_span(
+        "mistral.beta.conversations.start_stream",
+        _conversation_input(kwargs),
+        request_metadata,
+        span_type=SpanTypeAttribute.TASK,
+    )
+    start_time = time.time()
+    result = await _call_async_with_error_logging(span, wrapped, args, kwargs)
+
+    return _TracedMistralAsyncStream(
+        result,
+        span,
+        request_metadata,
+        start_time,
+        chunk_has_output=_conversation_chunk_has_output,
+        finalize_stream=_finalize_conversation_stream,
+    )
+
+
+def _conversations_append_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_conversation_append_metadata(kwargs, stream=bool(kwargs.get("stream")))
+    span = _start_span(
+        "mistral.beta.conversations.append",
+        _conversation_input(kwargs),
+        request_metadata,
+        span_type=SpanTypeAttribute.TASK,
+    )
+    start_time = time.time()
+    result = _call_with_error_logging(span, wrapped, args, kwargs)
+
+    if kwargs.get("stream"):
+        return _TracedMistralSyncStream(
+            result,
+            span,
+            request_metadata,
+            start_time,
+            chunk_has_output=_conversation_chunk_has_output,
+            finalize_stream=_finalize_conversation_stream,
+        )
+
+    _finalize_conversation_response(span, request_metadata, result, start_time)
+    return result
+
+
+async def _conversations_append_async_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_conversation_append_metadata(kwargs, stream=bool(kwargs.get("stream")))
+    span = _start_span(
+        "mistral.beta.conversations.append",
+        _conversation_input(kwargs),
+        request_metadata,
+        span_type=SpanTypeAttribute.TASK,
+    )
+    start_time = time.time()
+    result = await _call_async_with_error_logging(span, wrapped, args, kwargs)
+
+    if kwargs.get("stream"):
+        return _TracedMistralAsyncStream(
+            result,
+            span,
+            request_metadata,
+            start_time,
+            chunk_has_output=_conversation_chunk_has_output,
+            finalize_stream=_finalize_conversation_stream,
+        )
+
+    _finalize_conversation_response(span, request_metadata, result, start_time)
+    return result
+
+
+def _conversations_append_stream_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_conversation_append_metadata(kwargs, stream=True)
+    span = _start_span(
+        "mistral.beta.conversations.append_stream",
+        _conversation_input(kwargs),
+        request_metadata,
+        span_type=SpanTypeAttribute.TASK,
+    )
+    start_time = time.time()
+    result = _call_with_error_logging(span, wrapped, args, kwargs)
+
+    return _TracedMistralSyncStream(
+        result,
+        span,
+        request_metadata,
+        start_time,
+        chunk_has_output=_conversation_chunk_has_output,
+        finalize_stream=_finalize_conversation_stream,
+    )
+
+
+async def _conversations_append_stream_async_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_conversation_append_metadata(kwargs, stream=True)
+    span = _start_span(
+        "mistral.beta.conversations.append_stream",
+        _conversation_input(kwargs),
+        request_metadata,
+        span_type=SpanTypeAttribute.TASK,
+    )
+    start_time = time.time()
+    result = await _call_async_with_error_logging(span, wrapped, args, kwargs)
+
+    return _TracedMistralAsyncStream(
+        result,
+        span,
+        request_metadata,
+        start_time,
+        chunk_has_output=_conversation_chunk_has_output,
+        finalize_stream=_finalize_conversation_stream,
+    )
+
+
+def _conversations_restart_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_conversation_restart_metadata(kwargs, stream=bool(kwargs.get("stream")))
+    span = _start_span(
+        "mistral.beta.conversations.restart",
+        _conversation_input(kwargs),
+        request_metadata,
+        span_type=SpanTypeAttribute.TASK,
+    )
+    start_time = time.time()
+    result = _call_with_error_logging(span, wrapped, args, kwargs)
+
+    if kwargs.get("stream"):
+        return _TracedMistralSyncStream(
+            result,
+            span,
+            request_metadata,
+            start_time,
+            chunk_has_output=_conversation_chunk_has_output,
+            finalize_stream=_finalize_conversation_stream,
+        )
+
+    _finalize_conversation_response(span, request_metadata, result, start_time)
+    return result
+
+
+async def _conversations_restart_async_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_conversation_restart_metadata(kwargs, stream=bool(kwargs.get("stream")))
+    span = _start_span(
+        "mistral.beta.conversations.restart",
+        _conversation_input(kwargs),
+        request_metadata,
+        span_type=SpanTypeAttribute.TASK,
+    )
+    start_time = time.time()
+    result = await _call_async_with_error_logging(span, wrapped, args, kwargs)
+
+    if kwargs.get("stream"):
+        return _TracedMistralAsyncStream(
+            result,
+            span,
+            request_metadata,
+            start_time,
+            chunk_has_output=_conversation_chunk_has_output,
+            finalize_stream=_finalize_conversation_stream,
+        )
+
+    _finalize_conversation_response(span, request_metadata, result, start_time)
+    return result
+
+
+def _conversations_restart_stream_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_conversation_restart_metadata(kwargs, stream=True)
+    span = _start_span(
+        "mistral.beta.conversations.restart_stream",
+        _conversation_input(kwargs),
+        request_metadata,
+        span_type=SpanTypeAttribute.TASK,
+    )
+    start_time = time.time()
+    result = _call_with_error_logging(span, wrapped, args, kwargs)
+
+    return _TracedMistralSyncStream(
+        result,
+        span,
+        request_metadata,
+        start_time,
+        chunk_has_output=_conversation_chunk_has_output,
+        finalize_stream=_finalize_conversation_stream,
+    )
+
+
+async def _conversations_restart_stream_async_wrapper(wrapped, instance, args, kwargs):
+    request_metadata = _build_conversation_restart_metadata(kwargs, stream=True)
+    span = _start_span(
+        "mistral.beta.conversations.restart_stream",
+        _conversation_input(kwargs),
+        request_metadata,
+        span_type=SpanTypeAttribute.TASK,
+    )
+    start_time = time.time()
+    result = await _call_async_with_error_logging(span, wrapped, args, kwargs)
+
+    return _TracedMistralAsyncStream(
+        result,
+        span,
+        request_metadata,
+        start_time,
+        chunk_has_output=_conversation_chunk_has_output,
+        finalize_stream=_finalize_conversation_stream,
+    )
+
+
 def _embeddings_create_wrapper(wrapped, instance, args, kwargs):
     request_metadata = _build_embeddings_metadata(kwargs)
     span = _start_span("mistral.embeddings.create", kwargs.get("inputs"), request_metadata)
@@ -1258,6 +1776,7 @@ def wrap_mistral(client: Any) -> Any:
     from .patchers import (
         AgentsPatcher,
         ChatPatcher,
+        ConversationsPatcher,
         EmbeddingsPatcher,
         FimPatcher,
         OcrPatcher,
@@ -1280,6 +1799,12 @@ def wrap_mistral(client: Any) -> Any:
     agents = getattr(client, "agents", None)
     if agents is not None:
         AgentsPatcher.wrap_target(agents)
+
+    beta = getattr(client, "beta", None)
+    if beta is not None:
+        conversations = getattr(beta, "conversations", None)
+        if conversations is not None:
+            ConversationsPatcher.wrap_target(conversations)
 
     ocr = getattr(client, "ocr", None)
     if ocr is not None:


### PR DESCRIPTION
Trace beta conversations start, append, and restart calls across the Mistral client layouts, including streaming variants, and log them as task spans with conversation metadata and normalized outputs.

resolves https://github.com/braintrustdata/braintrust-sdk-python/issues/273