### PR TITLE
feat(autogen): trace agents inside teams

### DIFF
--- a/py/src/braintrust/integrations/auto_test_scripts/test_auto_autogen.py
+++ b/py/src/braintrust/integrations/auto_test_scripts/test_auto_autogen.py
@@ -1,10 +1,13 @@
-from autogen_agentchat.agents import BaseChatAgent
+from autogen_agentchat.agents import AssistantAgent, BaseChatAgent
 from autogen_agentchat.teams import BaseGroupChat
 from autogen_core.tools import FunctionTool
 from braintrust.auto import auto_instrument
 
 
 assert not getattr(BaseChatAgent.run, "__braintrust_patched_autogen_chat_agent_run__", False)
+assert not getattr(
+    AssistantAgent.on_messages_stream, "__braintrust_patched_autogen_chat_agent_assistant_on_messages_stream__", False
+)
 assert not getattr(BaseGroupChat.run, "__braintrust_patched_autogen_team_run__", False)
 assert not getattr(FunctionTool.run, "__braintrust_patched_autogen_function_tool_run__", False)
 
@@ -14,6 +17,14 @@ assert auto_instrument().get("autogen") == True
 
 assert getattr(BaseChatAgent.run, "__braintrust_patched_autogen_chat_agent_run__", False)
 assert getattr(BaseChatAgent.run_stream, "__braintrust_patched_autogen_chat_agent_run_stream__", False)
+assert getattr(BaseChatAgent.on_messages, "__braintrust_patched_autogen_chat_agent_base_on_messages__", False)
+assert getattr(
+    BaseChatAgent.on_messages_stream, "__braintrust_patched_autogen_chat_agent_base_on_messages_stream__", False
+)
+assert getattr(AssistantAgent.on_messages, "__braintrust_patched_autogen_chat_agent_assistant_on_messages__", False)
+assert getattr(
+    AssistantAgent.on_messages_stream, "__braintrust_patched_autogen_chat_agent_assistant_on_messages_stream__", False
+)
 assert getattr(BaseGroupChat.run, "__braintrust_patched_autogen_team_run__", False)
 assert getattr(BaseGroupChat.run_stream, "__braintrust_patched_autogen_team_run_stream__", False)
 assert getattr(FunctionTool.run, "__braintrust_patched_autogen_function_tool_run__", False)

--- a/py/src/braintrust/integrations/autogen/patchers.py
+++ b/py/src/braintrust/integrations/autogen/patchers.py
@@ -3,6 +3,8 @@
 from braintrust.integrations.base import CompositeFunctionWrapperPatcher, FunctionWrapperPatcher
 
 from .tracing import (
+    _agent_on_messages_stream_wrapper,
+    _agent_on_messages_wrapper,
     _agent_run_stream_wrapper,
     _agent_run_wrapper,
     _team_run_stream_wrapper,
@@ -25,9 +27,108 @@ class ChatAgentRunStreamPatcher(FunctionWrapperPatcher):
     wrapper = _agent_run_stream_wrapper
 
 
+class BaseChatAgentOnMessagesPatcher(FunctionWrapperPatcher):
+    name = "autogen.chat_agent.base.on_messages"
+    target_module = "autogen_agentchat.agents"
+    target_path = "BaseChatAgent.on_messages"
+    wrapper = _agent_on_messages_wrapper
+
+
+class AssistantAgentOnMessagesPatcher(FunctionWrapperPatcher):
+    name = "autogen.chat_agent.assistant.on_messages"
+    target_module = "autogen_agentchat.agents"
+    target_path = "AssistantAgent.on_messages"
+    wrapper = _agent_on_messages_wrapper
+
+
+class CodeExecutorAgentOnMessagesPatcher(FunctionWrapperPatcher):
+    name = "autogen.chat_agent.code_executor.on_messages"
+    target_module = "autogen_agentchat.agents"
+    target_path = "CodeExecutorAgent.on_messages"
+    wrapper = _agent_on_messages_wrapper
+
+
+class MessageFilterAgentOnMessagesPatcher(FunctionWrapperPatcher):
+    name = "autogen.chat_agent.message_filter.on_messages"
+    target_module = "autogen_agentchat.agents"
+    target_path = "MessageFilterAgent.on_messages"
+    wrapper = _agent_on_messages_wrapper
+
+
+class SocietyOfMindAgentOnMessagesPatcher(FunctionWrapperPatcher):
+    name = "autogen.chat_agent.society_of_mind.on_messages"
+    target_module = "autogen_agentchat.agents"
+    target_path = "SocietyOfMindAgent.on_messages"
+    wrapper = _agent_on_messages_wrapper
+
+
+class UserProxyAgentOnMessagesPatcher(FunctionWrapperPatcher):
+    name = "autogen.chat_agent.user_proxy.on_messages"
+    target_module = "autogen_agentchat.agents"
+    target_path = "UserProxyAgent.on_messages"
+    wrapper = _agent_on_messages_wrapper
+
+
+class BaseChatAgentOnMessagesStreamPatcher(FunctionWrapperPatcher):
+    name = "autogen.chat_agent.base.on_messages_stream"
+    target_module = "autogen_agentchat.agents"
+    target_path = "BaseChatAgent.on_messages_stream"
+    wrapper = _agent_on_messages_stream_wrapper
+
+
+class AssistantAgentOnMessagesStreamPatcher(FunctionWrapperPatcher):
+    name = "autogen.chat_agent.assistant.on_messages_stream"
+    target_module = "autogen_agentchat.agents"
+    target_path = "AssistantAgent.on_messages_stream"
+    wrapper = _agent_on_messages_stream_wrapper
+
+
+class CodeExecutorAgentOnMessagesStreamPatcher(FunctionWrapperPatcher):
+    name = "autogen.chat_agent.code_executor.on_messages_stream"
+    target_module = "autogen_agentchat.agents"
+    target_path = "CodeExecutorAgent.on_messages_stream"
+    wrapper = _agent_on_messages_stream_wrapper
+
+
+class MessageFilterAgentOnMessagesStreamPatcher(FunctionWrapperPatcher):
+    name = "autogen.chat_agent.message_filter.on_messages_stream"
+    target_module = "autogen_agentchat.agents"
+    target_path = "MessageFilterAgent.on_messages_stream"
+    wrapper = _agent_on_messages_stream_wrapper
+
+
+class SocietyOfMindAgentOnMessagesStreamPatcher(FunctionWrapperPatcher):
+    name = "autogen.chat_agent.society_of_mind.on_messages_stream"
+    target_module = "autogen_agentchat.agents"
+    target_path = "SocietyOfMindAgent.on_messages_stream"
+    wrapper = _agent_on_messages_stream_wrapper
+
+
+class UserProxyAgentOnMessagesStreamPatcher(FunctionWrapperPatcher):
+    name = "autogen.chat_agent.user_proxy.on_messages_stream"
+    target_module = "autogen_agentchat.agents"
+    target_path = "UserProxyAgent.on_messages_stream"
+    wrapper = _agent_on_messages_stream_wrapper
+
+
 class ChatAgentPatcher(CompositeFunctionWrapperPatcher):
     name = "autogen.chat_agent"
-    sub_patchers = (ChatAgentRunPatcher, ChatAgentRunStreamPatcher)
+    sub_patchers = (
+        ChatAgentRunPatcher,
+        ChatAgentRunStreamPatcher,
+        BaseChatAgentOnMessagesPatcher,
+        AssistantAgentOnMessagesPatcher,
+        CodeExecutorAgentOnMessagesPatcher,
+        MessageFilterAgentOnMessagesPatcher,
+        SocietyOfMindAgentOnMessagesPatcher,
+        UserProxyAgentOnMessagesPatcher,
+        BaseChatAgentOnMessagesStreamPatcher,
+        AssistantAgentOnMessagesStreamPatcher,
+        CodeExecutorAgentOnMessagesStreamPatcher,
+        MessageFilterAgentOnMessagesStreamPatcher,
+        SocietyOfMindAgentOnMessagesStreamPatcher,
+        UserProxyAgentOnMessagesStreamPatcher,
+    )
 
 
 class TeamRunPatcher(FunctionWrapperPatcher):

--- a/py/src/braintrust/integrations/autogen/test_autogen.py
+++ b/py/src/braintrust/integrations/autogen/test_autogen.py
@@ -112,6 +112,12 @@ async def test_autogen_team_run_creates_team_span(memory_logger):
     assert team_span["metadata"]["component"] == "team"
     assert team_span["metadata"]["team_name"] == "writing_team"
     assert team_span["metadata"]["participant_names"] == ["assistant"]
+    agent_span = next(span for span in spans if span["span_attributes"]["name"] == "assistant.run_stream")
+    assert _span_type(agent_span) == "task"
+    assert agent_span["metadata"]["component"] == "agent"
+    assert agent_span["metadata"]["agent_name"] == "assistant"
+    team_span_ids = {span["span_id"] for span in spans if span["metadata"].get("component") == "team"}
+    assert team_span_ids.intersection(agent_span["span_parents"])
 
 
 def test_autogen_auto_instrument_subprocess():

--- a/py/src/braintrust/integrations/autogen/tracing.py
+++ b/py/src/braintrust/integrations/autogen/tracing.py
@@ -1,11 +1,15 @@
 """AutoGen-specific tracing helpers."""
 
 from collections.abc import AsyncIterator
+from contextvars import ContextVar
 from typing import Any
 
 from braintrust.logger import start_span
 from braintrust.span_types import SpanTypeAttribute
 from braintrust.util import clean_nones
+
+
+_agent_public_run_depth: ContextVar[int] = ContextVar("braintrust_autogen_agent_public_run_depth", default=0)
 
 
 def _agent_metadata(instance: Any) -> dict[str, Any]:
@@ -45,12 +49,67 @@ def _task_input(kwargs: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def _messages_input(args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:
+    messages = args[0] if args else kwargs.get("messages")
+    return clean_nones({"messages": messages})
+
+
 async def _agent_run_wrapper(wrapped: Any, instance: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    name = getattr(instance, "name", None) or instance.__class__.__name__
+    token = _agent_public_run_depth.set(_agent_public_run_depth.get() + 1)
+    try:
+        with start_span(
+            name=f"{name}.run",
+            type=SpanTypeAttribute.TASK,
+            input=_task_input(kwargs),
+            metadata=_agent_metadata(instance),
+        ) as span:
+            try:
+                result = await wrapped(*args, **kwargs)
+            except Exception as exc:
+                span.log(error=exc)
+                raise
+            span.log(output=result)
+            return result
+    finally:
+        _agent_public_run_depth.reset(token)
+
+
+async def _agent_run_stream_wrapper(
+    wrapped: Any, instance: Any, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> AsyncIterator[Any]:
+    name = getattr(instance, "name", None) or instance.__class__.__name__
+    token = _agent_public_run_depth.set(_agent_public_run_depth.get() + 1)
+    try:
+        with start_span(
+            name=f"{name}.run_stream",
+            type=SpanTypeAttribute.TASK,
+            input=_task_input(kwargs),
+            metadata=_agent_metadata(instance),
+        ) as span:
+            events = []
+            try:
+                async for event in wrapped(*args, **kwargs):
+                    events.append(event)
+                    yield event
+            except Exception as exc:
+                span.log(error=exc, output={"events": events})
+                raise
+            span.log(output={"events": events})
+    finally:
+        _agent_public_run_depth.reset(token)
+
+
+async def _agent_on_messages_wrapper(
+    wrapped: Any, instance: Any, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> Any:
+    if _agent_public_run_depth.get() > 0:
+        return await wrapped(*args, **kwargs)
     name = getattr(instance, "name", None) or instance.__class__.__name__
     with start_span(
         name=f"{name}.run",
         type=SpanTypeAttribute.TASK,
-        input=_task_input(kwargs),
+        input=_messages_input(args, kwargs),
         metadata=_agent_metadata(instance),
     ) as span:
         try:
@@ -62,14 +121,18 @@ async def _agent_run_wrapper(wrapped: Any, instance: Any, args: tuple[Any, ...],
         return result
 
 
-async def _agent_run_stream_wrapper(
+async def _agent_on_messages_stream_wrapper(
     wrapped: Any, instance: Any, args: tuple[Any, ...], kwargs: dict[str, Any]
 ) -> AsyncIterator[Any]:
+    if _agent_public_run_depth.get() > 0:
+        async for event in wrapped(*args, **kwargs):
+            yield event
+        return
     name = getattr(instance, "name", None) or instance.__class__.__name__
     with start_span(
         name=f"{name}.run_stream",
         type=SpanTypeAttribute.TASK,
-        input=_task_input(kwargs),
+        input=_messages_input(args, kwargs),
         metadata=_agent_metadata(instance),
     ) as span:
         events = []


### PR DESCRIPTION
resolves https://linear.app/braintrustdata/issue/BT-5141/autogen-integration-no-per-agent-spans-when-agents-run-inside-a-team

Patch AutoGen agent on_messages and on_messages_stream paths so BaseGroupChat team runs emit per-agent spans in addition to team spans. Avoid duplicate direct-call spans while preserving existing run and run_stream behavior.

Adds VCR-backed coverage for team agent spans and updates auto-instrument patch assertions.