### PR TITLE
test(adk): refresh google-adk 2.1 cassettes

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -395,8 +395,8 @@ latest = "crewai==1.14.5"
 "1.13.0" = "crewai==1.13.0"
 
 [tool.braintrust.matrix.google-adk]
-latest = "google-adk==1.33.0"
-"1.14.1" = "google-adk==1.14.1"
+latest = "google-adk[mcp]==2.1.0"
+"1.14.1" = "google-adk[mcp]==1.14.1"
 
 [tool.braintrust.matrix.langchain-core]
 latest = "langchain-core==1.4.0"

--- a/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_agent_metadata_with_attachment.yaml
+++ b/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_agent_metadata_with_attachment.yaml
@@ -4,15 +4,26 @@ interactions:
       "user"}], "systemInstruction": {"parts": [{"text": "You are a helpful assistant
       with tools.\n\nYou are an agent. Your internal name is \"tool_agent\"."}], "role":
       "user"}, "tools": [{"functionDeclarations": [{"description": "A simple tool.",
-      "name": "simple_tool", "parameters": {"properties": {"query": {"type": "STRING"}},
-      "required": ["query"], "type": "OBJECT"}}]}], "generationConfig": {}}'
+      "name": "simple_tool", "parameters_json_schema": {"properties": {"query": {"title":
+      "Query", "type": "string"}}, "required": ["query"], "title": "simple_toolParams",
+      "type": "object"}}]}], "generationConfig": {}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '531'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
@@ -22,25 +33,23 @@ interactions:
         \             \"args\": {\n                \"query\": \"test\"\n              }\n
         \           }\n          }\n        ],\n        \"role\": \"model\"\n      },\n
         \     \"finishReason\": \"STOP\",\n      \"avgLogprobs\": -0.00010093948803842067\n
-        \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 41,\n    \"candidatesTokenCount\":
-        5,\n    \"totalTokenCount\": 46,\n    \"promptTokensDetails\": [\n      {\n
-        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 41\n      }\n    ],\n
+        \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 37,\n    \"candidatesTokenCount\":
+        5,\n    \"totalTokenCount\": 42,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 37\n      }\n    ],\n
         \   \"candidatesTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
         \       \"tokenCount\": 5\n      }\n    ],\n    \"serviceTier\": \"standard\"\n
-        \ },\n  \"modelVersion\": \"gemini-2.0-flash\",\n  \"responseId\": \"rPMBasaUM4WN_PUPldbV0Qc\"\n}\n"
+        \ },\n  \"modelVersion\": \"gemini-2.0-flash\",\n  \"responseId\": \"luYVapCjEaet1MkPsfqGqQ0\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:13 GMT
+      - Tue, 26 May 2026 18:29:43 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=633
+      - gfet4t7; dur=861
       Transfer-Encoding:
       - chunked
       Vary:
@@ -55,6 +64,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '808'
     status:
       code: 200
       message: OK
@@ -65,16 +76,27 @@ interactions:
       {"result": "Processed: test"}}}], "role": "user"}], "systemInstruction": {"parts":
       [{"text": "You are a helpful assistant with tools.\n\nYou are an agent. Your
       internal name is \"tool_agent\"."}], "role": "user"}, "tools": [{"functionDeclarations":
-      [{"description": "A simple tool.", "name": "simple_tool", "parameters": {"properties":
-      {"query": {"type": "STRING"}}, "required": ["query"], "type": "OBJECT"}}]}],
-      "generationConfig": {}}'
+      [{"description": "A simple tool.", "name": "simple_tool", "parameters_json_schema":
+      {"properties": {"query": {"title": "Query", "type": "string"}}, "required":
+      ["query"], "title": "simple_toolParams", "type": "object"}}]}], "generationConfig":
+      {}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '750'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
@@ -82,26 +104,24 @@ interactions:
       string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
         [\n          {\n            \"text\": \"Processed: test\\n\"\n          }\n
         \       ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
-        \"STOP\",\n      \"avgLogprobs\": -0.04451884329319\n    }\n  ],\n  \"usageMetadata\":
-        {\n    \"promptTokenCount\": 53,\n    \"candidatesTokenCount\": 4,\n    \"totalTokenCount\":
-        57,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
-        \       \"tokenCount\": 53\n      }\n    ],\n    \"candidatesTokensDetails\":
+        \"STOP\",\n      \"avgLogprobs\": -0.45421317219734192\n    }\n  ],\n  \"usageMetadata\":
+        {\n    \"promptTokenCount\": 49,\n    \"candidatesTokenCount\": 4,\n    \"totalTokenCount\":
+        53,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 49\n      }\n    ],\n    \"candidatesTokensDetails\":
         [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 4\n      }\n
         \   ],\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.0-flash\",\n
-        \ \"responseId\": \"rfMBaveKJLLj_uMP_K264Qo\"\n}\n"
+        \ \"responseId\": \"l-YVavP3EI2O1MkPw9KzYA\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:14 GMT
+      - Tue, 26 May 2026 18:29:43 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=563
+      - gfet4t7; dur=583
       Transfer-Encoding:
       - chunked
       Vary:
@@ -116,6 +136,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '691'
     status:
       code: 200
       message: OK

--- a/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_binary_data_attachment_conversion.yaml
+++ b/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_binary_data_attachment_conversion.yaml
@@ -6,12 +6,22 @@ interactions:
       analyze images.\n\nYou are an agent. Your internal name is \"vision_agent\"."}],
       "role": "user"}, "generationConfig": {"maxOutputTokens": 150}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '464'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
@@ -19,27 +29,25 @@ interactions:
       string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
         [\n          {\n            \"text\": \"The image is red.\"\n          }\n
         \       ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
-        \"STOP\",\n      \"avgLogprobs\": -0.011378899961709977\n    }\n  ],\n  \"usageMetadata\":
+        \"STOP\",\n      \"avgLogprobs\": -0.012568791210651398\n    }\n  ],\n  \"usageMetadata\":
         {\n    \"promptTokenCount\": 289,\n    \"candidatesTokenCount\": 5,\n    \"totalTokenCount\":
         294,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"IMAGE\",\n
         \       \"tokenCount\": 258\n      },\n      {\n        \"modality\": \"TEXT\",\n
         \       \"tokenCount\": 31\n      }\n    ],\n    \"candidatesTokensDetails\":
         [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 5\n      }\n
         \   ],\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.0-flash\",\n
-        \ \"responseId\": \"p_MBat-hIu6c_uMPnp-boAc\"\n}\n"
+        \ \"responseId\": \"j-YVav7-K-jV1MkPn7TI-QY\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:08 GMT
+      - Tue, 26 May 2026 18:29:36 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=939
+      - gfet4t7; dur=1041
       Transfer-Encoding:
       - chunked
       Vary:
@@ -54,6 +62,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '767'
     status:
       code: 200
       message: OK

--- a/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_braintrust_integration.yaml
+++ b/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_braintrust_integration.yaml
@@ -5,15 +5,26 @@ interactions:
       weather assistant. Use the get_weather tool to answer questions about weather.\n\nYou
       are an agent. Your internal name is \"weather_agent\"."}], "role": "user"},
       "tools": [{"functionDeclarations": [{"description": "Get the weather for a location.",
-      "name": "get_weather", "parameters": {"properties": {"location": {"type": "STRING"}},
-      "required": ["location"], "type": "OBJECT"}}]}], "generationConfig": {}}'
+      "name": "get_weather", "parameters_json_schema": {"properties": {"location":
+      {"title": "Location", "type": "string"}}, "required": ["location"], "title":
+      "get_weatherParams", "type": "object"}}]}], "generationConfig": {}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '624'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
@@ -23,26 +34,24 @@ interactions:
         \             \"args\": {\n                \"location\": \"San Francisco\"\n
         \             }\n            }\n          }\n        ],\n        \"role\":
         \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"avgLogprobs\":
-        1.1747082074483235e-06\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
-        57,\n    \"candidatesTokenCount\": 6,\n    \"totalTokenCount\": 63,\n    \"promptTokensDetails\":
-        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 57\n
+        1.6122163894275825e-06\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        53,\n    \"candidatesTokenCount\": 6,\n    \"totalTokenCount\": 59,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 53\n
         \     }\n    ],\n    \"candidatesTokensDetails\": [\n      {\n        \"modality\":
         \"TEXT\",\n        \"tokenCount\": 6\n      }\n    ],\n    \"serviceTier\":
         \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.0-flash\",\n  \"responseId\":
-        \"o_MBatyPH7mM_PUP5cSkyAs\"\n}\n"
+        \"i-YVaqHvDZmy1MkPwpCl-Qw\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:04 GMT
+      - Tue, 26 May 2026 18:29:31 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=616
+      - gfet4t7; dur=586
       Transfer-Encoding:
       - chunked
       Vary:
@@ -57,6 +66,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '819'
     status:
       code: 200
       message: OK
@@ -70,43 +81,52 @@ interactions:
       weather assistant. Use the get_weather tool to answer questions about weather.\n\nYou
       are an agent. Your internal name is \"weather_agent\"."}], "role": "user"},
       "tools": [{"functionDeclarations": [{"description": "Get the weather for a location.",
-      "name": "get_weather", "parameters": {"properties": {"location": {"type": "STRING"}},
-      "required": ["location"], "type": "OBJECT"}}]}], "generationConfig": {}}'
+      "name": "get_weather", "parameters_json_schema": {"properties": {"location":
+      {"title": "Location", "type": "string"}}, "required": ["location"], "title":
+      "get_weatherParams", "type": "object"}}]}], "generationConfig": {}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '944'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
     body:
       string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
         [\n          {\n            \"text\": \"The weather in San Francisco is sunny
-        with a temperature of 72\xB0F, 45% humidity, and 5 mph NW winds.\"\n          }\n
-        \       ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
-        \"STOP\",\n      \"avgLogprobs\": -0.019228482246398927\n    }\n  ],\n  \"usageMetadata\":
-        {\n    \"promptTokenCount\": 84,\n    \"candidatesTokenCount\": 30,\n    \"totalTokenCount\":
-        114,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
-        \       \"tokenCount\": 84\n      }\n    ],\n    \"candidatesTokensDetails\":
-        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 30\n
-        \     }\n    ],\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\":
-        \"gemini-2.0-flash\",\n  \"responseId\": \"pPMBavmIFfSd_uMP9--LsAc\"\n}\n"
+        with a temperature of 72\xB0F, humidity of 45%, and wind blowing from the
+        NW at 5 mph.\"\n          }\n        ],\n        \"role\": \"model\"\n      },\n
+        \     \"finishReason\": \"STOP\",\n      \"avgLogprobs\": -0.086359802414389217\n
+        \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 80,\n    \"candidatesTokenCount\":
+        34,\n    \"totalTokenCount\": 114,\n    \"promptTokensDetails\": [\n      {\n
+        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 80\n      }\n    ],\n
+        \   \"candidatesTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 34\n      }\n    ],\n    \"serviceTier\": \"standard\"\n
+        \ },\n  \"modelVersion\": \"gemini-2.0-flash\",\n  \"responseId\": \"jOYVatKDAvyb9MoP5crX4A0\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:04 GMT
+      - Tue, 26 May 2026 18:29:32 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=652
+      - gfet4t7; dur=658
       Transfer-Encoding:
       - chunked
       Vary:
@@ -121,6 +141,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '801'
     status:
       code: 200
       message: OK

--- a/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_captures_metrics.yaml
+++ b/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_captures_metrics.yaml
@@ -5,39 +5,47 @@ interactions:
       are an agent. Your internal name is \"metrics_agent\"."}], "role": "user"},
       "generationConfig": {}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '255'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
     body:
       string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
-        [\n          {\n            \"text\": \"Hello, how can I help?\\n\"\n          }\n
+        [\n          {\n            \"text\": \"Hello, how can I assist?\\n\"\n          }\n
         \       ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
-        \"STOP\",\n      \"avgLogprobs\": -0.092875339090824127\n    }\n  ],\n  \"usageMetadata\":
+        \"STOP\",\n      \"avgLogprobs\": -0.091088362038135529\n    }\n  ],\n  \"usageMetadata\":
         {\n    \"promptTokenCount\": 27,\n    \"candidatesTokenCount\": 8,\n    \"totalTokenCount\":
         35,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
         \       \"tokenCount\": 27\n      }\n    ],\n    \"candidatesTokensDetails\":
         [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 8\n      }\n
         \   ],\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.0-flash\",\n
-        \ \"responseId\": \"qPMBaoePKLq9_uMPvf3UkQU\"\n}\n"
+        \ \"responseId\": \"kOYVapOwO_SZ9MoPlMH_4Aw\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:09 GMT
+      - Tue, 26 May 2026 18:29:37 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=542
+      - gfet4t7; dur=602
       Transfer-Encoding:
       - chunked
       Vary:
@@ -52,6 +60,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '702'
     status:
       code: 200
       message: OK

--- a/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_complex_nested_schema.yaml
+++ b/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_complex_nested_schema.yaml
@@ -15,12 +15,22 @@ interactions:
       ["name", "age", "address"], "required": ["name", "age", "address"], "title":
       "Person", "type": "OBJECT"}}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1078'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
@@ -30,26 +40,24 @@ interactions:
         \ \\\"age\\\": 30,\\n  \\\"address\\\": {\\n    \\\"street\\\": \\\"Rue de
         Rivoli\\\",\\n    \\\"city\\\": \\\"Paris\\\",\\n    \\\"country\\\": \\\"France\\\"\\n
         \ }\\n}\"\n          }\n        ],\n        \"role\": \"model\"\n      },\n
-        \     \"finishReason\": \"STOP\",\n      \"avgLogprobs\": -0.02110424212047032\n
+        \     \"finishReason\": \"STOP\",\n      \"avgLogprobs\": -0.048483529261180332\n
         \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 81,\n    \"candidatesTokenCount\":
         56,\n    \"totalTokenCount\": 137,\n    \"promptTokensDetails\": [\n      {\n
         \       \"modality\": \"TEXT\",\n        \"tokenCount\": 81\n      }\n    ],\n
         \   \"candidatesTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
         \       \"tokenCount\": 56\n      }\n    ],\n    \"serviceTier\": \"standard\"\n
-        \ },\n  \"modelVersion\": \"gemini-2.0-flash\",\n  \"responseId\": \"qvMBap3xNrLj_uMP_K264Qo\"\n}\n"
+        \ },\n  \"modelVersion\": \"gemini-2.0-flash\",\n  \"responseId\": \"lOYVat7dB7O11MkPktGXkAQ\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:11 GMT
+      - Tue, 26 May 2026 18:29:40 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=826
+      - gfet4t7; dur=872
       Transfer-Encoding:
       - chunked
       Vary:
@@ -64,6 +72,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '837'
     status:
       code: 200
       message: OK

--- a/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_input_schema_serialization.yaml
+++ b/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_input_schema_serialization.yaml
@@ -1,43 +1,56 @@
 interactions:
 - request:
-    body: '{"contents": [{"parts": [{"text": "Hello"}], "role": "user"}], "systemInstruction":
-      {"parts": [{"text": "You are a test agent with input schema.\n\nYou are an agent.
-      Your internal name is \"input_schema_agent\"."}], "role": "user"}, "generationConfig":
-      {}}'
+    body: '{"contents": [{"parts": [{"text": "{\"name\":\"Alice\",\"age\":30}"}],
+      "role": "user"}], "systemInstruction": {"parts": [{"text": "You are a test agent
+      with input schema.\n\nYou are an agent. Your internal name is \"input_schema_agent\"."}],
+      "role": "user"}, "generationConfig": {}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '282'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
     body:
       string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
-        [\n          {\n            \"text\": \"Hello! How can I help you today?\\n\"\n
-        \         }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
-        \"STOP\",\n      \"avgLogprobs\": -0.0064555145800113678\n    }\n  ],\n  \"usageMetadata\":
-        {\n    \"promptTokenCount\": 27,\n    \"candidatesTokenCount\": 10,\n    \"totalTokenCount\":
-        37,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
-        \       \"tokenCount\": 27\n      }\n    ],\n    \"candidatesTokensDetails\":
-        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 10\n
-        \     }\n    ],\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\":
-        \"gemini-2.0-flash\",\n  \"responseId\": \"qvMBaoCTCsud_uMPuNbRmAc\"\n}\n"
+        [\n          {\n            \"text\": \"Okay, I have received the following
+        input:\\n\\n*   **Name:** Alice\\n*   **Age:** 30\\n\\nIs there anything I
+        should do with this information? For example, should I:\\n\\n*   Store this
+        information?\\n*   Use it to answer a question?\\n*   Generate a new piece
+        of information based on it?\\n*   Forward it to another agent or system?\\n\\nPlease
+        provide further instructions.\\n\"\n          }\n        ],\n        \"role\":
+        \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"avgLogprobs\":
+        -0.19191286298963758\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        36,\n    \"candidatesTokenCount\": 90,\n    \"totalTokenCount\": 126,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 36\n
+        \     }\n    ],\n    \"candidatesTokensDetails\": [\n      {\n        \"modality\":
+        \"TEXT\",\n        \"tokenCount\": 90\n      }\n    ],\n    \"serviceTier\":
+        \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.0-flash\",\n  \"responseId\":
+        \"kuYVasTFJ6Gn1MkPrPqFwA0\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:10 GMT
+      - Tue, 26 May 2026 18:29:39 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=595
+      - gfet4t7; dur=1360
       Transfer-Encoding:
       - chunked
       Vary:
@@ -52,6 +65,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '1044'
     status:
       code: 200
       message: OK

--- a/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_max_tokens_captures_content.yaml
+++ b/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_max_tokens_captures_content.yaml
@@ -6,41 +6,50 @@ interactions:
       "role": "user"}, "generationConfig": {"temperature": 0.7, "maxOutputTokens":
       50}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '320'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
     body:
       string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
-        [\n          {\n            \"text\": \"Okay, settle in. This is the story
-        of the Azure Beacon, a lighthouse that stood sentinel on the jagged, windswept
-        point of Cormorant's Kiss for over two centuries. It's a story of storms and
-        shipwrecks\"\n          }\n        ],\n        \"role\": \"model\"\n      },\n
-        \     \"finishReason\": \"MAX_TOKENS\",\n      \"avgLogprobs\": -0.40688674926757812\n
-        \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 30,\n    \"candidatesTokenCount\":
-        50,\n    \"totalTokenCount\": 80,\n    \"promptTokensDetails\": [\n      {\n
-        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 30\n      }\n    ],\n
-        \   \"candidatesTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
-        \       \"tokenCount\": 50\n      }\n    ],\n    \"serviceTier\": \"standard\"\n
-        \ },\n  \"modelVersion\": \"gemini-2.0-flash\",\n  \"responseId\": \"pvMBapzIIuiu_PUP9Z6_2As\"\n}\n"
+        [\n          {\n            \"text\": \"Alright, settle in, because this is
+        the tale of the Widow\u2019s Watch Lighthouse, and it\u2019s a story that
+        stretches across generations, whispered on the salt-laced winds of the North
+        Atlantic.\\n\\nIt begins, as many such stories\"\n          }\n        ],\n
+        \       \"role\": \"model\"\n      },\n      \"finishReason\": \"MAX_TOKENS\",\n
+        \     \"avgLogprobs\": -0.47878131866455076\n    }\n  ],\n  \"usageMetadata\":
+        {\n    \"promptTokenCount\": 30,\n    \"candidatesTokenCount\": 50,\n    \"totalTokenCount\":
+        80,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 30\n      }\n    ],\n    \"candidatesTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 50\n
+        \     }\n    ],\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\":
+        \"gemini-2.0-flash\",\n  \"responseId\": \"juYVaurSFcCs1MkP2-PswA0\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:07 GMT
+      - Tue, 26 May 2026 18:29:35 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=820
+      - gfet4t7; dur=1229
       Transfer-Encoding:
       - chunked
       Vary:
@@ -55,6 +64,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '908'
     status:
       code: 200
       message: OK

--- a/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_multi_turn_history_is_logged.yaml
+++ b/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_multi_turn_history_is_logged.yaml
@@ -6,12 +6,22 @@ interactions:
       it, answer with just the name.\n\nYou are an agent. Your internal name is \"conversation_agent\"."}],
       "role": "user"}, "generationConfig": {}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '374'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
@@ -25,20 +35,18 @@ interactions:
         \       \"tokenCount\": 52\n      }\n    ],\n    \"candidatesTokensDetails\":
         [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 5\n      }\n
         \   ],\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.0-flash\",\n
-        \ \"responseId\": \"oPMBatekKYS-_uMP3prgwAg\"\n}\n"
+        \ \"responseId\": \"iOYVaqmMBLav1MkPs9CY-QM\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:01 GMT
+      - Tue, 26 May 2026 18:29:28 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=486
+      - gfet4t7; dur=478
       Transfer-Encoding:
       - chunked
       Vary:
@@ -53,6 +61,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '690'
     status:
       code: 200
       message: OK
@@ -65,12 +75,22 @@ interactions:
       are an agent. Your internal name is \"conversation_agent\"."}], "role": "user"},
       "generationConfig": {}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '500'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
@@ -84,20 +104,18 @@ interactions:
         \       \"tokenCount\": 64\n      }\n    ],\n    \"candidatesTokensDetails\":
         [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 3\n      }\n
         \   ],\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.0-flash\",\n
-        \ \"responseId\": \"ofMBasXGEua3_uMPhO2b2Qo\"\n}\n"
+        \ \"responseId\": \"iOYVasbDKYTB1MkP4L_-iAM\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:01 GMT
+      - Tue, 26 May 2026 18:29:29 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=568
+      - gfet4t7; dur=843
       Transfer-Encoding:
       - chunked
       Vary:
@@ -112,6 +130,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '682'
     status:
       code: 200
       message: OK

--- a/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_nested_subagent_tool_calls_are_traced.yaml
+++ b/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_nested_subagent_tool_calls_are_traced.yaml
@@ -5,15 +5,26 @@ interactions:
       weather assistant. Use the get_weather tool to answer questions about weather.\n\nYou
       are an agent. Your internal name is \"weather_agent\"."}], "role": "user"},
       "tools": [{"functionDeclarations": [{"description": "Get the weather for a location.",
-      "name": "get_weather", "parameters": {"properties": {"location": {"type": "STRING"}},
-      "required": ["location"], "type": "OBJECT"}}]}], "generationConfig": {}}'
+      "name": "get_weather", "parameters_json_schema": {"properties": {"location":
+      {"title": "Location", "type": "string"}}, "required": ["location"], "title":
+      "get_weatherParams", "type": "object"}}]}], "generationConfig": {}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '624'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
@@ -23,26 +34,24 @@ interactions:
         \             \"args\": {\n                \"location\": \"San Francisco\"\n
         \             }\n            }\n          }\n        ],\n        \"role\":
         \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"avgLogprobs\":
-        1.6122163894275825e-06\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
-        57,\n    \"candidatesTokenCount\": 6,\n    \"totalTokenCount\": 63,\n    \"promptTokensDetails\":
-        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 57\n
+        1.1747082074483235e-06\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        53,\n    \"candidatesTokenCount\": 6,\n    \"totalTokenCount\": 59,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 53\n
         \     }\n    ],\n    \"candidatesTokensDetails\": [\n      {\n        \"modality\":
         \"TEXT\",\n        \"tokenCount\": 6\n      }\n    ],\n    \"serviceTier\":
         \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.0-flash\",\n  \"responseId\":
-        \"pfMBaomECPze_uMP5vDKmAQ\"\n}\n"
+        \"jOYVaq79Mpmy1MkPwpCl-Qw\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:05 GMT
+      - Tue, 26 May 2026 18:29:33 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=556
+      - gfet4t7; dur=624
       Transfer-Encoding:
       - chunked
       Vary:
@@ -57,6 +66,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '819'
     status:
       code: 200
       message: OK
@@ -69,16 +80,27 @@ interactions:
       {"parts": [{"text": "You are a helpful weather assistant. Use the get_weather
       tool to answer questions about weather.\n\nYou are an agent. Your internal name
       is \"weather_agent\"."}], "role": "user"}, "tools": [{"functionDeclarations":
-      [{"description": "Get the weather for a location.", "name": "get_weather", "parameters":
-      {"properties": {"location": {"type": "STRING"}}, "required": ["location"], "type":
-      "OBJECT"}}]}], "generationConfig": {}}'
+      [{"description": "Get the weather for a location.", "name": "get_weather", "parameters_json_schema":
+      {"properties": {"location": {"title": "Location", "type": "string"}}, "required":
+      ["location"], "title": "get_weatherParams", "type": "object"}}]}], "generationConfig":
+      {}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '905'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
@@ -88,25 +110,23 @@ interactions:
         with a temperature of 72\xB0F.\\n\"\n          }\n        ],\n        \"role\":
         \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"avgLogprobs\":
         -0.0043557501501507228\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
-        76,\n    \"candidatesTokenCount\": 18,\n    \"totalTokenCount\": 94,\n    \"promptTokensDetails\":
-        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 76\n
+        72,\n    \"candidatesTokenCount\": 18,\n    \"totalTokenCount\": 90,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 72\n
         \     }\n    ],\n    \"candidatesTokensDetails\": [\n      {\n        \"modality\":
         \"TEXT\",\n        \"tokenCount\": 18\n      }\n    ],\n    \"serviceTier\":
         \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.0-flash\",\n  \"responseId\":
-        \"pfMBap7BM-iu_PUP9Z6_2As\"\n}\n"
+        \"jeYVatekJteb9MoP1NLVAQ\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:06 GMT
+      - Tue, 26 May 2026 18:29:34 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=582
+      - gfet4t7; dur=528
       Transfer-Encoding:
       - chunked
       Vary:
@@ -121,6 +141,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '746'
     status:
       code: 200
       message: OK

--- a/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_response_json_schema_dict.yaml
+++ b/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_response_json_schema_dict.yaml
@@ -9,12 +9,22 @@ interactions:
       "Population of the city", "minimum": 0}, "country": {"type": "string", "description":
       "Country where the city is located"}}, "required": ["city", "country"]}}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '647'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
@@ -29,20 +39,18 @@ interactions:
         \       \"tokenCount\": 30\n      }\n    ],\n    \"candidatesTokensDetails\":
         [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 33\n
         \     }\n    ],\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\":
-        \"gemini-2.0-flash\",\n  \"responseId\": \"q_MBavKIN4C3_uMP-cnpwQs\"\n}\n"
+        \"gemini-2.0-flash\",\n  \"responseId\": \"leYVaq-OCuii1MkP7rbB0Qw\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:12 GMT
+      - Tue, 26 May 2026 18:29:42 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=784
+      - gfet4t7; dur=968
       Transfer-Encoding:
       - chunked
       Vary:
@@ -57,6 +65,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '761'
     status:
       code: 200
       message: OK

--- a/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_structured_output_pydantic.yaml
+++ b/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_structured_output_pydantic.yaml
@@ -9,12 +9,22 @@ interactions:
       "The capital of the country.", "title": "Capital", "type": "STRING"}}, "required":
       ["capital"], "title": "CapitalOutput", "type": "OBJECT"}}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '626'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
@@ -22,26 +32,24 @@ interactions:
       string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
         [\n          {\n            \"text\": \"{\\n  \\\"capital\\\": \\\"Paris\\\"\\n}\"\n
         \         }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
-        \"STOP\",\n      \"avgLogprobs\": -0.094380367885936386\n    }\n  ],\n  \"usageMetadata\":
+        \"STOP\",\n      \"avgLogprobs\": -0.27874890240755951\n    }\n  ],\n  \"usageMetadata\":
         {\n    \"promptTokenCount\": 66,\n    \"candidatesTokenCount\": 11,\n    \"totalTokenCount\":
         77,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
         \       \"tokenCount\": 66\n      }\n    ],\n    \"candidatesTokensDetails\":
         [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 11\n
         \     }\n    ],\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\":
-        \"gemini-2.0-flash\",\n  \"responseId\": \"qfMBapivFoS2_uMPypu9kQI\"\n}\n"
+        \"gemini-2.0-flash\",\n  \"responseId\": \"keYVapruLLO11MkPktGXkAQ\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:09 GMT
+      - Tue, 26 May 2026 18:29:38 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=597
+      - gfet4t7; dur=788
       Transfer-Encoding:
       - chunked
       Vary:
@@ -56,6 +64,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '707'
     status:
       code: 200
       message: OK

--- a/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_sync_runner_run_does_not_duplicate_invocation_spans.yaml
+++ b/py/src/braintrust/integrations/adk/cassettes/latest/test_adk_sync_runner_run_does_not_duplicate_invocation_spans.yaml
@@ -5,15 +5,26 @@ interactions:
       weather assistant. Use the get_weather tool to answer questions about weather.\n\nYou
       are an agent. Your internal name is \"weather_agent\"."}], "role": "user"},
       "tools": [{"functionDeclarations": [{"description": "Get the weather for a location.",
-      "name": "get_weather", "parameters": {"properties": {"location": {"type": "STRING"}},
-      "required": ["location"], "type": "OBJECT"}}]}], "generationConfig": {}}'
+      "name": "get_weather", "parameters_json_schema": {"properties": {"location":
+      {"title": "Location", "type": "string"}}, "required": ["location"], "title":
+      "get_weatherParams", "type": "object"}}]}], "generationConfig": {}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '624'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
@@ -23,26 +34,24 @@ interactions:
         \             \"args\": {\n                \"location\": \"San Francisco\"\n
         \             }\n            }\n          }\n        ],\n        \"role\":
         \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"avgLogprobs\":
-        1.1747082074483235e-06\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
-        57,\n    \"candidatesTokenCount\": 6,\n    \"totalTokenCount\": 63,\n    \"promptTokensDetails\":
-        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 57\n
+        1.6122163894275825e-06\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        53,\n    \"candidatesTokenCount\": 6,\n    \"totalTokenCount\": 59,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 53\n
         \     }\n    ],\n    \"candidatesTokensDetails\": [\n      {\n        \"modality\":
         \"TEXT\",\n        \"tokenCount\": 6\n      }\n    ],\n    \"serviceTier\":
         \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.0-flash\",\n  \"responseId\":
-        \"ovMBaurfAYXP_uMP14WP0QQ\"\n}\n"
+        \"ieYVapnhKtSj1MkPjI2ZiA4\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:02 GMT
+      - Tue, 26 May 2026 18:29:30 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=529
+      - gfet4t7; dur=599
       Transfer-Encoding:
       - chunked
       Vary:
@@ -57,6 +66,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '819'
     status:
       code: 200
       message: OK
@@ -70,15 +81,26 @@ interactions:
       weather assistant. Use the get_weather tool to answer questions about weather.\n\nYou
       are an agent. Your internal name is \"weather_agent\"."}], "role": "user"},
       "tools": [{"functionDeclarations": [{"description": "Get the weather for a location.",
-      "name": "get_weather", "parameters": {"properties": {"location": {"type": "STRING"}},
-      "required": ["location"], "type": "OBJECT"}}]}], "generationConfig": {}}'
+      "name": "get_weather", "parameters_json_schema": {"properties": {"location":
+      {"title": "Location", "type": "string"}}, "required": ["location"], "title":
+      "get_weatherParams", "type": "object"}}]}], "generationConfig": {}}'
     headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '944'
       Content-Type:
       - application/json
+      Host:
+      - generativelanguage.googleapis.com
       user-agent:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
       x-goog-api-client:
-      - google-genai-sdk/1.75.0 gl-python/3.12.12 google-adk/1.33.0 gl-python/3.12.12
+      - google-genai-sdk/1.75.0 gl-python/3.14.3 google-adk/2.1.0 gl-python/3.14.3
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
@@ -88,25 +110,23 @@ interactions:
         with a temperature of 72\xB0F. The humidity is 45% and the wind is 5 mph NW.\"\n
         \         }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
         \"STOP\",\n      \"avgLogprobs\": -0.012199996095715147\n    }\n  ],\n  \"usageMetadata\":
-        {\n    \"promptTokenCount\": 84,\n    \"candidatesTokenCount\": 33,\n    \"totalTokenCount\":
-        117,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
-        \       \"tokenCount\": 84\n      }\n    ],\n    \"candidatesTokensDetails\":
+        {\n    \"promptTokenCount\": 80,\n    \"candidatesTokenCount\": 33,\n    \"totalTokenCount\":
+        113,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
+        \       \"tokenCount\": 80\n      }\n    ],\n    \"candidatesTokensDetails\":
         [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 33\n
         \     }\n    ],\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\":
-        \"gemini-2.0-flash\",\n  \"responseId\": \"ovMBauz3K7jL_uMP6fmsqAE\"\n}\n"
+        \"gemini-2.0-flash\",\n  \"responseId\": \"iuYVaqv8GJWX1MkPgajbqQc\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Encoding:
-      - gzip
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 11 May 2026 15:20:03 GMT
+      - Tue, 26 May 2026 18:29:30 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=646
+      - gfet4t7; dur=642
       Transfer-Encoding:
       - chunked
       Vary:
@@ -121,6 +141,8 @@ interactions:
       - standard
       X-XSS-Protection:
       - '0'
+      content-length:
+      - '791'
     status:
       code: 200
       message: OK

--- a/py/src/braintrust/integrations/adk/test_adk.py
+++ b/py/src/braintrust/integrations/adk/test_adk.py
@@ -44,6 +44,7 @@ def vcr_config():
             "x-goog-api-key",
         ],
         "before_record_request": before_record_request,
+        "decode_compressed_response": True,
     }
 
 
@@ -1275,7 +1276,7 @@ async def test_adk_input_schema_serialization(memory_logger):
 
     runner = Runner(agent=agent, app_name=APP_NAME, session_service=session_service)
 
-    user_msg = types.Content(role="user", parts=[types.Part(text="Hello")])
+    user_msg = types.Content(role="user", parts=[types.Part(text='{"name":"Alice","age":30}')])
 
     responses = []
     async for event in runner.run_async(user_id=USER_ID, session_id=SESSION_ID, new_message=user_msg):
@@ -1299,7 +1300,7 @@ async def test_adk_input_schema_serialization(memory_logger):
         "contents": [
             {
                 "role": "user",
-                "parts": [{"text": "Hello"}],
+                "parts": [{"text": '{"name":"Alice","age":30}'}],
             }
         ],
         "config": {

--- a/py/src/braintrust/integrations/adk/test_adk_mcp_tool.py
+++ b/py/src/braintrust/integrations/adk/test_adk_mcp_tool.py
@@ -157,13 +157,11 @@ async def test_setup_adk_patches_mcp_tool():
     result = setup_adk(project_name="test")
     assert result is True
 
-    # Verify McpTool got patched (if available)
-    try:
-        from braintrust.integrations.adk.patchers import McpToolPatcher
+    # Verify McpTool got patched. The google-adk nox matrix installs the
+    # optional MCP extra so this integration surface stays covered.
+    from braintrust.integrations.adk.patchers import McpToolPatcher
 
-        assert McpToolPatcher.is_patched(None, None), "McpTool should be patched"
-    except ImportError:
-        pass  # MCP is optional
+    assert McpToolPatcher.is_patched(None, None), "McpTool should be patched"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk-python/issues/463

Install the ADK MCP extra in the provider matrix so MCP tracing stays covered, update the input_schema cassette scenario for ADK 2.x validation, and decode compressed VCR responses to avoid httpx replay errors.

Re-record latest ADK cassettes and validate with nox -s "test_google_adk(latest)".