### PR TITLE
task(logger): accept serializable objects as metadata

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -3891,7 +3891,7 @@ class Experiment(ObjectFetcher[ExperimentEvent], Exportable):
         :param expected: (Optional) the ground truth value (an arbitrary, JSON serializable object) that you'd compare to `output` to determine if your `output` value is correct or not.
         :param tags: (Optional) a list of strings that you can use to filter and group records later.
         :param comment: (Optional) an optional comment string to log about the event.
-        :param metadata: (Optional) a dictionary, or an object that serializes to a dictionary, with additional data about the feedback. If you have a `user_id`, you can log it here and access it in the Braintrust UI. Note, this metadata does not correspond to the main event itself, but rather the audit log attached to the event. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
+        :param metadata: (Optional) a dictionary, or an object that serializes to a dictionary (such as a Pydantic model), with additional data about the feedback. If you have a `user_id`, you can log it here and access it in the Braintrust UI. Note, this metadata does not correspond to the main event itself, but rather the audit log attached to the event. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
         :param source: (Optional) the source of the feedback. Must be one of "external" (default), "app", or "api".
         """
         return _log_feedback_impl(
@@ -5323,7 +5323,7 @@ class Logger(Exportable):
         :param expected: (Optional) the ground truth value (an arbitrary, JSON serializable object) that you'd compare to `output` to determine if your `output` value is correct or not.
         :param tags: (Optional) a list of strings that you can use to filter and group records later.
         :param comment: (Optional) an optional comment string to log about the event.
-        :param metadata: (Optional) a dictionary, or an object that serializes to a dictionary, with additional data about the feedback. If you have a `user_id`, you can log it here and access it in the Braintrust UI. Note, this metadata does not correspond to the main event itself, but rather the audit log attached to the event. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
+        :param metadata: (Optional) a dictionary, or an object that serializes to a dictionary (such as a Pydantic model), with additional data about the feedback. If you have a `user_id`, you can log it here and access it in the Braintrust UI. Note, this metadata does not correspond to the main event itself, but rather the audit log attached to the event. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
         :param source: (Optional) the source of the feedback. Must be one of "external" (default), "app", or "api".
         """
         return _log_feedback_impl(

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -3391,7 +3391,7 @@ def _log_feedback_impl(
     expected: Any | None = None,
     tags: Sequence[str] | None = None,
     comment: str | None = None,
-    metadata: Metadata | None = None,
+    metadata: object | None = None,
     source: Literal["external", "app", "api", None] = None,
 ):
     if source is None:
@@ -3880,7 +3880,7 @@ class Experiment(ObjectFetcher[ExperimentEvent], Exportable):
         expected: Any | None = None,
         tags: Sequence[str] | None = None,
         comment: str | None = None,
-        metadata: Metadata | None = None,
+        metadata: object | None = None,
         source: Literal["external", "app", "api", None] = None,
     ) -> None:
         """
@@ -3891,7 +3891,7 @@ class Experiment(ObjectFetcher[ExperimentEvent], Exportable):
         :param expected: (Optional) the ground truth value (an arbitrary, JSON serializable object) that you'd compare to `output` to determine if your `output` value is correct or not.
         :param tags: (Optional) a list of strings that you can use to filter and group records later.
         :param comment: (Optional) an optional comment string to log about the event.
-        :param metadata: (Optional) a dictionary with additional data about the feedback. If you have a `user_id`, you can log it here and access it in the Braintrust UI. Note, this metadata does not correspond to the main event itself, but rather the audit log attached to the event.
+        :param metadata: (Optional) a dictionary, or an object that serializes to a dictionary, with additional data about the feedback. If you have a `user_id`, you can log it here and access it in the Braintrust UI. Note, this metadata does not correspond to the main event itself, but rather the audit log attached to the event. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
         :param source: (Optional) the source of the feedback. Must be one of "external" (default), "app", or "api".
         """
         return _log_feedback_impl(
@@ -5312,7 +5312,7 @@ class Logger(Exportable):
         expected: Any | None = None,
         tags: Sequence[str] | None = None,
         comment: str | None = None,
-        metadata: Metadata | None = None,
+        metadata: object | None = None,
         source: Literal["external", "app", "api", None] = None,
     ) -> None:
         """
@@ -5323,7 +5323,7 @@ class Logger(Exportable):
         :param expected: (Optional) the ground truth value (an arbitrary, JSON serializable object) that you'd compare to `output` to determine if your `output` value is correct or not.
         :param tags: (Optional) a list of strings that you can use to filter and group records later.
         :param comment: (Optional) an optional comment string to log about the event.
-        :param metadata: (Optional) a dictionary with additional data about the feedback. If you have a `user_id`, you can log it here and access it in the Braintrust UI. Note, this metadata does not correspond to the main event itself, but rather the audit log attached to the event.
+        :param metadata: (Optional) a dictionary, or an object that serializes to a dictionary, with additional data about the feedback. If you have a `user_id`, you can log it here and access it in the Braintrust UI. Note, this metadata does not correspond to the main event itself, but rather the audit log attached to the event. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
         :param source: (Optional) the source of the feedback. Must be one of "external" (default), "app", or "api".
         """
         return _log_feedback_impl(

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1800,7 +1800,8 @@ def init_dataset(
     key is specified, will prompt the user to login.
     :param org_name: (Optional) The name of a specific organization to connect to. This is useful if you belong to multiple.
     :param project_id: The id of the project to create the dataset in. This takes precedence over `project` if specified.
-    :param metadata: (Optional) a dictionary with additional data about the dataset. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
+    :param metadata: (Optional) a dictionary, or an object that serializes to a dictionary (such as a Pydantic model), with additional data about the dataset. The values in `metadata` can be any
+    JSON-serializable type, but its keys must be strings.
     :param use_output: (Deprecated) If True, records will be fetched from this dataset in the legacy format, with the "expected" field renamed to "output". This option will be removed in a future version of Braintrust.
     :param _internal_btql: (Internal) If specified, the dataset will be created with the given BTQL filters.
     :param state: (Internal) The Braintrust state to use. If not specified, will use the global state. For advanced use only.
@@ -2777,23 +2778,24 @@ def _enrich_attachments(event: TMutableMapping) -> TMutableMapping:
     return event
 
 
-def _validate_and_sanitize_metadata(metadata: object) -> dict[str, Any]:
-    if not isinstance(metadata, dict):
-        metadata = bt_safe_deep_copy(metadata)
+def _validate_and_sanitize_metadata(metadata: Metadata) -> dict[str, Any]:
+    if isinstance(metadata, dict):
+        sanitized_metadata = metadata
+    else:
+        sanitized_metadata = bt_safe_deep_copy(metadata)
+        if not isinstance(sanitized_metadata, dict):
+            raise ValueError("metadata must be a dictionary or serialize to a dictionary")
 
-    if not isinstance(metadata, dict):
-        raise ValueError("metadata must be a dictionary or serialize to a dictionary")
-
-    for key in metadata.keys():
+    for key in sanitized_metadata.keys():
         if not isinstance(key, str):
             raise ValueError("metadata keys must be strings")
 
-    return metadata
+    return sanitized_metadata
 
 
 def _validate_and_sanitize_experiment_log_partial_args(event: Mapping[str, Any]) -> dict[str, Any]:
-    event = dict(event)
-    scores = event.get("scores")
+    sanitized_event = dict(event)
+    scores = sanitized_event.get("scores")
     if scores:
         for name, score in scores.items():
             if not isinstance(name, str):
@@ -2811,10 +2813,10 @@ def _validate_and_sanitize_experiment_log_partial_args(event: Mapping[str, Any])
             if score < 0 or score > 1:
                 raise ValueError("score values must be between 0 and 1")
 
-    if "metadata" in event and event["metadata"] is not None:
-        event["metadata"] = _validate_and_sanitize_metadata(event["metadata"])
+    if "metadata" in sanitized_event and sanitized_event["metadata"] is not None:
+        sanitized_event["metadata"] = _validate_and_sanitize_metadata(sanitized_event["metadata"])
 
-    metrics = event.get("metrics")
+    metrics = sanitized_event.get("metrics")
     if metrics:
         if not isinstance(metrics, dict):
             raise ValueError("metrics must be a dictionary")
@@ -2826,11 +2828,11 @@ def _validate_and_sanitize_experiment_log_partial_args(event: Mapping[str, Any])
             if not isinstance(value, (int, float)):
                 raise ValueError("metric values must be numbers")
 
-    tags = event.get("tags")
+    tags = sanitized_event.get("tags")
     if tags:
         validate_tags(tags)
 
-    span_attributes = event.get("span_attributes")
+    span_attributes = sanitized_event.get("span_attributes")
     if span_attributes:
         if not isinstance(span_attributes, dict):
             raise ValueError("span_attributes must be a dictionary")
@@ -2838,14 +2840,14 @@ def _validate_and_sanitize_experiment_log_partial_args(event: Mapping[str, Any])
             if not isinstance(key, str):
                 raise ValueError("span_attributes keys must be strings")
 
-    input = event.get("input")
-    inputs = event.get("inputs")
+    input = sanitized_event.get("input")
+    inputs = sanitized_event.get("inputs")
     if input is not None and inputs is not None:
         raise ValueError("Only one of input or inputs (deprecated) can be specified. Prefer input.")
     if inputs is not None:
-        return dict(**{k: v for k, v in event.items() if k not in ["input", "inputs"]}, input=inputs)
+        return dict(**{k: v for k, v in sanitized_event.items() if k not in ["input", "inputs"]}, input=inputs)
     else:
-        return {k: v for k, v in event.items()}
+        return {k: v for k, v in sanitized_event.items()}
 
 
 # Note that this only checks properties that are expected of a complete event.
@@ -3391,7 +3393,7 @@ def _log_feedback_impl(
     expected: Any | None = None,
     tags: Sequence[str] | None = None,
     comment: str | None = None,
-    metadata: object | None = None,
+    metadata: Metadata | None = None,
     source: Literal["external", "app", "api", None] = None,
 ):
     if source is None:
@@ -3828,7 +3830,7 @@ class Experiment(ObjectFetcher[ExperimentEvent], Exportable):
         error: str | None = None,
         tags: Sequence[str] | None = None,
         scores: Mapping[str, int | float] | None = None,
-        metadata: object | None = None,
+        metadata: Metadata | None = None,
         metrics: Mapping[str, int | float] | None = None,
         id: str | None = None,
         dataset_record_id: str | None = None,
@@ -3880,7 +3882,7 @@ class Experiment(ObjectFetcher[ExperimentEvent], Exportable):
         expected: Any | None = None,
         tags: Sequence[str] | None = None,
         comment: str | None = None,
-        metadata: object | None = None,
+        metadata: Metadata | None = None,
         source: Literal["external", "app", "api", None] = None,
     ) -> None:
         """
@@ -4663,18 +4665,10 @@ class Dataset(ObjectFetcher[DatasetEvent]):
 
     def _validate_event(
         self,
-        metadata: Metadata | None = None,
         expected: Any | None = None,
         output: Any | None = None,
         tags: Sequence[str] | None = None,
-    ):
-        if metadata is not None:
-            if not isinstance(metadata, dict):
-                raise ValueError("metadata must be a dictionary")
-            for key in metadata.keys():
-                if not isinstance(key, str):
-                    raise ValueError("metadata keys must be strings")
-
+    ) -> None:
         if expected is not None and output is not None:
             raise ValueError("Only one of expected or output (deprecated) can be specified. Prefer expected.")
 
@@ -4727,15 +4721,18 @@ class Dataset(ObjectFetcher[DatasetEvent]):
         :param input: The argument that uniquely define an input case (an arbitrary, JSON serializable object).
         :param expected: The output of your application, including post-processing (an arbitrary, JSON serializable object).
         :param tags: (Optional) a list of strings that you can use to filter and group records later.
-        :param metadata: (Optional) a dictionary with additional data about the test example, model outputs, or just
-        about anything else that's relevant, that you can use to help find and analyze examples later. For example, you could log the
+        :param metadata: (Optional) a dictionary, or an object that serializes to a dictionary (such as a Pydantic model), with
+        additional data about the test example, model outputs, or just about anything else that's relevant, that you can use to help
+        find and analyze examples later. For example, you could log the
         `prompt`, example's `id`, or anything else that would be useful to slice/dice later. The values in `metadata` can be any
         JSON-serializable type, but its keys must be strings.
         :param id: (Optional) a unique identifier for the event. If you don't provide one, Braintrust will generate one for you.
         :param output: (Deprecated) The output of your application. Use `expected` instead.
         :returns: The `id` of the logged record.
         """
-        self._validate_event(metadata=metadata, expected=expected, output=output, tags=tags)
+        if metadata is not None:
+            metadata = _validate_and_sanitize_metadata(metadata)
+        self._validate_event(expected=expected, output=output, tags=tags)
 
         row_id = id or str(uuid.uuid4())
 
@@ -4770,11 +4767,13 @@ class Dataset(ObjectFetcher[DatasetEvent]):
         :param input: (Optional) The new input value for the record (an arbitrary, JSON serializable object).
         :param expected: (Optional) The new expected output value for the record (an arbitrary, JSON serializable object).
         :param tags: (Optional) A list of strings to update the tags of the record.
-        :param metadata: (Optional) A dictionary to update the metadata of the record. The values in `metadata` can be any
-            JSON-serializable type, but its keys must be strings.
+        :param metadata: (Optional) A dictionary, or an object that serializes to a dictionary (such as a Pydantic model), to update
+            the metadata of the record. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
         :returns: The `id` of the updated record.
         """
-        self._validate_event(metadata=metadata, expected=expected, tags=tags)
+        if metadata is not None:
+            metadata = _validate_and_sanitize_metadata(metadata)
+        self._validate_event(expected=expected, tags=tags)
 
         args = self._create_args(
             id=id,
@@ -5261,7 +5260,7 @@ class Logger(Exportable):
         error: str | None = None,
         tags: Sequence[str] | None = None,
         scores: Mapping[str, int | float] | None = None,
-        metadata: object | None = None,
+        metadata: Metadata | None = None,
         metrics: Mapping[str, int | float] | None = None,
         id: str | None = None,
         allow_concurrent_with_spans: bool = False,
@@ -5312,7 +5311,7 @@ class Logger(Exportable):
         expected: Any | None = None,
         tags: Sequence[str] | None = None,
         comment: str | None = None,
-        metadata: object | None = None,
+        metadata: Metadata | None = None,
         source: Literal["external", "app", "api", None] = None,
     ) -> None:
         """

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -2777,7 +2777,22 @@ def _enrich_attachments(event: TMutableMapping) -> TMutableMapping:
     return event
 
 
+def _validate_and_sanitize_metadata(metadata: object) -> dict[str, Any]:
+    if not isinstance(metadata, dict):
+        metadata = bt_safe_deep_copy(metadata)
+
+    if not isinstance(metadata, dict):
+        raise ValueError("metadata must be a dictionary or serialize to a dictionary")
+
+    for key in metadata.keys():
+        if not isinstance(key, str):
+            raise ValueError("metadata keys must be strings")
+
+    return metadata
+
+
 def _validate_and_sanitize_experiment_log_partial_args(event: Mapping[str, Any]) -> dict[str, Any]:
+    event = dict(event)
     scores = event.get("scores")
     if scores:
         for name, score in scores.items():
@@ -2796,13 +2811,8 @@ def _validate_and_sanitize_experiment_log_partial_args(event: Mapping[str, Any])
             if score < 0 or score > 1:
                 raise ValueError("score values must be between 0 and 1")
 
-    metadata = event.get("metadata")
-    if metadata:
-        if not isinstance(metadata, dict):
-            raise ValueError("metadata must be a dictionary")
-        for key in metadata.keys():
-            if not isinstance(key, str):
-                raise ValueError("metadata keys must be strings")
+    if "metadata" in event and event["metadata"] is not None:
+        event["metadata"] = _validate_and_sanitize_metadata(event["metadata"])
 
     metrics = event.get("metrics")
     if metrics:
@@ -3818,7 +3828,7 @@ class Experiment(ObjectFetcher[ExperimentEvent], Exportable):
         error: str | None = None,
         tags: Sequence[str] | None = None,
         scores: Mapping[str, int | float] | None = None,
-        metadata: Metadata | None = None,
+        metadata: object | None = None,
         metrics: Mapping[str, int | float] | None = None,
         id: str | None = None,
         dataset_record_id: str | None = None,
@@ -3832,7 +3842,7 @@ class Experiment(ObjectFetcher[ExperimentEvent], Exportable):
         :param expected: (Optional) the ground truth value (an arbitrary, JSON serializable object) that you'd compare to `output` to determine if your `output` value is correct or not. Braintrust currently does not compare `output` to `expected` for you, since there are so many different ways to do that correctly. Instead, these values are just used to help you navigate your experiments while digging into analyses. However, we may later use these values to re-score outputs or fine-tune your models.
         :param error: (Optional) The error that occurred, if any. If you use tracing to run an experiment, errors are automatically logged when your code throws an exception.
         :param scores: A dictionary of numeric values (between 0 and 1) to log. The scores should give you a variety of signals that help you determine how accurate the outputs are compared to what you expect and diagnose failures. For example, a summarization app might have one score that tells you how accurate the summary is, and another that measures the word similarity between the generated and grouth truth summary. The word similarity score could help you determine whether the summarization was covering similar concepts or not. You can use these scores to help you sort, filter, and compare experiments.
-        :param metadata: (Optional) a dictionary with additional data about the test example, model outputs, or just about anything else that's relevant, that you can use to help find and analyze examples later. For example, you could log the `prompt`, example's `id`, or anything else that would be useful to slice/dice later. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
+        :param metadata: (Optional) a dictionary, or an object that serializes to a dictionary (such as a Pydantic model), with additional data about the test example, model outputs, or just about anything else that's relevant, that you can use to help find and analyze examples later. For example, you could log the `prompt`, example's `id`, or anything else that would be useful to slice/dice later. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
         :param tags: (Optional) a list of strings that you can use to filter and group records later.
         :param metrics: (Optional) a dictionary of metrics to log. The following keys are populated automatically: "start", "end".
         :param id: (Optional) a unique identifier for the event. If you don't provide one, BrainTrust will generate one for you.
@@ -5251,7 +5261,7 @@ class Logger(Exportable):
         error: str | None = None,
         tags: Sequence[str] | None = None,
         scores: Mapping[str, int | float] | None = None,
-        metadata: Metadata | None = None,
+        metadata: object | None = None,
         metrics: Mapping[str, int | float] | None = None,
         id: str | None = None,
         allow_concurrent_with_spans: bool = False,
@@ -5265,7 +5275,7 @@ class Logger(Exportable):
         :param error: (Optional) The error that occurred, if any. If you use tracing to run an experiment, errors are automatically logged when your code throws an exception.
         :param tags: (Optional) a list of strings that you can use to filter and group records later.
         :param scores: (Optional) a dictionary of numeric values (between 0 and 1) to log. The scores should give you a variety of signals that help you determine how accurate the outputs are compared to what you expect and diagnose failures. For example, a summarization app might have one score that tells you how accurate the summary is, and another that measures the word similarity between the generated and grouth truth summary. The word similarity score could help you determine whether the summarization was covering similar concepts or not. You can use these scores to help you sort, filter, and compare logs.
-        :param metadata: (Optional) a dictionary with additional data about the test example, model outputs, or just about anything else that's relevant, that you can use to help find and analyze examples later. For example, you could log the `prompt`, example's `id`, or anything else that would be useful to slice/dice later. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
+        :param metadata: (Optional) a dictionary, or an object that serializes to a dictionary (such as a Pydantic model), with additional data about the test example, model outputs, or just about anything else that's relevant, that you can use to help find and analyze examples later. For example, you could log the `prompt`, example's `id`, or anything else that would be useful to slice/dice later. The values in `metadata` can be any JSON-serializable type, but its keys must be strings.
         :param metrics: (Optional) a dictionary of metrics to log. The following keys are populated automatically: "start", "end".
         :param id: (Optional) a unique identifier for the event. If you don't provide one, BrainTrust will generate one for you.
         :param allow_concurrent_with_spans: (Optional) in rare cases where you need to log at the top level separately from using spans on the logger elsewhere, set this to True.

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -22,6 +22,7 @@ from braintrust import (
     init_logger,
     logger,
 )
+from braintrust.db_fields import AUDIT_METADATA_FIELD
 from braintrust.id_gen import OTELIDGenerator, get_id_generator
 from braintrust.logger import (
     RemoteEvalParameters,
@@ -858,20 +859,64 @@ def test_span_log_accepts_pydantic_model_metadata(with_memory_logger):
     assert logs[0]["metadata"] == {"foo": "bar"}
 
 
-def test_span_log_accepts_model_dump_metadata(with_memory_logger):
-    class MetadataModel:
-        def model_dump(self, **kwargs):
-            assert kwargs == {"exclude_none": True}
-            return {"foo": "bar"}
+class _ModelDumpMetadata:
+    def __init__(self, **values):
+        self.values = values
 
+    def model_dump(self, **kwargs):
+        assert kwargs == {"exclude_none": True}
+        return dict(self.values)
+
+
+def test_span_log_accepts_model_dump_metadata(with_memory_logger):
     logger = init_test_logger(__name__)
 
     with logger.start_span(name="test_span") as span:
-        span.log(metadata=MetadataModel())
+        span.log(metadata=_ModelDumpMetadata(foo="bar"))
 
     logs = with_memory_logger.pop()
     assert len(logs) == 1
     assert logs[0]["metadata"] == {"foo": "bar"}
+
+
+def test_logger_log_accepts_model_dump_metadata(with_memory_logger):
+    logger = init_test_logger(__name__)
+
+    logger.log(input="input", output="output", metadata=_ModelDumpMetadata(foo="bar"))
+
+    logs = with_memory_logger.pop()
+    assert len(logs) == 1
+    assert logs[0]["metadata"] == {"foo": "bar"}
+
+
+def test_experiment_log_accepts_model_dump_metadata(with_memory_logger):
+    experiment = init_test_exp("test-experiment", "test-project")
+
+    experiment.log(input="input", output="output", scores={"score": 1}, metadata=_ModelDumpMetadata(foo="bar"))
+
+    logs = with_memory_logger.pop()
+    assert len(logs) == 1
+    assert logs[0]["metadata"] == {"foo": "bar"}
+
+
+def test_logger_log_feedback_accepts_model_dump_metadata(with_memory_logger):
+    logger = init_test_logger(__name__)
+
+    logger.log_feedback(id="event-id", scores={"score": 1}, metadata=_ModelDumpMetadata(user_id="user-1"))
+
+    logs = with_memory_logger.pop()
+    assert len(logs) == 1
+    assert logs[0][AUDIT_METADATA_FIELD] == {"user_id": "user-1"}
+
+
+def test_experiment_log_feedback_accepts_model_dump_metadata(with_memory_logger):
+    experiment = init_test_exp("test-experiment", "test-project")
+
+    experiment.log_feedback(id="event-id", scores={"score": 1}, metadata=_ModelDumpMetadata(user_id="user-1"))
+
+    logs = with_memory_logger.pop()
+    assert len(logs) == 1
+    assert logs[0][AUDIT_METADATA_FIELD] == {"user_id": "user-1"}
 
 
 def test_span_log_rejects_metadata_with_non_string_keys(with_memory_logger):
@@ -2976,12 +3021,13 @@ def test_update_span_includes_span_id_and_root_span_id_from_export(with_memory_l
 
     with_memory_logger.pop()
 
-    braintrust.update_span(exported=exported, output="updated output")
+    braintrust.update_span(exported=exported, output="updated output", metadata=_ModelDumpMetadata(foo="bar"))
 
     logs = with_memory_logger.pop()
     updated_log = next(log for log in logs if log.get("output") == "updated output")
     assert updated_log["span_id"] == span_id
     assert updated_log["root_span_id"] == root_span_id
+    assert updated_log["metadata"] == {"foo": "bar"}
 
 
 def test_get_exporter_returns_v3_by_default():

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -868,6 +868,15 @@ class _ModelDumpMetadata:
         return dict(self.values)
 
 
+def _init_test_dataset():
+    from braintrust.logger import Dataset, ObjectMetadata, ProjectDatasetMetadata
+
+    project_metadata = ObjectMetadata(id="test_project", name="test_project", full_info={})
+    dataset_metadata = ObjectMetadata(id="test_dataset", name="test_dataset", full_info={})
+    metadata = ProjectDatasetMetadata(project=project_metadata, dataset=dataset_metadata)
+    return Dataset(lazy_metadata=LazyValue(lambda: metadata, use_mutex=False))
+
+
 def test_span_log_accepts_model_dump_metadata(with_memory_logger):
     logger = init_test_logger(__name__)
 
@@ -917,6 +926,26 @@ def test_experiment_log_feedback_accepts_model_dump_metadata(with_memory_logger)
     logs = with_memory_logger.pop()
     assert len(logs) == 1
     assert logs[0][AUDIT_METADATA_FIELD] == {"user_id": "user-1"}
+
+
+def test_dataset_insert_accepts_model_dump_metadata(with_memory_logger):
+    dataset = _init_test_dataset()
+
+    dataset.insert(input="input", expected="expected", metadata=_ModelDumpMetadata(foo="bar"))
+
+    logs = with_memory_logger.pop()
+    assert len(logs) == 1
+    assert logs[0]["metadata"] == {"foo": "bar"}
+
+
+def test_dataset_update_accepts_model_dump_metadata(with_memory_logger):
+    dataset = _init_test_dataset()
+
+    dataset.update(id="record-id", metadata=_ModelDumpMetadata(foo="bar"))
+
+    logs = with_memory_logger.pop()
+    assert len(logs) == 1
+    assert logs[0]["metadata"] == {"foo": "bar"}
 
 
 def test_span_log_rejects_metadata_with_non_string_keys(with_memory_logger):

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -838,6 +838,63 @@ def test_span_log_with_simple_circular_reference(with_memory_logger):
     assert "circular" in logged_output["self"].lower()
 
 
+def test_span_log_accepts_pydantic_model_metadata(with_memory_logger):
+    try:
+        from pydantic import BaseModel
+    except ImportError:
+        pytest.skip("Pydantic not available")
+
+    class MetadataModel(BaseModel):
+        foo: str = "bar"
+
+    logger = init_test_logger(__name__)
+
+    with logger.start_span(name="test_span") as span:
+        span.log(input=MetadataModel(), metadata=MetadataModel())
+
+    logs = with_memory_logger.pop()
+    assert len(logs) == 1
+    assert logs[0]["input"] == {"foo": "bar"}
+    assert logs[0]["metadata"] == {"foo": "bar"}
+
+
+def test_span_log_accepts_model_dump_metadata(with_memory_logger):
+    class MetadataModel:
+        def model_dump(self, **kwargs):
+            assert kwargs == {"exclude_none": True}
+            return {"foo": "bar"}
+
+    logger = init_test_logger(__name__)
+
+    with logger.start_span(name="test_span") as span:
+        span.log(metadata=MetadataModel())
+
+    logs = with_memory_logger.pop()
+    assert len(logs) == 1
+    assert logs[0]["metadata"] == {"foo": "bar"}
+
+
+def test_span_log_rejects_metadata_with_non_string_keys(with_memory_logger):
+    logger = init_test_logger(__name__)
+
+    with logger.start_span(name="test_span") as span:
+        with pytest.raises(ValueError, match="metadata keys must be strings"):
+            span.log(metadata={1: "bad"})
+
+
+def test_span_log_rejects_metadata_that_serializes_to_non_dict(with_memory_logger):
+    class BadMetadata:
+        def model_dump(self, **kwargs):
+            assert kwargs == {"exclude_none": True}
+            return ["not", "metadata"]
+
+    logger = init_test_logger(__name__)
+
+    with logger.start_span(name="test_span") as span:
+        with pytest.raises(ValueError, match="metadata must be a dictionary or serialize to a dictionary"):
+            span.log(metadata=BadMetadata())
+
+
 def test_span_log_with_nested_circular_reference(with_memory_logger):
     """Test that span.log() with nested circular reference works gracefully."""
     logger = init_test_logger(__name__)

--- a/py/src/braintrust/type_tests/test_metadata_types.py
+++ b/py/src/braintrust/type_tests/test_metadata_types.py
@@ -1,0 +1,52 @@
+from collections.abc import Mapping
+from typing import Any
+
+from braintrust.logger import Dataset, Experiment, Logger
+
+
+class PydanticV2Metadata:
+    def model_dump(self, *, exclude_none: bool = False) -> Mapping[str, Any]:
+        assert exclude_none
+        return {"user_id": "user-1"}
+
+
+class PydanticV1Metadata:
+    def dict(self, *, exclude_none: bool = False) -> Mapping[str, Any]:
+        assert exclude_none
+        return {"user_id": "user-1"}
+
+
+def accepts_logger_metadata(logger: Logger) -> None:
+    mapping_metadata: Mapping[str, Any] = {"user_id": "user-1"}
+
+    logger.log(metadata=mapping_metadata)
+    logger.log(metadata=PydanticV2Metadata())
+    logger.log(metadata=PydanticV1Metadata())
+
+    logger.log_feedback(id="event-id", metadata=mapping_metadata)
+    logger.log_feedback(id="event-id", metadata=PydanticV2Metadata())
+    logger.log_feedback(id="event-id", metadata=PydanticV1Metadata())
+
+
+def accepts_experiment_metadata(experiment: Experiment) -> None:
+    mapping_metadata: Mapping[str, Any] = {"user_id": "user-1"}
+
+    experiment.log(metadata=mapping_metadata)
+    experiment.log(metadata=PydanticV2Metadata())
+    experiment.log(metadata=PydanticV1Metadata())
+
+    experiment.log_feedback(id="event-id", metadata=mapping_metadata)
+    experiment.log_feedback(id="event-id", metadata=PydanticV2Metadata())
+    experiment.log_feedback(id="event-id", metadata=PydanticV1Metadata())
+
+
+def accepts_dataset_metadata(dataset: Dataset) -> None:
+    mapping_metadata: Mapping[str, Any] = {"user_id": "user-1"}
+
+    dataset.insert(metadata=mapping_metadata)
+    dataset.insert(metadata=PydanticV2Metadata())
+    dataset.insert(metadata=PydanticV1Metadata())
+
+    dataset.update(id="record-id", metadata=mapping_metadata)
+    dataset.update(id="record-id", metadata=PydanticV2Metadata())
+    dataset.update(id="record-id", metadata=PydanticV1Metadata())

--- a/py/src/braintrust/types/__init__.py
+++ b/py/src/braintrust/types/__init__.py
@@ -2,12 +2,12 @@ from collections.abc import Mapping
 from typing import Any, Protocol, TypeAlias
 
 
-class _PydanticV2Metadata(Protocol):
+class PydanticV2Metadata(Protocol):
     def model_dump(self, *, exclude_none: bool = ...) -> Mapping[str, Any]: ...
 
 
-class _PydanticV1Metadata(Protocol):
+class PydanticV1Metadata(Protocol):
     def dict(self, *, exclude_none: bool = ...) -> Mapping[str, Any]: ...
 
 
-Metadata: TypeAlias = Mapping[str, Any] | _PydanticV2Metadata | _PydanticV1Metadata
+Metadata: TypeAlias = Mapping[str, Any] | PydanticV2Metadata | PydanticV1Metadata

--- a/py/src/braintrust/types/__init__.py
+++ b/py/src/braintrust/types/__init__.py
@@ -1,5 +1,13 @@
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Protocol, TypeAlias
 
 
-Metadata = Mapping[str, Any]
+class _PydanticV2Metadata(Protocol):
+    def model_dump(self, *, exclude_none: bool = ...) -> Mapping[str, Any]: ...
+
+
+class _PydanticV1Metadata(Protocol):
+    def dict(self, *, exclude_none: bool = ...) -> Mapping[str, Any]: ...
+
+
+Metadata: TypeAlias = Mapping[str, Any] | _PydanticV2Metadata | _PydanticV1Metadata


### PR DESCRIPTION
### Description
Run `metadata` through the `bt_safe_deep_copy` before validating it so Pydantic models and other objects that dump to dictionaries can be logged as metadata.
This change covers:
- `Logger.log`
- `Experiment.log`
- `Span.log`
- `Logger.log_feedback`
- `Experiment.log_feedback`
- `update_span`
- `Dataset.__init__`
- `Dataset.insert`
- `Dataset.update`

### Testing
- Added type tests
- Added unit tests for the following:
  - Mocked Pydantic `model_dump` behavior to avoid needing dependency:
    - `span.log`
    - `logger.log`
    - `experiment.log`
    - `logger.log_feedback`
    - `experiment.log_feedback`
    - `dataset.insert`
    - `dataset.update`
  - reject `metadata` with non string keys
  - reject `metadata` that does not serialize into dict
  - test `span.log` with actual pydantic model
- Manually tested the repro script 