### PR TITLE
Use local pinned action check

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -26,12 +26,11 @@ jobs:
           mise exec -- pre-commit run --from-ref origin/${{ github.base_ref || 'main' }} --to-ref HEAD
 
   ensure-pinned-actions:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Ensure SHA pinned actions
-        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@70c4af2ed5282c51ba40566d026d6647852ffa3e # v5.0.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - run: bash scripts/ensure-pinned-actions.sh
 
   static_checks:
     runs-on: ubuntu-24.04

--- a/scripts/ensure-pinned-actions.sh
+++ b/scripts/ensure-pinned-actions.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify every action reference in .github/workflows/ is pinned to a full commit SHA.
+# A pinned ref looks like: uses: owner/action@<40 hex chars>
+# Tags (@v4, @main) are rejected — they are mutable and can be hijacked.
+
+unpinned=$(grep -rn --include="*.yml" --include="*.yaml" -E 'uses:\s+\S+@' .github/ \
+  | grep -vE '@[a-f0-9]{40}(\s|$|#)' || true)
+
+if [ -n "$unpinned" ]; then
+  echo "ERROR: unpinned action(s) found — use a full commit SHA instead of a tag or branch:"
+  echo "$unpinned"
+  exit 1
+fi
+
+echo "OK: all actions are pinned to commit SHAs."


### PR DESCRIPTION
Rather than use a 3rd part Github Action, let's use a simple script to do the pinned action check.