### PR TITLE
feat(bedrock): trace bedrock runtime calls

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -62,6 +62,7 @@ Unless noted otherwise, every example below uses `braintrust.auto_instrument()`.
 | `agno/` | Agno agents and teams, sync + async, streaming + non-streaming |
 | `anthropic/` | Sync and async Anthropic clients |
 | `autogen/` | AutoGen `AssistantAgent` backed by `OpenAIChatCompletionClient` |
+| `bedrock_runtime/` | boto3 Bedrock Runtime `converse()` call against Amazon Nova Lite |
 | `claude_agent_sdk/` | Claude Agent SDK subprocess query |
 | `cohere/` | Cohere `ClientV2` chat call |
 | `crewai/` | CrewAI `Agent` + `Task` + `Crew` end-to-end |

--- a/examples/bedrock_runtime/README.md
+++ b/examples/bedrock_runtime/README.md
@@ -1,0 +1,25 @@
+# AWS Bedrock + Braintrust
+
+Calls `braintrust.auto_instrument()` to patch boto3's Bedrock Runtime client factory, then runs a single `client.converse(...)` call against Amazon Nova Lite. The trace captures a parent `answer_question` span plus a child `bedrock.converse` LLM span with input, output, metadata, and token metrics.
+
+## Run
+
+```bash
+export BRAINTRUST_API_KEY=...
+export AWS_BEARER_TOKEN_BEDROCK=...
+export AWS_REGION=us-east-1
+export AWS_DEFAULT_REGION=us-east-1
+
+uv sync
+uv run python example.py
+```
+
+If you use IAM credentials instead of a Bedrock API key, set the usual AWS variables instead:
+
+```bash
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_SESSION_TOKEN=... # if using temporary credentials
+```
+
+The default model is `us.amazon.nova-lite-v1:0`. Override it with `BRAINTRUST_BEDROCK_MODEL` if needed.

--- a/examples/bedrock_runtime/example.py
+++ b/examples/bedrock_runtime/example.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""boto3 Bedrock Runtime client traced via braintrust.auto_instrument()."""
+
+import os
+
+import braintrust
+
+
+braintrust.auto_instrument()
+braintrust.init_logger(project="example-bedrock")
+
+import boto3  # noqa: E402
+
+
+MODEL = os.getenv("BRAINTRUST_BEDROCK_MODEL", "us.amazon.nova-lite-v1:0")
+REGION = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "us-east-1"
+
+
+@braintrust.traced
+def answer_question(question: str) -> str:
+    client = boto3.client("bedrock-runtime", region_name=REGION)
+    response = client.converse(
+        modelId=MODEL,
+        messages=[{"role": "user", "content": [{"text": question}]}],
+        inferenceConfig={"maxTokens": 64, "temperature": 0},
+    )
+    message = response["output"]["message"]
+    return "".join(block.get("text", "") for block in message.get("content", []))
+
+
+def main() -> None:
+    answer = answer_question("What is the capital of Australia? Reply in one sentence.")
+    print(answer)
+    braintrust.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/bedrock_runtime/pyproject.toml
+++ b/examples/bedrock_runtime/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "braintrust-bedrock-example"
+version = "0.1.0"
+description = "boto3 Bedrock Runtime client traced with Braintrust"
+requires-python = ">=3.10"
+dependencies = [
+    "braintrust",
+    "boto3",
+]
+
+[tool.uv.sources]
+braintrust = { path = "../../py", editable = true }

--- a/py/noxfile.py
+++ b/py/noxfile.py
@@ -230,6 +230,19 @@ def test_cohere(session, version):
     _run_tests(session, f"{INTEGRATION_DIR}/cohere/test_cohere.py", version=version)
 
 
+BOTO3_VERSIONS = _get_matrix_versions("boto3")
+
+
+@nox.session()
+@nox.parametrize("version", BOTO3_VERSIONS, ids=BOTO3_VERSIONS)
+def test_bedrock_runtime(session, version):
+    """Test the boto3 Bedrock Runtime integration."""
+    _install_test_deps(session)
+    _install_matrix_dep(session, "boto3", version)
+    _install_matrix_dep(session, "botocore", version)
+    _run_tests(session, f"{INTEGRATION_DIR}/bedrock_runtime/test_bedrock_runtime.py", version=version)
+
+
 INSTRUCTOR_VERSIONS = _get_matrix_versions("instructor")
 
 

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -438,6 +438,14 @@ latest = "pytest==9.0.3"
 [tool.braintrust.matrix.braintrust-core]
 latest = "braintrust-core==0.0.59"
 
+[tool.braintrust.matrix.boto3]
+latest = "boto3==1.43.29"
+"1.34.116" = "boto3==1.34.116"
+
+[tool.braintrust.matrix.botocore]
+latest = "botocore==1.43.29"
+"1.34.116" = "botocore==1.34.116"
+
 # ---------------------------------------------------------------------------
 # Vendor packages — optional third-party packages the SDK can work without.
 # Keys are matrix keys; values are Python import names.  The noxfile uses this
@@ -461,6 +469,7 @@ agentscope = ["agentscope"]
 agno = ["agno"]
 autogen = ["autogen-agentchat"]
 anthropic = ["anthropic"]
+bedrock_runtime = ["boto3", "botocore"]
 cohere = ["cohere"]
 claude_agent_sdk = ["claude-agent-sdk"]
 crewai = ["crewai"]
@@ -488,6 +497,8 @@ anthropic = "anthropic"
 cohere = "cohere"
 autoevals = "autoevals"
 braintrust-core = "braintrust_core"
+boto3 = "boto3"
+botocore = "botocore"
 crewai = "crewai"
 dspy = "dspy"
 google-adk = "google.adk"

--- a/py/src/braintrust/auto.py
+++ b/py/src/braintrust/auto.py
@@ -13,6 +13,7 @@ from braintrust.integrations import (
     AgnoIntegration,
     AnthropicIntegration,
     AutoGenIntegration,
+    BedrockRuntimeIntegration,
     ClaudeAgentSDKIntegration,
     CohereIntegration,
     CrewAIIntegration,
@@ -72,6 +73,7 @@ def auto_instrument(
     openai_agents: bool = True,
     cohere: bool = True,
     autogen: bool = True,
+    bedrock: bool = True,
     crewai: bool = True,
     strands: bool = True,
     temporal: bool = True,
@@ -106,6 +108,7 @@ def auto_instrument(
         openai_agents: Enable OpenAI Agents SDK instrumentation (default: True)
         cohere: Enable Cohere instrumentation (default: True)
         autogen: Enable AutoGen instrumentation (default: True)
+        bedrock: Enable boto3 Bedrock Runtime instrumentation (default: True)
         crewai: Enable CrewAI instrumentation (default: True)
         strands: Enable Strands Agents instrumentation (default: True)
         temporal: Enable Temporal instrumentation (default: True)
@@ -195,6 +198,8 @@ def auto_instrument(
         results["cohere"] = _instrument_integration(CohereIntegration)
     if autogen:
         results["autogen"] = _instrument_integration(AutoGenIntegration)
+    if bedrock:
+        results["bedrock_runtime"] = _instrument_integration(BedrockRuntimeIntegration)
     if crewai:
         results["crewai"] = _instrument_integration(CrewAIIntegration)
     if strands:

--- a/py/src/braintrust/conftest.py
+++ b/py/src/braintrust/conftest.py
@@ -247,6 +247,12 @@ def get_vcr_config():
             "openai-api-key",
             "x-goog-api-key",
             "x-bt-auth-token",
+            "x-amz-security-token",
+            "x-amz-date",
+            "x-amz-content-sha256",
+            "amz-sdk-invocation-id",
+            "amz-sdk-request",
+            "x-amzn-bedrock-api-key",
         ],
     }
 

--- a/py/src/braintrust/integrations/__init__.py
+++ b/py/src/braintrust/integrations/__init__.py
@@ -3,6 +3,7 @@ from .agentscope import AgentScopeIntegration
 from .agno import AgnoIntegration
 from .anthropic import AnthropicIntegration
 from .autogen import AutoGenIntegration
+from .bedrock_runtime import BedrockRuntimeIntegration
 from .claude_agent_sdk import ClaudeAgentSDKIntegration
 from .cohere import CohereIntegration
 from .crewai import CrewAIIntegration
@@ -29,6 +30,7 @@ __all__ = [
     "AgnoIntegration",
     "AnthropicIntegration",
     "AutoGenIntegration",
+    "BedrockRuntimeIntegration",
     "ClaudeAgentSDKIntegration",
     "CohereIntegration",
     "CrewAIIntegration",

--- a/py/src/braintrust/integrations/auto_test_scripts/test_auto_bedrock_runtime.py
+++ b/py/src/braintrust/integrations/auto_test_scripts/test_auto_bedrock_runtime.py
@@ -1,0 +1,43 @@
+"""Test auto_instrument for boto3 Bedrock Runtime."""
+
+import os
+
+
+os.environ.setdefault("AWS_EC2_METADATA_DISABLED", "true")
+if not os.environ.get("AWS_PROFILE") and not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+    os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+    os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+    os.environ.setdefault("AWS_SESSION_TOKEN", "testing")
+
+import boto3
+from braintrust.auto import auto_instrument
+from braintrust.integrations.test_utils import autoinstrument_test_context
+
+
+MODEL = os.getenv("BRAINTRUST_BEDROCK_CONVERSE_MODEL", "us.amazon.nova-lite-v1:0")
+REGION = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "us-east-1"
+
+results = auto_instrument()
+assert results.get("bedrock_runtime") is True
+
+results2 = auto_instrument()
+assert results2.get("bedrock_runtime") is True
+
+with autoinstrument_test_context("test_auto_bedrock_runtime", integration="bedrock_runtime") as memory_logger:
+    client = boto3.client("bedrock-runtime", region_name=REGION)
+    response = client.converse(
+        modelId=MODEL,
+        messages=[{"role": "user", "content": [{"text": "Say hello in one word."}]}],
+        inferenceConfig={"maxTokens": 20, "temperature": 0},
+    )
+    assert response["output"]["message"]["role"] == "assistant"
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1, f"Expected 1 span, got {len(spans)}"
+    span = spans[0]
+    assert span["metadata"]["provider"] == "bedrock"
+    assert span["metadata"]["model"] == MODEL
+    assert span["metadata"]["endpoint"] == "converse"
+    assert span["span_attributes"]["name"] == "bedrock.converse"
+
+print("SUCCESS")

--- a/py/src/braintrust/integrations/bedrock_runtime/__init__.py
+++ b/py/src/braintrust/integrations/bedrock_runtime/__init__.py
@@ -1,0 +1,17 @@
+"""Public entry points for the boto3 Bedrock Runtime integration."""
+
+from .integration import BedrockRuntimeIntegration
+from .patchers import wrap_bedrock_client
+
+
+__all__ = ["BedrockRuntimeIntegration", "setup_bedrock", "wrap_bedrock"]
+
+
+def setup_bedrock() -> bool:
+    """Patch botocore client creation to auto-wrap Bedrock Runtime clients."""
+    return BedrockRuntimeIntegration.setup()
+
+
+def wrap_bedrock(client):
+    """Instrument a boto3 Bedrock Runtime client instance in place."""
+    return wrap_bedrock_client(client)

--- a/py/src/braintrust/integrations/bedrock_runtime/cassettes/1.34.116/test_auto_bedrock_runtime.yaml
+++ b/py/src/braintrust/integrations/bedrock_runtime/cassettes/1.34.116/test_auto_bedrock_runtime.yaml
@@ -1,0 +1,35 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "Say hello in one word."}]}],
+      "inferenceConfig": {"maxTokens": 20, "temperature": 0}}'
+    headers:
+      Content-Length:
+      - '137'
+      Content-Type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS40My4yOSBtZC9Cb3RvY29yZSMxLjQzLjI5IHVhLzIuMSBvcy9tYWNvcyMyNS41LjAg
+        bWQvYXJjaCNhcm02NCBsYW5nL3B5dGhvbiMzLjE0LjMgbWQvcHlpbXBsI0NQeXRob24gbS9aLGIs
+        RCwzIGNmZy9yZXRyeS1tb2RlI2xlZ2FjeSBCb3RvY29yZS8xLjQzLjI5
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.amazon.nova-lite-v1%3A0/converse
+  response:
+    body:
+      string: '{"metrics":{"latencyMs":511},"output":{"message":{"content":[{"text":"Hi."}],"role":"assistant"}},"stopReason":"end_turn","usage":{"inputTokens":6,"outputTokens":3,"serverToolUsage":{},"totalTokens":9}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '202'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 15 Jun 2026 20:24:03 GMT
+      x-amzn-RequestId:
+      - caa9fd4f-69d2-459b-baf5-0ad888a79845
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/bedrock_runtime/cassettes/1.34.116/test_setup_bedrock_converse_auto_wraps_new_clients.yaml
+++ b/py/src/braintrust/integrations/bedrock_runtime/cassettes/1.34.116/test_setup_bedrock_converse_auto_wraps_new_clients.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: '{"system": [{"text": "You answer with concise lowercase text."}], "messages":
+      [{"role": "user", "content": [{"text": "Say hello in one word."}]}], "inferenceConfig":
+      {"maxTokens": 20, "temperature": 0, "topP": 0.9, "stopSequences": ["STOP"]}}'
+    headers:
+      Content-Length:
+      - '242'
+      Content-Type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS40My4yOSBtZC9Cb3RvY29yZSMxLjQzLjI5IHVhLzIuMSBvcy9tYWNvcyMyNS41LjAg
+        bWQvYXJjaCNhcm02NCBsYW5nL3B5dGhvbiMzLjE0LjMgbWQvcHlpbXBsI0NQeXRob24gbS9iLDMs
+        WixEIGNmZy9yZXRyeS1tb2RlI2xlZ2FjeSBCb3RvY29yZS8xLjQzLjI5
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.amazon.nova-lite-v1%3A0/converse
+  response:
+    body:
+      string: '{"metrics":{"latencyMs":613},"output":{"message":{"content":[{"text":"hi"}],"role":"assistant"}},"stopReason":"end_turn","usage":{"inputTokens":13,"outputTokens":2,"serverToolUsage":{},"totalTokens":15}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '203'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 15 Jun 2026 20:24:01 GMT
+      x-amzn-RequestId:
+      - 7c3bdcc8-1124-46b5-982e-3ced2d1a5371
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/bedrock_runtime/cassettes/1.34.116/test_wrap_bedrock_converse.yaml
+++ b/py/src/braintrust/integrations/bedrock_runtime/cassettes/1.34.116/test_wrap_bedrock_converse.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: '{"system": [{"text": "You answer with concise lowercase text."}], "messages":
+      [{"role": "user", "content": [{"text": "Say hello in one word."}]}], "inferenceConfig":
+      {"maxTokens": 20, "temperature": 0, "topP": 0.9, "stopSequences": ["STOP"]}}'
+    headers:
+      Content-Length:
+      - '242'
+      Content-Type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS40My4yOSBtZC9Cb3RvY29yZSMxLjQzLjI5IHVhLzIuMSBvcy9tYWNvcyMyNS41LjAg
+        bWQvYXJjaCNhcm02NCBsYW5nL3B5dGhvbiMzLjE0LjMgbWQvcHlpbXBsI0NQeXRob24gbS9iLDMs
+        WixEIGNmZy9yZXRyeS1tb2RlI2xlZ2FjeSBCb3RvY29yZS8xLjQzLjI5
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.amazon.nova-lite-v1%3A0/converse
+  response:
+    body:
+      string: '{"metrics":{"latencyMs":486},"output":{"message":{"content":[{"text":"hi"}],"role":"assistant"}},"stopReason":"end_turn","usage":{"inputTokens":13,"outputTokens":2,"serverToolUsage":{},"totalTokens":15}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '203'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 15 Jun 2026 20:24:00 GMT
+      x-amzn-RequestId:
+      - 1935727d-5309-4a70-8c15-1ce0ffbe877e
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/bedrock_runtime/cassettes/1.34.116/test_wrap_bedrock_converse_stream.yaml
+++ b/py/src/braintrust/integrations/bedrock_runtime/cassettes/1.34.116/test_wrap_bedrock_converse_stream.yaml
@@ -1,0 +1,57 @@
+interactions:
+- request:
+    body: '{"system": [{"text": "You answer with concise lowercase text."}], "messages":
+      [{"role": "user", "content": [{"text": "Say hello in one word."}]}], "inferenceConfig":
+      {"maxTokens": 20, "temperature": 0, "topP": 0.9, "stopSequences": ["STOP"]}}'
+    headers:
+      Content-Length:
+      - '242'
+      Content-Type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS40My4yOSBtZC9Cb3RvY29yZSMxLjQzLjI5IHVhLzIuMSBvcy9tYWNvcyMyNS41LjAg
+        bWQvYXJjaCNhcm02NCBsYW5nL3B5dGhvbiMzLjE0LjMgbWQvcHlpbXBsI0NQeXRob24gbS9iLDMs
+        WixEIGNmZy9yZXRyeS1tb2RlI2xlZ2FjeSBCb3RvY29yZS8xLjQzLjI5
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.amazon.nova-lite-v1%3A0/converse-stream
+  response:
+    body:
+      string: !!binary |
+        AAAAqQAAAFKdcBJWCzpldmVudC10eXBlBwAMbWVzc2FnZVN0YXJ0DTpjb250ZW50LXR5cGUHABBh
+        cHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsicCI6ImFiY2RlZmdoaWprbG1u
+        b3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSIiwicm9sZSI6ImFzc2lzdGFudCJ9gLQCXgAA
+        ALgAAABXsJpY6ws6ZXZlbnQtdHlwZQcAEWNvbnRlbnRCbG9ja0RlbHRhDTpjb250ZW50LXR5cGUH
+        ABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiY29udGVudEJsb2NrSW5k
+        ZXgiOjAsImRlbHRhIjp7InRleHQiOiJoaSJ9LCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4
+        eXpBQkMifWTl2tgAAADLAAAAVw7owvQLOmV2ZW50LXR5cGUHABFjb250ZW50QmxvY2tEZWx0YQ06
+        Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImNv
+        bnRlbnRCbG9ja0luZGV4IjowLCJkZWx0YSI6eyJ0ZXh0IjoiIn0sInAiOiJhYmNkZWZnaGlqa2xt
+        bm9wcXJzdHV2d3h5ekFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWCJ9wcJyhwAAAJIAAABWTOxf2As6
+        ZXZlbnQtdHlwZQcAEGNvbnRlbnRCbG9ja1N0b3ANOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9u
+        L2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwicCI6ImFi
+        Y2RlZmdoaWprbG1uIn0+qWA7AAAAvQAAAFGRGXKuCzpldmVudC10eXBlBwALbWVzc2FnZVN0b3AN
+        OmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJw
+        IjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjAx
+        MjM0NTY3Iiwic3RvcFJlYXNvbiI6ImVuZF90dXJuIn2lawg0AAAA/AAAAE55gg6iCzpldmVudC10
+        eXBlBwAIbWV0YWRhdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2Ut
+        dHlwZQcABWV2ZW50eyJtZXRyaWNzIjp7ImxhdGVuY3lNcyI6ODE1fSwicCI6ImFiY2RlZmdoaWpr
+        bG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU4iLCJ1c2FnZSI6eyJpbnB1dFRva2VucyI6MTMs
+        Im91dHB1dFRva2VucyI6Miwic2VydmVyVG9vbFVzYWdlIjp7fSwidG90YWxUb2tlbnMiOjE1fX1A
+        ORUO
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/vnd.amazon.eventstream
+      Date:
+      - Mon, 15 Jun 2026 20:24:02 GMT
+      Transfer-Encoding:
+      - chunked
+      x-amzn-RequestId:
+      - 80d9cf51-9c72-4526-a7dd-b595a1a4916a
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/bedrock_runtime/cassettes/1.34.116/test_wrap_bedrock_invoke_model_preserves_response_body_and_logs_json.yaml
+++ b/py/src/braintrust/integrations/bedrock_runtime/cassettes/1.34.116/test_wrap_bedrock_invoke_model_preserves_response_body_and_logs_json.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "Say hello in one word."}]}],
+      "inferenceConfig": {"max_new_tokens": 20, "temperature": 0}}'
+    headers:
+      Accept:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+      Content-Length:
+      - '142'
+      Content-Type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS40My4yOSBtZC9Cb3RvY29yZSMxLjQzLjI5IHVhLzIuMSBvcy9tYWNvcyMyNS41LjAg
+        bWQvYXJjaCNhcm02NCBsYW5nL3B5dGhvbiMzLjE0LjMgbWQvcHlpbXBsI0NQeXRob24gbS9iLDMs
+        WixEIGNmZy9yZXRyeS1tb2RlI2xlZ2FjeSBCb3RvY29yZS8xLjQzLjI5
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.amazon.nova-lite-v1%3A0/invoke
+  response:
+    body:
+      string: '{"output":{"message":{"content":[{"text":"Hi."}],"role":"assistant"}},"stopReason":"end_turn","usage":{"inputTokens":6,"outputTokens":3,"totalTokens":9,"cacheReadInputTokenCount":0,"cacheWriteInputTokenCount":0}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '212'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 15 Jun 2026 20:24:02 GMT
+      X-Amzn-Bedrock-Cache-Read-Input-Token-Count:
+      - '0'
+      X-Amzn-Bedrock-Cache-Write-Input-Token-Count:
+      - '0'
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '6'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '545'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '3'
+      x-amzn-RequestId:
+      - 36f35389-456b-4a25-b07c-5a9c83164dc1
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/bedrock_runtime/cassettes/latest/test_auto_bedrock_runtime.yaml
+++ b/py/src/braintrust/integrations/bedrock_runtime/cassettes/latest/test_auto_bedrock_runtime.yaml
@@ -1,0 +1,35 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "Say hello in one word."}]}],
+      "inferenceConfig": {"maxTokens": 20, "temperature": 0}}'
+    headers:
+      Content-Length:
+      - '137'
+      Content-Type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS40My4yOSBtZC9Cb3RvY29yZSMxLjQzLjI5IHVhLzIuMSBvcy9tYWNvcyMyNS41LjAg
+        bWQvYXJjaCNhcm02NCBsYW5nL3B5dGhvbiMzLjE0LjMgbWQvcHlpbXBsI0NQeXRob24gbS9aLGIs
+        RCwzIGNmZy9yZXRyeS1tb2RlI2xlZ2FjeSBCb3RvY29yZS8xLjQzLjI5
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.amazon.nova-lite-v1%3A0/converse
+  response:
+    body:
+      string: '{"metrics":{"latencyMs":511},"output":{"message":{"content":[{"text":"Hi."}],"role":"assistant"}},"stopReason":"end_turn","usage":{"inputTokens":6,"outputTokens":3,"serverToolUsage":{},"totalTokens":9}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '202'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 15 Jun 2026 20:24:03 GMT
+      x-amzn-RequestId:
+      - caa9fd4f-69d2-459b-baf5-0ad888a79845
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/bedrock_runtime/cassettes/latest/test_setup_bedrock_converse_auto_wraps_new_clients.yaml
+++ b/py/src/braintrust/integrations/bedrock_runtime/cassettes/latest/test_setup_bedrock_converse_auto_wraps_new_clients.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: '{"system": [{"text": "You answer with concise lowercase text."}], "messages":
+      [{"role": "user", "content": [{"text": "Say hello in one word."}]}], "inferenceConfig":
+      {"maxTokens": 20, "temperature": 0, "topP": 0.9, "stopSequences": ["STOP"]}}'
+    headers:
+      Content-Length:
+      - '242'
+      Content-Type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS40My4yOSBtZC9Cb3RvY29yZSMxLjQzLjI5IHVhLzIuMSBvcy9tYWNvcyMyNS41LjAg
+        bWQvYXJjaCNhcm02NCBsYW5nL3B5dGhvbiMzLjE0LjMgbWQvcHlpbXBsI0NQeXRob24gbS9iLDMs
+        WixEIGNmZy9yZXRyeS1tb2RlI2xlZ2FjeSBCb3RvY29yZS8xLjQzLjI5
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.amazon.nova-lite-v1%3A0/converse
+  response:
+    body:
+      string: '{"metrics":{"latencyMs":613},"output":{"message":{"content":[{"text":"hi"}],"role":"assistant"}},"stopReason":"end_turn","usage":{"inputTokens":13,"outputTokens":2,"serverToolUsage":{},"totalTokens":15}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '203'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 15 Jun 2026 20:24:01 GMT
+      x-amzn-RequestId:
+      - 7c3bdcc8-1124-46b5-982e-3ced2d1a5371
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/bedrock_runtime/cassettes/latest/test_wrap_bedrock_converse.yaml
+++ b/py/src/braintrust/integrations/bedrock_runtime/cassettes/latest/test_wrap_bedrock_converse.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: '{"system": [{"text": "You answer with concise lowercase text."}], "messages":
+      [{"role": "user", "content": [{"text": "Say hello in one word."}]}], "inferenceConfig":
+      {"maxTokens": 20, "temperature": 0, "topP": 0.9, "stopSequences": ["STOP"]}}'
+    headers:
+      Content-Length:
+      - '242'
+      Content-Type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS40My4yOSBtZC9Cb3RvY29yZSMxLjQzLjI5IHVhLzIuMSBvcy9tYWNvcyMyNS41LjAg
+        bWQvYXJjaCNhcm02NCBsYW5nL3B5dGhvbiMzLjE0LjMgbWQvcHlpbXBsI0NQeXRob24gbS9iLDMs
+        WixEIGNmZy9yZXRyeS1tb2RlI2xlZ2FjeSBCb3RvY29yZS8xLjQzLjI5
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.amazon.nova-lite-v1%3A0/converse
+  response:
+    body:
+      string: '{"metrics":{"latencyMs":486},"output":{"message":{"content":[{"text":"hi"}],"role":"assistant"}},"stopReason":"end_turn","usage":{"inputTokens":13,"outputTokens":2,"serverToolUsage":{},"totalTokens":15}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '203'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 15 Jun 2026 20:24:00 GMT
+      x-amzn-RequestId:
+      - 1935727d-5309-4a70-8c15-1ce0ffbe877e
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/bedrock_runtime/cassettes/latest/test_wrap_bedrock_converse_stream.yaml
+++ b/py/src/braintrust/integrations/bedrock_runtime/cassettes/latest/test_wrap_bedrock_converse_stream.yaml
@@ -1,0 +1,57 @@
+interactions:
+- request:
+    body: '{"system": [{"text": "You answer with concise lowercase text."}], "messages":
+      [{"role": "user", "content": [{"text": "Say hello in one word."}]}], "inferenceConfig":
+      {"maxTokens": 20, "temperature": 0, "topP": 0.9, "stopSequences": ["STOP"]}}'
+    headers:
+      Content-Length:
+      - '242'
+      Content-Type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS40My4yOSBtZC9Cb3RvY29yZSMxLjQzLjI5IHVhLzIuMSBvcy9tYWNvcyMyNS41LjAg
+        bWQvYXJjaCNhcm02NCBsYW5nL3B5dGhvbiMzLjE0LjMgbWQvcHlpbXBsI0NQeXRob24gbS9iLDMs
+        WixEIGNmZy9yZXRyeS1tb2RlI2xlZ2FjeSBCb3RvY29yZS8xLjQzLjI5
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.amazon.nova-lite-v1%3A0/converse-stream
+  response:
+    body:
+      string: !!binary |
+        AAAAqQAAAFKdcBJWCzpldmVudC10eXBlBwAMbWVzc2FnZVN0YXJ0DTpjb250ZW50LXR5cGUHABBh
+        cHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsicCI6ImFiY2RlZmdoaWprbG1u
+        b3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSIiwicm9sZSI6ImFzc2lzdGFudCJ9gLQCXgAA
+        ALgAAABXsJpY6ws6ZXZlbnQtdHlwZQcAEWNvbnRlbnRCbG9ja0RlbHRhDTpjb250ZW50LXR5cGUH
+        ABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiY29udGVudEJsb2NrSW5k
+        ZXgiOjAsImRlbHRhIjp7InRleHQiOiJoaSJ9LCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4
+        eXpBQkMifWTl2tgAAADLAAAAVw7owvQLOmV2ZW50LXR5cGUHABFjb250ZW50QmxvY2tEZWx0YQ06
+        Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImNv
+        bnRlbnRCbG9ja0luZGV4IjowLCJkZWx0YSI6eyJ0ZXh0IjoiIn0sInAiOiJhYmNkZWZnaGlqa2xt
+        bm9wcXJzdHV2d3h5ekFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWCJ9wcJyhwAAAJIAAABWTOxf2As6
+        ZXZlbnQtdHlwZQcAEGNvbnRlbnRCbG9ja1N0b3ANOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9u
+        L2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJjb250ZW50QmxvY2tJbmRleCI6MCwicCI6ImFi
+        Y2RlZmdoaWprbG1uIn0+qWA7AAAAvQAAAFGRGXKuCzpldmVudC10eXBlBwALbWVzc2FnZVN0b3AN
+        OmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJw
+        IjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjAx
+        MjM0NTY3Iiwic3RvcFJlYXNvbiI6ImVuZF90dXJuIn2lawg0AAAA/AAAAE55gg6iCzpldmVudC10
+        eXBlBwAIbWV0YWRhdGENOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2Ut
+        dHlwZQcABWV2ZW50eyJtZXRyaWNzIjp7ImxhdGVuY3lNcyI6ODE1fSwicCI6ImFiY2RlZmdoaWpr
+        bG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU4iLCJ1c2FnZSI6eyJpbnB1dFRva2VucyI6MTMs
+        Im91dHB1dFRva2VucyI6Miwic2VydmVyVG9vbFVzYWdlIjp7fSwidG90YWxUb2tlbnMiOjE1fX1A
+        ORUO
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/vnd.amazon.eventstream
+      Date:
+      - Mon, 15 Jun 2026 20:24:02 GMT
+      Transfer-Encoding:
+      - chunked
+      x-amzn-RequestId:
+      - 80d9cf51-9c72-4526-a7dd-b595a1a4916a
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/bedrock_runtime/cassettes/latest/test_wrap_bedrock_invoke_model_preserves_response_body_and_logs_json.yaml
+++ b/py/src/braintrust/integrations/bedrock_runtime/cassettes/latest/test_wrap_bedrock_invoke_model_preserves_response_body_and_logs_json.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "Say hello in one word."}]}],
+      "inferenceConfig": {"max_new_tokens": 20, "temperature": 0}}'
+    headers:
+      Accept:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+      Content-Length:
+      - '142'
+      Content-Type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+      User-Agent:
+      - !!binary |
+        Qm90bzMvMS40My4yOSBtZC9Cb3RvY29yZSMxLjQzLjI5IHVhLzIuMSBvcy9tYWNvcyMyNS41LjAg
+        bWQvYXJjaCNhcm02NCBsYW5nL3B5dGhvbiMzLjE0LjMgbWQvcHlpbXBsI0NQeXRob24gbS9iLDMs
+        WixEIGNmZy9yZXRyeS1tb2RlI2xlZ2FjeSBCb3RvY29yZS8xLjQzLjI5
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.amazon.nova-lite-v1%3A0/invoke
+  response:
+    body:
+      string: '{"output":{"message":{"content":[{"text":"Hi."}],"role":"assistant"}},"stopReason":"end_turn","usage":{"inputTokens":6,"outputTokens":3,"totalTokens":9,"cacheReadInputTokenCount":0,"cacheWriteInputTokenCount":0}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '212'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 15 Jun 2026 20:24:02 GMT
+      X-Amzn-Bedrock-Cache-Read-Input-Token-Count:
+      - '0'
+      X-Amzn-Bedrock-Cache-Write-Input-Token-Count:
+      - '0'
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '6'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '545'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '3'
+      x-amzn-RequestId:
+      - 36f35389-456b-4a25-b07c-5a9c83164dc1
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/bedrock_runtime/integration.py
+++ b/py/src/braintrust/integrations/bedrock_runtime/integration.py
@@ -1,0 +1,17 @@
+"""boto3 Bedrock Runtime integration orchestration."""
+
+from braintrust.integrations.base import BaseIntegration
+
+from .patchers import BedrockClientCreatorPatcher
+
+
+class BedrockRuntimeIntegration(BaseIntegration):
+    """Braintrust instrumentation for boto3 Bedrock Runtime clients."""
+
+    name = "bedrock_runtime"
+    import_names = ("botocore",)
+    distribution_names = ("botocore",)
+    # Botocore 1.34.116 is the first release whose Bedrock Runtime service model
+    # exposes both Converse and ConverseStream.
+    min_version = "1.34.116"
+    patchers = (BedrockClientCreatorPatcher,)

--- a/py/src/braintrust/integrations/bedrock_runtime/patchers.py
+++ b/py/src/braintrust/integrations/bedrock_runtime/patchers.py
@@ -1,0 +1,73 @@
+"""Patchers for the boto3 Bedrock Runtime integration."""
+
+from typing import Any
+
+from braintrust.integrations.base import CompositeFunctionWrapperPatcher, FunctionWrapperPatcher
+
+from .tracing import (
+    _converse_stream_wrapper,
+    _converse_wrapper,
+    _invoke_model_stream_wrapper,
+    _invoke_model_wrapper,
+)
+
+
+def _is_bedrock_runtime_client(client: Any) -> bool:
+    meta = getattr(client, "meta", None)
+    service_model = getattr(meta, "service_model", None) or getattr(client, "_service_model", None)
+    return getattr(service_model, "service_name", None) == "bedrock-runtime"
+
+
+def wrap_bedrock_client(client: Any) -> Any:
+    """Instrument a boto3/botocore Bedrock Runtime client instance in place."""
+    if not _is_bedrock_runtime_client(client):
+        return client
+    return BedrockRuntimeClientMethodsPatcher.wrap_target(client)
+
+
+def _create_client_wrapper(wrapped, instance, args, kwargs):  # noqa: ARG001
+    client = wrapped(*args, **kwargs)
+    return wrap_bedrock_client(client)
+
+
+class ConversePatcher(FunctionWrapperPatcher):
+    name = "bedrock_runtime.converse"
+    target_path = "converse"
+    wrapper = _converse_wrapper
+
+
+class ConverseStreamPatcher(FunctionWrapperPatcher):
+    name = "bedrock_runtime.converse_stream"
+    target_path = "converse_stream"
+    wrapper = _converse_stream_wrapper
+
+
+class InvokeModelPatcher(FunctionWrapperPatcher):
+    name = "bedrock_runtime.invoke_model"
+    target_path = "invoke_model"
+    wrapper = _invoke_model_wrapper
+
+
+class InvokeModelWithResponseStreamPatcher(FunctionWrapperPatcher):
+    name = "bedrock_runtime.invoke_model_with_response_stream"
+    target_path = "invoke_model_with_response_stream"
+    wrapper = _invoke_model_stream_wrapper
+
+
+class BedrockRuntimeClientMethodsPatcher(CompositeFunctionWrapperPatcher):
+    name = "bedrock_runtime.client_methods"
+    sub_patchers = (
+        ConversePatcher,
+        ConverseStreamPatcher,
+        InvokeModelPatcher,
+        InvokeModelWithResponseStreamPatcher,
+    )
+
+
+class BedrockClientCreatorPatcher(FunctionWrapperPatcher):
+    """Patch botocore's dynamic client factory to wrap Bedrock Runtime clients."""
+
+    name = "bedrock_runtime.client_creator"
+    target_module = "botocore.client"
+    target_path = "ClientCreator.create_client"
+    wrapper = _create_client_wrapper

--- a/py/src/braintrust/integrations/bedrock_runtime/test_bedrock_runtime.py
+++ b/py/src/braintrust/integrations/bedrock_runtime/test_bedrock_runtime.py
@@ -1,0 +1,270 @@
+"""Tests for the boto3 Bedrock Runtime integration."""
+
+import inspect
+import json
+import os
+import time
+
+import pytest
+from braintrust import logger
+from braintrust.integrations.bedrock_runtime import BedrockRuntimeIntegration, setup_bedrock, wrap_bedrock
+from braintrust.integrations.bedrock_runtime.patchers import (
+    BedrockClientCreatorPatcher,
+    BedrockRuntimeClientMethodsPatcher,
+)
+from braintrust.integrations.test_utils import assert_metrics_are_valid, verify_autoinstrument_script
+from braintrust.test_helpers import init_test_logger
+
+
+pytest.importorskip("boto3")
+pytest.importorskip("botocore")
+
+import boto3  # noqa: E402
+import botocore.client  # noqa: E402
+
+
+PROJECT_NAME = "test-boto3-bedrock"
+# Match the Java SDK Bedrock test defaults in Bedrock30TestUtils / BraintrustAWSBedrockTest.
+AWS_REGION = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION") or "us-east-1"
+CONVERSE_MODEL = os.getenv("BRAINTRUST_BEDROCK_CONVERSE_MODEL", "us.amazon.nova-lite-v1:0")
+CONVERSE_STREAM_MODEL = os.getenv("BRAINTRUST_BEDROCK_CONVERSE_STREAM_MODEL", "us.amazon.nova-lite-v1:0")
+INVOKE_MODEL = os.getenv("BRAINTRUST_BEDROCK_INVOKE_MODEL", "us.amazon.nova-lite-v1:0")
+
+
+os.environ.setdefault("AWS_EC2_METADATA_DISABLED", "true")
+if not os.environ.get("AWS_PROFILE") and not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+    os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+    os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+    os.environ.setdefault("AWS_SESSION_TOKEN", "testing")
+
+
+@pytest.fixture(scope="module")
+def vcr_config():
+    record_mode = "none" if (os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS")) else "once"
+    return {
+        "record_mode": record_mode,
+        "decode_compressed_response": True,
+        "filter_headers": [
+            "authorization",
+            "Authorization",
+            "x-amz-security-token",
+            "X-Amz-Security-Token",
+            "x-amz-date",
+            "X-Amz-Date",
+            "x-amz-content-sha256",
+            "X-Amz-Content-Sha256",
+            "amz-sdk-invocation-id",
+            "amz-sdk-request",
+            "x-amzn-bedrock-api-key",
+        ],
+    }
+
+
+@pytest.fixture
+def memory_logger():
+    init_test_logger(PROJECT_NAME)
+    with logger._internal_with_memory_background_logger() as bgl:
+        yield bgl
+
+
+@pytest.fixture
+def clean_client_creator():
+    original = inspect.getattr_static(botocore.client.ClientCreator, "create_client")
+    marker = BedrockClientCreatorPatcher.patch_marker_attr()
+    try:
+        yield
+    finally:
+        setattr(botocore.client.ClientCreator, "create_client", original)
+        for obj in (botocore.client.ClientCreator, original):
+            if hasattr(obj, marker):
+                try:
+                    delattr(obj, marker)
+                except AttributeError:
+                    pass
+
+
+def _bedrock_client():
+    return boto3.client("bedrock-runtime", region_name=AWS_REGION)
+
+
+def _s3_client():
+    return boto3.client("s3", region_name=AWS_REGION)
+
+
+def _converse_kwargs(model_id=CONVERSE_MODEL):
+    return {
+        "modelId": model_id,
+        "system": [{"text": "You answer with concise lowercase text."}],
+        "messages": [{"role": "user", "content": [{"text": "Say hello in one word."}]}],
+        "inferenceConfig": {"maxTokens": 20, "temperature": 0, "topP": 0.9, "stopSequences": ["STOP"]},
+    }
+
+
+def _assert_converse_span(span, *, name: str, start: float, end: float, model_id=CONVERSE_MODEL):
+    assert span["span_attributes"]["name"] == name
+    assert span["span_attributes"]["type"] == "llm"
+    assert span["metadata"]["provider"] == "bedrock"
+    assert span["metadata"]["model"] == model_id
+    assert span["metadata"]["max_tokens"] == 20
+    assert span["metadata"]["temperature"] == 0
+    assert span["metadata"]["top_p"] == 0.9
+    assert span["metadata"]["stop_sequences"] == ["STOP"]
+
+    assert span["input"][0] == {
+        "role": "system",
+        "content": [{"type": "text", "text": "You answer with concise lowercase text."}],
+    }
+    assert span["input"][1] == {
+        "role": "user",
+        "content": [{"type": "text", "text": "Say hello in one word."}],
+    }
+    assert span["output"][0]["role"] == "assistant"
+    assert span["output"][0]["content"]
+    assert span["output"][0]["content"][0]["type"] == "text"
+    assert "stop_reason" in span["metadata"]
+    assert_metrics_are_valid(span["metrics"], start, end)
+
+
+# ---------------------------------------------------------------------------
+# Local integration boilerplate tests
+# ---------------------------------------------------------------------------
+
+
+def test_integration_metadata_and_min_version():
+    assert BedrockRuntimeIntegration.name == "bedrock_runtime"
+    assert BedrockRuntimeIntegration.min_version == "1.34.116"
+    assert BedrockRuntimeIntegration.available_patchers() == ("bedrock_runtime.client_creator",)
+
+
+def test_wrap_bedrock_returns_non_bedrock_clients_unchanged():
+    client = _s3_client()
+
+    assert wrap_bedrock(client) is client
+    assert not BedrockRuntimeClientMethodsPatcher.is_patched(None, None, target=client)
+
+
+def test_wrap_bedrock_is_idempotent():
+    client = _bedrock_client()
+
+    assert wrap_bedrock(client) is client
+    assert wrap_bedrock(client) is client
+    assert BedrockRuntimeClientMethodsPatcher.is_patched(None, None, target=client)
+
+
+def test_setup_bedrock_wraps_only_new_bedrock_clients(clean_client_creator):
+    assert setup_bedrock() is True
+    assert setup_bedrock() is True
+
+    bedrock = _bedrock_client()
+    s3 = _s3_client()
+
+    assert BedrockRuntimeClientMethodsPatcher.is_patched(None, None, target=bedrock)
+    assert not BedrockRuntimeClientMethodsPatcher.is_patched(None, None, target=s3)
+
+
+# ---------------------------------------------------------------------------
+# VCR-backed integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.vcr
+def test_wrap_bedrock_converse(memory_logger):
+    assert not memory_logger.pop()
+    client = wrap_bedrock(_bedrock_client())
+
+    start = time.time()
+    response = client.converse(**_converse_kwargs())
+    end = time.time()
+
+    assert response["output"]["message"]["role"] == "assistant"
+    assert response["usage"]["totalTokens"] > 0
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    _assert_converse_span(spans[0], name="bedrock.converse", start=start, end=end)
+    assert spans[0]["metadata"]["endpoint"] == "converse"
+
+
+@pytest.mark.vcr
+def test_setup_bedrock_converse_auto_wraps_new_clients(memory_logger, clean_client_creator):
+    assert setup_bedrock() is True
+    assert not memory_logger.pop()
+
+    client = _bedrock_client()
+    start = time.time()
+    response = client.converse(**_converse_kwargs())
+    end = time.time()
+
+    assert response["output"]["message"]["role"] == "assistant"
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    _assert_converse_span(spans[0], name="bedrock.converse", start=start, end=end)
+
+
+@pytest.mark.vcr
+def test_wrap_bedrock_converse_stream(memory_logger):
+    assert not memory_logger.pop()
+    client = wrap_bedrock(_bedrock_client())
+
+    start = time.time()
+    response = client.converse_stream(**_converse_kwargs(CONVERSE_STREAM_MODEL))
+    chunks = []
+    for event in response["stream"]:
+        if "contentBlockDelta" in event:
+            delta = event["contentBlockDelta"].get("delta", {})
+            if "text" in delta:
+                chunks.append(delta["text"])
+    end = time.time()
+
+    assert "".join(chunks).strip()
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    _assert_converse_span(span, name="bedrock.converse-stream", start=start, end=end, model_id=CONVERSE_STREAM_MODEL)
+    assert span["metadata"]["endpoint"] == "converse-stream"
+    assert span["metadata"]["stream"] is True
+    assert span["metrics"]["time_to_first_token"] >= 0
+
+
+@pytest.mark.vcr
+def test_wrap_bedrock_invoke_model_preserves_response_body_and_logs_json(memory_logger):
+    assert not memory_logger.pop()
+    client = wrap_bedrock(_bedrock_client())
+    body = {
+        "messages": [{"role": "user", "content": [{"text": "Say hello in one word."}]}],
+        "inferenceConfig": {"max_new_tokens": 20, "temperature": 0},
+    }
+
+    start = time.time()
+    response = client.invoke_model(
+        modelId=INVOKE_MODEL,
+        body=json.dumps(body),
+        contentType="application/json",
+        accept="application/json",
+    )
+    end = time.time()
+
+    # The integration reads the body for tracing and must replace it so user code
+    # can still consume the provider response normally.
+    response_body = json.loads(response["body"].read())
+    assert response_body["output"]["message"]["content"]
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span["span_attributes"]["name"] == "bedrock.invoke_model"
+    assert span["span_attributes"]["type"] == "llm"
+    assert span["metadata"]["provider"] == "bedrock"
+    assert span["metadata"]["endpoint"] == "invoke_model"
+    assert span["metadata"]["model"] == INVOKE_MODEL
+    assert span["input"]["modelId"] == INVOKE_MODEL
+    assert span["input"]["body"] == body
+    assert span["output"] == response_body
+    assert_metrics_are_valid(span["metrics"], start, end)
+
+
+@pytest.mark.vcr
+def test_auto_instrument_bedrock_runtime_subprocess():
+    verify_autoinstrument_script("test_auto_bedrock_runtime.py", timeout=60)

--- a/py/src/braintrust/integrations/bedrock_runtime/tracing.py
+++ b/py/src/braintrust/integrations/bedrock_runtime/tracing.py
@@ -1,0 +1,655 @@
+"""Tracing helpers for the boto3 Bedrock Runtime integration."""
+
+import io
+import json
+import time
+from typing import Any
+
+from braintrust.integrations.utils import (
+    _log_and_end_span,
+    _log_error_and_end_span,
+    _materialize_attachment,
+    _timing_metrics,
+)
+from braintrust.logger import start_span
+from braintrust.span_types import SpanTypeAttribute
+from braintrust.util import is_numeric
+
+
+_PROVIDER = "bedrock"
+
+_CONVERSE_METADATA_KEYS = (
+    "guardrailConfig",
+    "toolConfig",
+    "additionalModelRequestFields",
+    "additionalModelResponseFieldPaths",
+    "performanceConfig",
+    "requestMetadata",
+)
+_INFERENCE_CONFIG_KEYS = {
+    "maxTokens": "max_tokens",
+    "temperature": "temperature",
+    "topP": "top_p",
+    "stopSequences": "stop_sequences",
+}
+
+
+def _converse_wrapper(wrapped, instance, args, kwargs):  # noqa: ARG001
+    span = _start_span(
+        "bedrock.converse",
+        _converse_input(kwargs),
+        _converse_metadata(kwargs, endpoint="converse"),
+    )
+    start_time = time.time()
+    try:
+        result = wrapped(*args, **kwargs)
+    except Exception as error:
+        _log_error_and_end_span(span, error)
+        raise
+
+    metadata = _converse_response_metadata(result)
+    metrics = {
+        **_timing_metrics(start_time, time.time()),
+        **_converse_usage_metrics(result.get("usage") if isinstance(result, dict) else None),
+        **_bedrock_latency_metrics(result.get("metrics") if isinstance(result, dict) else None),
+    }
+    _log_and_end_span(span, output=_converse_output(result), metrics=metrics, metadata=metadata or None)
+    return result
+
+
+def _converse_stream_wrapper(wrapped, instance, args, kwargs):  # noqa: ARG001
+    span = _start_span(
+        "bedrock.converse-stream",
+        _converse_input(kwargs),
+        _converse_metadata(kwargs, endpoint="converse-stream", stream=True),
+    )
+    start_time = time.time()
+    try:
+        result = wrapped(*args, **kwargs)
+    except Exception as error:
+        _log_error_and_end_span(span, error)
+        raise
+
+    if isinstance(result, dict) and "stream" in result:
+        result = dict(result)
+        result["stream"] = _TracedConverseStream(result["stream"], span, start_time)
+        return result
+
+    _log_and_end_span(span, metrics=_timing_metrics(start_time, time.time()))
+    return result
+
+
+def _invoke_model_wrapper(wrapped, instance, args, kwargs):  # noqa: ARG001
+    model_id = kwargs.get("modelId")
+    span = _start_span(
+        "bedrock.invoke_model",
+        _invoke_model_input(kwargs),
+        _invoke_model_metadata(model_id, endpoint="invoke_model"),
+    )
+    start_time = time.time()
+    try:
+        result = wrapped(*args, **kwargs)
+    except Exception as error:
+        _log_error_and_end_span(span, error)
+        raise
+
+    output = None
+    if isinstance(result, dict) and "body" in result:
+        body_bytes = _read_streaming_body(result["body"])
+        if body_bytes is not None:
+            output = _parse_json_bytes(body_bytes)
+            result = dict(result)
+            result["body"] = _replacement_streaming_body(body_bytes)
+    output_usage = output.get("usage") if isinstance(output, dict) else None
+    metrics = {
+        **_timing_metrics(start_time, time.time()),
+        **_converse_usage_metrics(output_usage),
+        **_anthropic_invoke_usage_metrics(model_id, output),
+    }
+    _log_and_end_span(span, output=output, metrics=metrics)
+    return result
+
+
+def _invoke_model_stream_wrapper(wrapped, instance, args, kwargs):  # noqa: ARG001
+    model_id = kwargs.get("modelId")
+    span = _start_span(
+        "bedrock.invoke_model_stream",
+        _invoke_model_input(kwargs),
+        _invoke_model_metadata(model_id, endpoint="invoke_model_stream", stream=True),
+    )
+    start_time = time.time()
+    try:
+        result = wrapped(*args, **kwargs)
+    except Exception as error:
+        _log_error_and_end_span(span, error)
+        raise
+
+    if isinstance(result, dict) and "body" in result:
+        result = dict(result)
+        result["body"] = _TracedInvokeModelStream(result["body"], span, start_time, model_id)
+        return result
+
+    _log_and_end_span(span, metrics=_timing_metrics(start_time, time.time()))
+    return result
+
+
+def _start_span(name: str, span_input: Any, metadata: dict[str, Any]):
+    return start_span(name=name, type=SpanTypeAttribute.LLM, input=span_input, metadata=metadata)
+
+
+def _converse_metadata(kwargs: dict[str, Any], *, endpoint: str, stream: bool = False) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"provider": _PROVIDER, "endpoint": endpoint}
+    model = kwargs.get("modelId")
+    if model is not None:
+        metadata["model"] = model
+    inference_config = kwargs.get("inferenceConfig")
+    if isinstance(inference_config, dict):
+        for source_key, dest_key in _INFERENCE_CONFIG_KEYS.items():
+            value = inference_config.get(source_key)
+            if value is not None:
+                metadata[dest_key] = value
+    for key in _CONVERSE_METADATA_KEYS:
+        value = kwargs.get(key)
+        if value is not None:
+            metadata[_camel_metadata_key(key)] = value
+    if stream:
+        metadata["stream"] = True
+    return metadata
+
+
+def _invoke_model_metadata(model_id: Any, *, endpoint: str, stream: bool = False) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"provider": _PROVIDER, "endpoint": endpoint}
+    if model_id is not None:
+        metadata["model"] = model_id
+    if stream:
+        metadata["stream"] = True
+    return metadata
+
+
+def _camel_metadata_key(key: str) -> str:
+    return {
+        "guardrailConfig": "guardrail_config",
+        "toolConfig": "tool_config",
+        "additionalModelRequestFields": "additional_model_request_fields",
+        "additionalModelResponseFieldPaths": "additional_model_response_field_paths",
+        "performanceConfig": "performance_config",
+        "requestMetadata": "request_metadata",
+    }.get(key, key)
+
+
+def _converse_input(kwargs: dict[str, Any]) -> list[dict[str, Any]] | None:
+    messages: list[dict[str, Any]] = []
+    system = _system_blocks_to_content(kwargs.get("system"))
+    if system:
+        messages.append({"role": "system", "content": system})
+    for message in kwargs.get("messages") or []:
+        if not isinstance(message, dict):
+            continue
+        messages.append(_message_to_json(message))
+    return messages or None
+
+
+def _message_to_json(message: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    role = message.get("role")
+    if role is not None:
+        result["role"] = role
+    result["content"] = _content_blocks_to_json(message.get("content") or [])
+    return result
+
+
+def _system_blocks_to_content(blocks: Any) -> list[Any]:
+    if not isinstance(blocks, list):
+        return []
+    result = []
+    for block in blocks:
+        if isinstance(block, dict) and "text" in block:
+            result.append({"type": "text", "text": block["text"]})
+        else:
+            result.append(block)
+    return result
+
+
+def _content_blocks_to_json(blocks: Any) -> list[Any]:
+    if not isinstance(blocks, list):
+        return []
+    return [_content_block_to_json(block) for block in blocks]
+
+
+def _content_block_to_json(block: Any) -> Any:
+    if not isinstance(block, dict):
+        return block
+    if "text" in block:
+        return {"type": "text", "text": block["text"]}
+    if "toolUse" in block:
+        return _tool_use_to_json(block.get("toolUse"))
+    if "toolResult" in block:
+        return _tool_result_to_json(block.get("toolResult"))
+    if "image" in block:
+        return _image_to_json(block.get("image"))
+    if "document" in block:
+        return _document_to_json(block.get("document"))
+    if "reasoningContent" in block:
+        return _reasoning_to_json(block.get("reasoningContent"))
+    return block
+
+
+def _tool_use_to_json(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"type": "tool_use", "value": value}
+    result: dict[str, Any] = {"type": "tool_use"}
+    if value.get("toolUseId") is not None:
+        result["id"] = value["toolUseId"]
+    if value.get("name") is not None:
+        result["name"] = value["name"]
+    if value.get("input") is not None:
+        result["input"] = value["input"]
+    return result
+
+
+def _tool_result_to_json(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"type": "tool_result", "value": value}
+    result: dict[str, Any] = {"type": "tool_result"}
+    if value.get("toolUseId") is not None:
+        result["tool_use_id"] = value["toolUseId"]
+    if value.get("status") is not None:
+        result["status"] = value["status"]
+    content = value.get("content")
+    if isinstance(content, list):
+        result["content"] = [_tool_result_content_to_json(block) for block in content]
+    return result
+
+
+def _tool_result_content_to_json(block: Any) -> Any:
+    if not isinstance(block, dict):
+        return block
+    if "text" in block:
+        return {"type": "text", "text": block["text"]}
+    if "json" in block:
+        return {"type": "json", "json": block["json"]}
+    return block
+
+
+def _image_to_json(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"type": "image", "value": value}
+    result: dict[str, Any] = {"type": "image"}
+    image_format = value.get("format")
+    if image_format is not None:
+        result["format"] = image_format
+    source = value.get("source")
+    if isinstance(source, dict):
+        source_result = dict(source)
+        image_bytes = source_result.pop("bytes", None)
+        if image_bytes is not None:
+            mime_type = f"image/{image_format or 'png'}"
+            resolved = _materialize_attachment(image_bytes, mime_type=mime_type, prefix="image")
+            if resolved is not None:
+                result["image_url"] = {"url": resolved.attachment}
+            else:
+                source_result["bytes"] = image_bytes
+        result["source"] = source_result
+    return result
+
+
+def _document_to_json(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"type": "document", "value": value}
+    result: dict[str, Any] = {"type": "document"}
+    for key in ("format", "name", "citations"):
+        if value.get(key) is not None:
+            result[key] = value[key]
+    source = value.get("source")
+    if isinstance(source, dict):
+        source_result = dict(source)
+        document_bytes = source_result.pop("bytes", None)
+        if document_bytes is not None:
+            mime_type = _document_mime_type(value.get("format"))
+            resolved = _materialize_attachment(document_bytes, mime_type=mime_type, prefix="document")
+            if resolved is not None:
+                result["file"] = {"file_data": resolved.attachment, "filename": resolved.filename}
+            else:
+                source_result["bytes"] = document_bytes
+        result["source"] = source_result
+    return result
+
+
+def _document_mime_type(document_format: Any) -> str:
+    return {
+        "pdf": "application/pdf",
+        "csv": "text/csv",
+        "doc": "application/msword",
+        "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "html": "text/html",
+        "md": "text/markdown",
+        "txt": "text/plain",
+        "xls": "application/vnd.ms-excel",
+        "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    }.get(str(document_format), "application/octet-stream")
+
+
+def _reasoning_to_json(value: Any) -> dict[str, Any]:
+    result: dict[str, Any] = {"type": "reasoning"}
+    if not isinstance(value, dict):
+        result["value"] = value
+        return result
+    reasoning_text = value.get("reasoningText")
+    if isinstance(reasoning_text, dict):
+        if reasoning_text.get("text") is not None:
+            result["text"] = reasoning_text["text"]
+        if reasoning_text.get("signature") is not None:
+            result["signature"] = reasoning_text["signature"]
+    return result
+
+
+def _converse_output(result: Any) -> Any:
+    if not isinstance(result, dict):
+        return None
+    output = result.get("output")
+    if isinstance(output, dict) and isinstance(output.get("message"), dict):
+        return [_message_to_json(output["message"])]
+    return output
+
+
+def _converse_response_metadata(result: Any) -> dict[str, Any]:
+    if not isinstance(result, dict):
+        return {}
+    metadata: dict[str, Any] = {}
+    if result.get("stopReason") is not None:
+        metadata["stop_reason"] = result["stopReason"]
+    for key in ("additionalModelResponseFields", "trace"):
+        if result.get(key) is not None:
+            metadata[_camel_metadata_key(key)] = result[key]
+    return metadata
+
+
+def _converse_usage_metrics(usage: Any) -> dict[str, Any]:
+    if not isinstance(usage, dict):
+        return {}
+    metrics: dict[str, Any] = {}
+    input_tokens = _numeric_or_zero(usage.get("inputTokens"))
+    cache_read = _numeric_or_zero(usage.get("cacheReadInputTokens"))
+    cache_write = _numeric_or_zero(usage.get("cacheWriteInputTokens"))
+    if input_tokens or "inputTokens" in usage or cache_read or cache_write:
+        metrics["prompt_tokens"] = input_tokens + cache_read + cache_write
+    if is_numeric(usage.get("outputTokens")):
+        metrics["completion_tokens"] = usage["outputTokens"]
+    if is_numeric(usage.get("cacheReadInputTokens")):
+        metrics["prompt_cached_tokens"] = usage["cacheReadInputTokens"]
+    if is_numeric(usage.get("cacheWriteInputTokens")):
+        metrics["prompt_cache_creation_tokens"] = usage["cacheWriteInputTokens"]
+    if is_numeric(usage.get("totalTokens")):
+        metrics["tokens"] = usage["totalTokens"]
+    elif "prompt_tokens" in metrics and "completion_tokens" in metrics:
+        metrics["tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
+    return metrics
+
+
+def _bedrock_latency_metrics(metrics_payload: Any) -> dict[str, Any]:
+    if not isinstance(metrics_payload, dict):
+        return {}
+    latency = metrics_payload.get("latencyMs")
+    return {"bedrock_latency_ms": latency} if is_numeric(latency) else {}
+
+
+def _numeric_or_zero(value: Any) -> Any:
+    return value if is_numeric(value) else 0
+
+
+def _invoke_model_input(kwargs: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    model_id = kwargs.get("modelId")
+    if model_id is not None:
+        result["modelId"] = model_id
+    body = kwargs.get("body")
+    parsed_body = _parse_json_body(body)
+    if parsed_body is not None:
+        result["body"] = parsed_body
+    for key in (
+        "contentType",
+        "accept",
+        "trace",
+        "guardrailIdentifier",
+        "guardrailVersion",
+        "performanceConfigLatency",
+    ):
+        value = kwargs.get(key)
+        if value is not None:
+            result[key] = value
+    return result
+
+
+def _parse_json_body(body: Any) -> Any:
+    if body is None:
+        return None
+    if isinstance(body, str):
+        return _parse_json_text(body)
+    if isinstance(body, (bytes, bytearray)):
+        return _parse_json_bytes(bytes(body))
+    return None
+
+
+def _parse_json_bytes(data: bytes) -> Any:
+    try:
+        return json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return data.decode("utf-8", errors="replace")
+
+
+def _parse_json_text(value: str) -> Any:
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def _read_streaming_body(body: Any) -> bytes | None:
+    read = getattr(body, "read", None)
+    if not callable(read):
+        return None
+    data = read()
+    if isinstance(data, (bytes, bytearray)):
+        return bytes(data)
+    return None
+
+
+def _replacement_streaming_body(data: bytes) -> Any:
+    from botocore.response import StreamingBody
+
+    return StreamingBody(io.BytesIO(data), len(data))
+
+
+def _anthropic_invoke_usage_metrics(model_id: Any, output: Any) -> dict[str, Any]:
+    if not isinstance(model_id, str) or "anthropic.claude" not in model_id.lower():
+        return {}
+    if not isinstance(output, dict):
+        return {}
+    usage = output.get("usage")
+    if not isinstance(usage, dict):
+        return {}
+    metrics: dict[str, Any] = {}
+    input_tokens = _numeric_or_zero(usage.get("input_tokens"))
+    cache_read = _numeric_or_zero(usage.get("cache_read_input_tokens"))
+    cache_create = _numeric_or_zero(usage.get("cache_creation_input_tokens"))
+    if input_tokens or "input_tokens" in usage or cache_read or cache_create:
+        metrics["prompt_tokens"] = input_tokens + cache_read + cache_create
+    if is_numeric(usage.get("output_tokens")):
+        metrics["completion_tokens"] = usage["output_tokens"]
+    if is_numeric(usage.get("cache_read_input_tokens")):
+        metrics["prompt_cached_tokens"] = usage["cache_read_input_tokens"]
+    if is_numeric(usage.get("cache_creation_input_tokens")):
+        metrics["prompt_cache_creation_tokens"] = usage["cache_creation_input_tokens"]
+    if "prompt_tokens" in metrics and "completion_tokens" in metrics:
+        metrics["tokens"] = metrics["prompt_tokens"] + metrics["completion_tokens"]
+    return metrics
+
+
+class _TracedConverseStream:
+    """Wrap a botocore EventStream and log the final span when it drains."""
+
+    def __init__(self, stream: Any, span: Any, start_time: float):
+        self._stream = stream
+        self._span = span
+        self._start_time = start_time
+        self._first_token_time: float | None = None
+        self._message_role = "assistant"
+        self._content_blocks: dict[int, dict[str, Any]] = {}
+        self._builders: dict[int, list[str]] = {}
+        self._usage: dict[str, Any] | None = None
+        self._metrics_payload: dict[str, Any] | None = None
+        self._stop_reason: str | None = None
+        self._finished = False
+
+    def __iter__(self):
+        try:
+            for event in self._stream:
+                self._observe(event)
+                yield event
+        except Exception as error:
+            self._finish(error)
+            raise
+        else:
+            self._finish(None)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def close(self):
+        close = getattr(self._stream, "close", None)
+        try:
+            return close() if callable(close) else None
+        finally:
+            self._finish(None)
+
+    def _observe(self, event: Any) -> None:
+        if not isinstance(event, dict):
+            return
+        if self._first_token_time is None:
+            self._first_token_time = time.time()
+        if "messageStart" in event:
+            role = event.get("messageStart", {}).get("role")
+            if role is not None:
+                self._message_role = role
+        elif "contentBlockStart" in event:
+            data = event["contentBlockStart"]
+            idx = int(data.get("contentBlockIndex", 0))
+            start = data.get("start") or {}
+            if "toolUse" in start:
+                self._content_blocks[idx] = _tool_use_to_json(start["toolUse"])
+            else:
+                self._content_blocks.setdefault(idx, {})
+        elif "contentBlockDelta" in event:
+            data = event["contentBlockDelta"]
+            idx = int(data.get("contentBlockIndex", 0))
+            block = self._content_blocks.setdefault(idx, {})
+            delta = data.get("delta") or {}
+            if "text" in delta:
+                block["type"] = "text"
+                self._builders.setdefault(idx, []).append(delta["text"])
+            elif "toolUse" in delta:
+                block["type"] = "tool_use"
+                tool_delta = delta["toolUse"] or {}
+                if tool_delta.get("input") is not None:
+                    self._builders.setdefault(idx, []).append(tool_delta["input"])
+            elif "reasoningContent" in delta:
+                block["type"] = "reasoning"
+                reasoning = delta["reasoningContent"] or {}
+                if reasoning.get("text") is not None:
+                    self._builders.setdefault(idx, []).append(reasoning["text"])
+                if reasoning.get("signature") is not None:
+                    block["signature"] = reasoning["signature"]
+            elif "citation" in delta:
+                block.setdefault("citations", []).append(delta["citation"])
+        elif "messageStop" in event:
+            self._stop_reason = event.get("messageStop", {}).get("stopReason")
+        elif "metadata" in event:
+            metadata = event["metadata"] or {}
+            if isinstance(metadata.get("usage"), dict):
+                self._usage = metadata["usage"]
+            if isinstance(metadata.get("metrics"), dict):
+                self._metrics_payload = metadata["metrics"]
+
+    def _finish(self, error: BaseException | None) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        if error is not None:
+            _log_error_and_end_span(self._span, error)
+            return
+        for idx, pieces in self._builders.items():
+            block = self._content_blocks.setdefault(idx, {})
+            text = "".join(pieces)
+            if block.get("type") == "tool_use":
+                block["input"] = text
+            else:
+                block["text"] = text
+        content = [self._content_blocks[idx] for idx in sorted(self._content_blocks)]
+        output = [{"role": self._message_role, "content": content}] if content else None
+        metadata = {"stop_reason": self._stop_reason} if self._stop_reason else None
+        metrics = {
+            **_timing_metrics(self._start_time, time.time(), self._first_token_time),
+            **_converse_usage_metrics(self._usage),
+            **_bedrock_latency_metrics(self._metrics_payload),
+        }
+        _log_and_end_span(self._span, output=output, metrics=metrics, metadata=metadata)
+
+
+class _TracedInvokeModelStream:
+    """Wrap an InvokeModelWithResponseStream EventStream and log observed chunks."""
+
+    def __init__(self, stream: Any, span: Any, start_time: float, model_id: Any):
+        self._stream = stream
+        self._span = span
+        self._start_time = start_time
+        self._model_id = model_id
+        self._first_token_time: float | None = None
+        self._chunks: list[Any] = []
+        self._finished = False
+
+    def __iter__(self):
+        try:
+            for event in self._stream:
+                self._observe(event)
+                yield event
+        except Exception as error:
+            self._finish(error)
+            raise
+        else:
+            self._finish(None)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def close(self):
+        close = getattr(self._stream, "close", None)
+        try:
+            return close() if callable(close) else None
+        finally:
+            self._finish(None)
+
+    def _observe(self, event: Any) -> None:
+        if self._first_token_time is None:
+            self._first_token_time = time.time()
+        if not isinstance(event, dict):
+            return
+        chunk = event.get("chunk")
+        if isinstance(chunk, dict) and isinstance(chunk.get("bytes"), (bytes, bytearray)):
+            self._chunks.append(_parse_json_bytes(bytes(chunk["bytes"])))
+        elif event:
+            self._chunks.append(event)
+
+    def _finish(self, error: BaseException | None) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        if error is not None:
+            _log_error_and_end_span(self._span, error)
+            return
+        output = self._chunks or None
+        usage_metrics: dict[str, Any] = {}
+        if output:
+            for chunk in output:
+                usage_metrics.update(_anthropic_invoke_usage_metrics(self._model_id, chunk))
+        metrics = {**_timing_metrics(self._start_time, time.time(), self._first_token_time), **usage_metrics}
+        _log_and_end_span(self._span, output=output, metrics=metrics)


### PR DESCRIPTION
resolves https://github.com/braintrustdata/braintrust-sdk-python/issues/279

Add a Python Bedrock Runtime integration that auto-instruments boto3/botocore client creation.

```python
import braintrust

braintrust.auto_instrument(bedrock=True)
```

The integration requires botocore >= 1.34.116, the first supported version whose Bedrock Runtime service model exposes both Converse and ConverseStream. It traces Converse, ConverseStream, InvokeModel, and InvokeModelWithResponseStream with Bedrock-shaped LLM spans.

Manual wrapping is also exposed:

```python
from braintrust.integrations.bedrock_runtime import wrap_bedrock

client = wrap_bedrock(client)
```

<img width="650" height="692" alt="image" src="https://github.com/user-attachments/assets/5c331f07-5978-48e6-b67c-be7723042268" />
