### PR TITLE
fix(openai): filter omit sentinel from metadata

### DIFF
--- a/py/src/braintrust/integrations/openai/cassettes/latest/test_openai_omit_filtering.yaml
+++ b/py/src/braintrust/integrations/openai/cassettes/latest/test_openai_omit_filtering.yaml
@@ -1,0 +1,108 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"What''s 12 + 12?"}],"model":"gpt-4o-mini","temperature":0.5}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json
+      Host:
+      - api.openai.com
+      User-Agent:
+      - OpenAI/Python 2.36.0
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.36.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.12.12
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"id\": \"chatcmpl-Deqr3AS7sfalyDh0zUbV7GTbfJ6FW\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1778628665,\n  \"model\": \"gpt-4o-mini-2024-07-18\",\n
+        \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
+        \"assistant\",\n        \"content\": \"12 + 12 equals 24.\",\n        \"refusal\":
+        null,\n        \"annotations\": []\n      },\n      \"logprobs\": null,\n
+        \     \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\":
+        14,\n    \"completion_tokens\": 8,\n    \"total_tokens\": 22,\n    \"prompt_tokens_details\":
+        {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
+        {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
+        0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
+        \"default\",\n  \"system_fingerprint\": \"fp_026a2c69f4\"\n}\n"
+    headers:
+      Access-Control-Expose-Headers:
+      - CF-Ray
+      CF-RAY:
+      - 9fad36ffb950ebc0-YYZ
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 12 May 2026 23:31:05 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '824'
+      openai-organization:
+      - braintrust-data
+      openai-processing-ms:
+      - '361'
+      openai-project:
+      - proj_vsCSXafhhByzWOThMrJcZiw9
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=REd5IGOCpA5St.7gaT4pJICQVAr4JZiYdU25UG5p2xk-1778628664.2733116-1.0.1.1-nGe1F_BTvWxO_eU6nY7JccQmtUHd4b4g8fMcFAwRFJNRPDTkvb6VzkeO7mtA0pGKwCIjuJGBX84ijewVEXCxE5BEDqOG8tjxG6p9YIRyEhDhGkiyC8xsZryTsIMIxTUP;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=api.openai.com; Expires=Wed,
+        13 May 2026 00:01:05 GMT
+      x-openai-proxy-wasm:
+      - v0.1
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999995'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_e4e8696b1b1b4b9abc9713aaddc43464
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/openai/test_openai.py
+++ b/py/src/braintrust/integrations/openai/test_openai.py
@@ -20,7 +20,8 @@ from braintrust.integrations.test_utils import assert_metrics_are_valid, verify_
 from braintrust.span_types import SpanTypeAttribute
 from braintrust.test_helpers import assert_dict_matches, init_test_logger
 from openai import AsyncOpenAI
-from openai._types import NOT_GIVEN
+from openai._types import NOT_GIVEN, Omit
+from packaging.version import Version
 from pydantic import BaseModel
 
 
@@ -1566,6 +1567,45 @@ def test_openai_not_given_filtering(memory_logger):
     assert "NOT_GIVEN" not in str(meta)
     for k in ["max_tokens", "top_p", "frequency_penalty", "presence_penalty", "tools"]:
         assert k not in meta
+
+
+@pytest.mark.skipif(Version(openai.__version__) < Version("2.0.0"), reason="openai.Omit is not omitted by OpenAI 1.x")
+@pytest.mark.vcr
+def test_openai_omit_filtering(memory_logger):
+    """Test that Omit values are filtered out of logged inputs but API call still works."""
+    assert not memory_logger.pop()
+
+    client = wrap_openai(openai.OpenAI())
+
+    response = client.chat.completions.create(
+        model=TEST_MODEL,
+        messages=[{"role": "user", "content": TEST_PROMPT}],
+        temperature=0.5,
+        tools=Omit(),
+    )
+
+    assert response
+    assert response.choices[0].message.content
+    assert "24" in response.choices[0].message.content or "twenty-four" in response.choices[0].message.content.lower()
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+
+    assert_dict_matches(
+        span,
+        {
+            "input": [{"role": "user", "content": TEST_PROMPT}],
+            "metadata": {
+                "model": TEST_MODEL,
+                "provider": "openai",
+                "temperature": 0.5,
+            },
+        },
+    )
+    meta = span["metadata"]
+    assert "Omit" not in str(meta)
+    assert "tools" not in meta
 
 
 @pytest.mark.vcr

--- a/py/src/braintrust/integrations/utils.py
+++ b/py/src/braintrust/integrations/utils.py
@@ -482,7 +482,7 @@ def _extract_audio_output(
 
 
 def _is_not_given(value: object) -> bool:
-    """Return ``True`` when *value* is a provider ``NOT_GIVEN`` sentinel.
+    """Return ``True`` when *value* is a provider omitted-parameter sentinel.
 
     Works by type-name inspection so that Braintrust does not need a
     direct import dependency on any provider SDK.
@@ -490,7 +490,7 @@ def _is_not_given(value: object) -> bool:
     if value is None:
         return False
     try:
-        return type(value).__name__ == "NotGiven"
+        return type(value).__name__ in {"NotGiven", "Omit"}
     except Exception:
         return False
 


### PR DESCRIPTION
Treat OpenAI Omit values like other omitted-parameter sentinels when prettifying traced request metadata, so omitted tools do not appear as object reprs in spans.

Add VCR-backed regression coverage for chat completions on OpenAI 2.x and keep older 1.x sessions skipped because that SDK version does not omit Omit from requests.

resolves https://github.com/braintrustdata/braintrust-sdk-python/issues/414