### PR TITLE
Adding version_pretty to fetch prompt response

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -5071,6 +5071,11 @@ class Prompt:
         return self._lazy_metadata.get()._xact_id
 
     @property
+    def version_pretty(self) -> str | None:
+        version = cast(str | None, self.version)
+        return prettify_xact(version) if version is not None else None
+
+    @property
     def options(self) -> PromptOptions:
         return self._lazy_metadata.get().prompt_data.options or {}
 

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -263,6 +263,35 @@ class TestLogger(TestCase):
             {"version": "v1"},
         )
 
+    def test_load_prompt_exposes_pretty_version(self):
+        mock_api_conn = MagicMock()
+        mock_api_conn.get_json.return_value = {
+            "objects": [
+                {
+                    "id": "prompt-123",
+                    "project_id": "project-123",
+                    "name": "Saved prompt",
+                    "slug": "saved-prompt",
+                    "_xact_id": "123456789",
+                    "description": None,
+                    "tags": None,
+                    "prompt_data": {
+                        "prompt": {
+                            "type": "chat",
+                            "messages": [{"role": "user", "content": "Hello"}],
+                        },
+                        "options": {"model": "gpt-5-mini"},
+                    },
+                }
+            ]
+        }
+
+        simulate_login()
+        with patch.object(logger._state, "api_conn", return_value=mock_api_conn):
+            prompt = braintrust.load_prompt(project="test-project", slug="saved-prompt")
+            assert prompt.version == "123456789"
+            assert prompt.version_pretty == "f2be28742b0b0c2d"
+
     def test_load_parameters_returns_remote_object(self):
         mock_api_conn = MagicMock()
         mock_api_conn.get_json.return_value = {


### PR DESCRIPTION
Adding a `version_pretty` property to loaded prompts so callers can access the prettified transaction/version ID directly from the SDK. This helps since the UI exposes the pretty version only instead of the decimal value that is `_xact_id` by default.

- Added `Prompt.version_pretty`
- Uses the existing `prettify_xact()` helper
- Returns the prettified version when  `_xact_id` is present or `None` if the prompt has no version
- Added a test for this

Tested locally:
<img width="559" height="53" alt="image" src="https://github.com/user-attachments/assets/c1cc3fb2-0413-427c-ac08-1ea5a9534070" />
