### PR TITLE
fix(claude-agent-sdk): improve error logging

### DIFF
--- a/py/src/braintrust/integrations/claude_agent_sdk/_constants.py
+++ b/py/src/braintrust/integrations/claude_agent_sdk/_constants.py
@@ -48,6 +48,7 @@ class MCPToolMetadataValues:
 DEFAULT_TOOL_NAME: Final[str] = "unknown"
 
 CLAUDE_AGENT_TASK_SPAN_NAME: Final[str] = "Claude Agent"
+CLAUDE_AGENT_RUN_FAILED_ERROR: Final[str] = "Claude Agent run failed"
 ANTHROPIC_MESSAGES_CREATE_SPAN_NAME: Final[str] = "anthropic.messages.create"
 
 MCP_TOOL_PREFIX: Final[str] = "mcp__"

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/0.1.10/test_agent_error_logged_on_spans.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/0.1.10/test_agent_error_logged_on_spans.json
@@ -1,0 +1,181 @@
+{
+  "cassette_name": "test_agent_error_logged_on_spans",
+  "events": [
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "request": {
+            "hooks": null,
+            "subtype": "initialize"
+          },
+          "request_id": "req_1_50f779aa",
+          "type": "control_request"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "response": {
+          "request_id": "req_1_50f779aa",
+          "response": {
+            "account": {
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "tokenSource": "none"
+            },
+            "available_output_styles": [],
+            "commands": [],
+            "models": []
+          },
+          "subtype": "success"
+        },
+        "type": "control_response"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "Say hi",
+            "role": "user"
+          },
+          "parent_tool_use_id": null,
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "agents": [
+          "general-purpose",
+          "statusline-setup",
+          "Explore",
+          "Plan"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.0.53",
+        "cwd": "<REDACTED_CWD>",
+        "mcp_servers": [],
+        "model": "claude-3-5-haiku-20241022",
+        "output_style": "default",
+        "permissionMode": "bypassPermissions",
+        "plugins": [],
+        "session_id": "eb8c581c-6a47-4841-9feb-3cd73cf6196e",
+        "skills": [],
+        "slash_commands": [
+          "compact",
+          "context",
+          "cost",
+          "init",
+          "pr-comments",
+          "release-notes",
+          "todos",
+          "review",
+          "security-review"
+        ],
+        "subtype": "init",
+        "tools": [
+          "Task",
+          "Bash",
+          "Glob",
+          "Grep",
+          "ExitPlanMode",
+          "Read",
+          "Edit",
+          "Write",
+          "NotebookEdit",
+          "WebFetch",
+          "TodoWrite",
+          "WebSearch",
+          "BashOutput",
+          "KillShell",
+          "Skill",
+          "SlashCommand",
+          "EnterPlanMode"
+        ],
+        "type": "system",
+        "uuid": "b3b234b1-788c-4d9a-8314-0f1ee6954022"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "error": "unknown",
+        "message": {
+          "container": null,
+          "content": [
+            {
+              "text": "API Error: 404 {\"type\":\"error\",\"error\":{\"type\":\"not_found_error\",\"message\":\"model: claude-3-5-haiku-20241022\"},\"request_id\":\"req_011Ca7oFHun4K1hs2Nq6Gk9T\"}",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "06842473-7288-4727-98de-2ff655ae857d",
+          "model": "<synthetic>",
+          "role": "assistant",
+          "stop_reason": "stop_sequence",
+          "stop_sequence": "",
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 0
+            },
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "server_tool_use": {
+              "web_fetch_requests": 0,
+              "web_search_requests": 0
+            },
+            "service_tier": null
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "eb8c581c-6a47-4841-9feb-3cd73cf6196e",
+        "type": "assistant",
+        "uuid": "c9571b2d-a75b-43f7-9aea-1f2c3ce85084"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "duration_api_ms": 0,
+        "duration_ms": 632,
+        "is_error": true,
+        "modelUsage": {},
+        "num_turns": 1,
+        "permission_denials": [],
+        "result": "API Error: 404 {\"type\":\"error\",\"error\":{\"type\":\"not_found_error\",\"message\":\"model: claude-3-5-haiku-20241022\"},\"request_id\":\"req_011Ca7oFHun4K1hs2Nq6Gk9T\"}",
+        "session_id": "eb8c581c-6a47-4841-9feb-3cd73cf6196e",
+        "subtype": "success",
+        "total_cost_usd": 0,
+        "type": "result",
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 0
+          },
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "input_tokens": 0,
+          "output_tokens": 0,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0
+          },
+          "service_tier": "standard"
+        },
+        "uuid": "8f56a573-2839-4c94-8b4d-74ab58de9c3d"
+      }
+    }
+  ],
+  "sdk_version": "0.1.10"
+}

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_agent_error_logged_on_spans.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_agent_error_logged_on_spans.json
@@ -1,0 +1,317 @@
+{
+  "cassette_name": "test_agent_error_logged_on_spans",
+  "events": [
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "request": {
+            "hooks": null,
+            "subtype": "initialize"
+          },
+          "request_id": "req_1_9dfd30e4",
+          "type": "control_request"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "response": {
+          "request_id": "req_1_9dfd30e4",
+          "response": {
+            "account": {
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "apiProvider": "firstParty",
+              "tokenSource": "none"
+            },
+            "agents": [],
+            "available_output_styles": [],
+            "commands": [],
+            "models": []
+          },
+          "subtype": "success"
+        },
+        "type": "control_response"
+      }
+    },
+    {
+      "op": "write",
+      "payload": {
+        "kind": "json",
+        "value": {
+          "message": {
+            "content": "Say hi",
+            "role": "user"
+          },
+          "parent_tool_use_id": null,
+          "session_id": "default",
+          "type": "user"
+        }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "agents": [
+          "claude",
+          "Explore",
+          "general-purpose",
+          "Plan",
+          "statusline-setup"
+        ],
+        "analytics_disabled": false,
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.142",
+        "cwd": "<REDACTED_CWD>",
+        "fast_mode_state": "off",
+        "mcp_servers": [
+          {
+            "name": "braintrust",
+            "status": "connected"
+          },
+          {
+            "name": "linear-server",
+            "status": "connected"
+          }
+        ],
+        "memory_paths": {
+          "auto": "<REDACTED_PATH>"
+        },
+        "model": "claude-3-5-haiku-20241022",
+        "output_style": "default",
+        "permissionMode": "bypassPermissions",
+        "plugins": [
+          {
+            "name": "rust-analyzer-lsp",
+            "path": "<REDACTED_PATH>",
+            "source": "rust-analyzer-lsp@claude-plugins-official"
+          }
+        ],
+        "session_id": "9b6e89c4-cb08-4bf9-8c49-6fa98e532202",
+        "skills": [
+          "create-braintrust-demo",
+          "braintrust",
+          "sdk-dependency-updates",
+          "sdk-integrations",
+          "sdk-vcr-workflows",
+          "sdk-ci-triage",
+          "commit-message",
+          "sdk-benchmarking",
+          "update-config",
+          "debug",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "loop",
+          "claude-api"
+        ],
+        "slash_commands": [
+          "create-braintrust-demo",
+          "braintrust",
+          "sdk-dependency-updates",
+          "sdk-integrations",
+          "sdk-vcr-workflows",
+          "sdk-ci-triage",
+          "commit-message",
+          "sdk-benchmarking",
+          "update-config",
+          "debug",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "loop",
+          "claude-api",
+          "clear",
+          "compact",
+          "context",
+          "heapdump",
+          "init",
+          "review",
+          "security-review",
+          "usage",
+          "insights",
+          "goal",
+          "team-onboarding"
+        ],
+        "subtype": "init",
+        "tools": [
+          "Task",
+          "AskUserQuestion",
+          "Bash",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "Edit",
+          "EnterPlanMode",
+          "EnterWorktree",
+          "ExitPlanMode",
+          "ExitWorktree",
+          "Glob",
+          "Grep",
+          "ListMcpResourcesTool",
+          "LSP",
+          "Monitor",
+          "NotebookEdit",
+          "PushNotification",
+          "Read",
+          "ReadMcpResourceTool",
+          "ScheduleWakeup",
+          "Skill",
+          "TaskCreate",
+          "TaskGet",
+          "TaskList",
+          "TaskOutput",
+          "TaskStop",
+          "TaskUpdate",
+          "ToolSearch",
+          "WebFetch",
+          "WebSearch",
+          "Write",
+          "mcp__braintrust__generate_permalink",
+          "mcp__braintrust__infer_schema",
+          "mcp__braintrust__list_recent_objects",
+          "mcp__braintrust__resolve_object",
+          "mcp__braintrust__search_docs",
+          "mcp__braintrust__sql_query",
+          "mcp__braintrust__summarize_experiment",
+          "mcp__linear-server__create_attachment",
+          "mcp__linear-server__create_attachment_from_upload",
+          "mcp__linear-server__create_issue_label",
+          "mcp__linear-server__delete_attachment",
+          "mcp__linear-server__delete_comment",
+          "mcp__linear-server__delete_customer",
+          "mcp__linear-server__delete_customer_need",
+          "mcp__linear-server__delete_status_update",
+          "mcp__linear-server__extract_images",
+          "mcp__linear-server__get_attachment",
+          "mcp__linear-server__get_diff",
+          "mcp__linear-server__get_diff_threads",
+          "mcp__linear-server__get_document",
+          "mcp__linear-server__get_initiative",
+          "mcp__linear-server__get_issue",
+          "mcp__linear-server__get_issue_status",
+          "mcp__linear-server__get_milestone",
+          "mcp__linear-server__get_project",
+          "mcp__linear-server__get_status_updates",
+          "mcp__linear-server__get_team",
+          "mcp__linear-server__get_user",
+          "mcp__linear-server__list_comments",
+          "mcp__linear-server__list_customers",
+          "mcp__linear-server__list_cycles",
+          "mcp__linear-server__list_diffs",
+          "mcp__linear-server__list_documents",
+          "mcp__linear-server__list_initiatives",
+          "mcp__linear-server__list_issue_labels",
+          "mcp__linear-server__list_issue_statuses",
+          "mcp__linear-server__list_issues",
+          "mcp__linear-server__list_milestones",
+          "mcp__linear-server__list_project_labels",
+          "mcp__linear-server__list_projects",
+          "mcp__linear-server__list_teams",
+          "mcp__linear-server__list_users",
+          "mcp__linear-server__prepare_attachment_upload",
+          "mcp__linear-server__save_comment",
+          "mcp__linear-server__save_customer",
+          "mcp__linear-server__save_customer_need",
+          "mcp__linear-server__save_document",
+          "mcp__linear-server__save_initiative",
+          "mcp__linear-server__save_issue",
+          "mcp__linear-server__save_milestone",
+          "mcp__linear-server__save_project",
+          "mcp__linear-server__save_status_update",
+          "mcp__linear-server__search_documentation"
+        ],
+        "type": "system",
+        "uuid": "c9a781dd-6500-4e83-9cbd-1c1310bfc83e"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "error": "invalid_request",
+        "message": {
+          "container": null,
+          "content": [
+            {
+              "text": "There's an issue with the selected model (claude-3-5-haiku-20241022). It may not exist or you may not have access to it. Run --model to pick a different model.",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "id": "6ed07d52-6b92-417c-8f89-4b63a8da364e",
+          "model": "<synthetic>",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": "stop_sequence",
+          "stop_sequence": "",
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 0
+            },
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "inference_geo": null,
+            "input_tokens": 0,
+            "iterations": null,
+            "output_tokens": 0,
+            "server_tool_use": {
+              "web_fetch_requests": 0,
+              "web_search_requests": 0
+            },
+            "service_tier": null,
+            "speed": null
+          }
+        },
+        "parent_tool_use_id": null,
+        "request_id": "req_011CbC7pFUgYd4TsT5eWnmaZ",
+        "session_id": "9b6e89c4-cb08-4bf9-8c49-6fa98e532202",
+        "type": "assistant",
+        "uuid": "90886438-cc93-4fb4-a96a-7a73870e55b4"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "api_error_status": 404,
+        "duration_api_ms": 0,
+        "duration_ms": 492,
+        "fast_mode_state": "off",
+        "is_error": true,
+        "modelUsage": {},
+        "num_turns": 1,
+        "permission_denials": [],
+        "result": "There's an issue with the selected model (claude-3-5-haiku-20241022). It may not exist or you may not have access to it. Run --model to pick a different model.",
+        "session_id": "9b6e89c4-cb08-4bf9-8c49-6fa98e532202",
+        "stop_reason": "stop_sequence",
+        "subtype": "success",
+        "terminal_reason": "completed",
+        "total_cost_usd": 0,
+        "type": "result",
+        "usage": {
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 0
+          },
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "inference_geo": "",
+          "input_tokens": 0,
+          "iterations": [],
+          "output_tokens": 0,
+          "server_tool_use": {
+            "web_fetch_requests": 0,
+            "web_search_requests": 0
+          },
+          "service_tier": "standard",
+          "speed": "standard"
+        },
+        "uuid": "05876312-f52b-4522-ba4b-950a3f992122"
+      }
+    }
+  ],
+  "sdk_version": "0.2.82"
+}

--- a/py/src/braintrust/integrations/claude_agent_sdk/test_claude_agent_sdk.py
+++ b/py/src/braintrust/integrations/claude_agent_sdk/test_claude_agent_sdk.py
@@ -351,7 +351,7 @@ async def test_agent_error_logged_on_spans(memory_logger):
             permission_mode="bypassPermissions",
         )
         transport = make_cassette_transport(
-            cassette_name="test_auto_claude_agent_sdk",
+            cassette_name="test_agent_error_logged_on_spans",
             prompt="",
             options=options,
         )

--- a/py/src/braintrust/integrations/claude_agent_sdk/test_claude_agent_sdk.py
+++ b/py/src/braintrust/integrations/claude_agent_sdk/test_claude_agent_sdk.py
@@ -341,6 +341,60 @@ async def test_query_async_iterable(memory_logger, cassette_name, input_factory,
 
 @pytest.mark.skipif(not CLAUDE_SDK_AVAILABLE, reason="Claude Agent SDK not installed")
 @pytest.mark.asyncio
+async def test_agent_error_logged_on_spans(memory_logger):
+    """AssistantMessage.error propagates to the LLM span; ResultMessage.is_error to the root span."""
+    assert not memory_logger.pop()
+
+    with _patched_claude_sdk(wrap_client=True):
+        options = claude_agent_sdk.ClaudeAgentOptions(
+            model="claude-3-5-haiku-20241022",
+            permission_mode="bypassPermissions",
+        )
+        transport = make_cassette_transport(
+            cassette_name="test_auto_claude_agent_sdk",
+            prompt="",
+            options=options,
+        )
+
+        assistant_error: Any = None
+        result_message: Any = None
+        async with claude_agent_sdk.ClaudeSDKClient(options=options, transport=transport) as client:
+            await client.query("Say hi")
+            async for message in client.receive_response():
+                message_type = type(message).__name__
+                if message_type == "AssistantMessage" and assistant_error is None:
+                    assistant_error = getattr(message, "error", None)
+                if message_type == "ResultMessage":
+                    result_message = message
+                    break
+
+    assert result_message is not None and getattr(result_message, "is_error", False) is True, (
+        "Cassette must include a ResultMessage with is_error=True"
+    )
+
+    spans = memory_logger.pop()
+    task_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.TASK), "Claude Agent")
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
+
+    root_error = task_span.get("error")
+    assert root_error, f"Root task span should log error when ResultMessage.is_error=True; got error={root_error!r}"
+    expected_result = getattr(result_message, "result", None)
+    if isinstance(expected_result, str) and expected_result:
+        assert expected_result == root_error, (
+            f"Root span error should match ResultMessage.result; expected {expected_result!r}, got {root_error!r}"
+        )
+
+    # claude-agent-sdk 0.1.10 doesn't parse the top-level `error` field onto AssistantMessage.
+    if assistant_error:
+        assert llm_spans, "Expected at least one LLM span"
+        llm_errors = [span.get("error") for span in llm_spans if span.get("error")]
+        assert llm_errors, (
+            f"At least one LLM span should log error when AssistantMessage.error is set; got llm spans: {llm_spans!r}"
+        )
+
+
+@pytest.mark.skipif(not CLAUDE_SDK_AVAILABLE, reason="Claude Agent SDK not installed")
+@pytest.mark.asyncio
 async def test_user_prompt_submit_hook_creates_function_span(memory_logger):
     assert not memory_logger.pop()
     prompt = "Say hello in one short sentence."

--- a/py/src/braintrust/integrations/claude_agent_sdk/tracing.py
+++ b/py/src/braintrust/integrations/claude_agent_sdk/tracing.py
@@ -10,6 +10,7 @@ from typing import Any
 from braintrust.integrations.anthropic._utils import Wrapper, extract_anthropic_usage
 from braintrust.integrations.claude_agent_sdk._constants import (
     ANTHROPIC_MESSAGES_CREATE_SPAN_NAME,
+    CLAUDE_AGENT_RUN_FAILED_ERROR,
     CLAUDE_AGENT_TASK_SPAN_NAME,
     DEFAULT_TOOL_NAME,
     MCP_TOOL_METADATA,
@@ -697,6 +698,10 @@ class ContextTracker:
         parent_export = self._llm_parent_for_message(message)
         final_content, extended = self._start_or_merge_llm_span(message, parent_export, ctx)
 
+        message_error = getattr(message, "error", None)
+        if message_error and ctx.llm_span is not None:
+            ctx.llm_span.log(error=str(message_error))
+
         llm_export = ctx.llm_span.export() if ctx.llm_span else None
         self._tool_tracker.start_tool_spans(message, llm_export)
 
@@ -746,6 +751,12 @@ class ContextTracker:
         }
         if result_metadata:
             self._root_span.log(metadata=result_metadata)
+
+        if getattr(message, "is_error", None) is True:
+            error_text = (
+                result_value if isinstance(result_value, str) and result_value else CLAUDE_AGENT_RUN_FAILED_ERROR
+            )
+            self._root_span.log(error=error_text)
 
     def _handle_system(self, message: Any) -> None:
         agent_span_export = self._tool_tracker.get_span_export(_msg_field(message, "tool_use_id"))


### PR DESCRIPTION
Closes https://github.com/braintrustdata/braintrust-sdk-python/issues/149

Failed agent runs and assistant-side errors now surface on the root task span and the LLM span instead of being silently dropped.