### PR TITLE
feat(evals): Forward/pick up `bt eval <...> --sample N` flag

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1808,12 +1808,12 @@ def init_dataset(
     """
 
     state = state or _state
-    sample_rate = getattr(builtins, "__bt_eval_sample_rate", None)
-    if isinstance(sample_rate, (int, float)) and not isinstance(sample_rate, bool):
+    cli_internal_btql = getattr(builtins, "__bt_eval_internal_btql", None)
+    if isinstance(cli_internal_btql, Mapping):
         if _internal_btql is None:
-            _internal_btql = {"sample": sample_rate}
+            _internal_btql = dict(cli_internal_btql)
         elif "sample" not in _internal_btql:
-            _internal_btql = {**_internal_btql, "sample": sample_rate}
+            _internal_btql = {**_internal_btql, **cli_internal_btql}
 
     def compute_metadata():
         state.login(org_name=org_name, api_key=api_key, app_url=app_url)

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1,5 +1,6 @@
 import atexit
 import base64
+import builtins
 import concurrent.futures
 import contextlib
 import contextvars
@@ -1807,6 +1808,12 @@ def init_dataset(
     """
 
     state = state or _state
+    sample_rate = getattr(builtins, "__bt_eval_sample_rate", None)
+    if isinstance(sample_rate, (int, float)) and not isinstance(sample_rate, bool):
+        if _internal_btql is None:
+            _internal_btql = {"sample": sample_rate}
+        elif "sample" not in _internal_btql:
+            _internal_btql = {**_internal_btql, "sample": sample_rate}
 
     def compute_metadata():
         state.login(org_name=org_name, api_key=api_key, app_url=app_url)

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1812,8 +1812,8 @@ def init_dataset(
     if isinstance(cli_internal_btql, Mapping):
         if _internal_btql is None:
             _internal_btql = dict(cli_internal_btql)
-        elif "sample" not in _internal_btql:
-            _internal_btql = {**_internal_btql, **cli_internal_btql}
+        else:
+            _internal_btql = {**cli_internal_btql, **_internal_btql}
 
     def compute_metadata():
         state.login(org_name=org_name, api_key=api_key, app_url=app_url)

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -3497,8 +3497,8 @@ class TestDatasetInternalBtql(TestCase):
         finally:
             monkeypatch.undo()
 
-    def test_init_dataset_preserves_explicit_internal_btql_sample(self):
-        """Test that an explicit BTQL sample overrides bt eval runtime BTQL."""
+    def test_init_dataset_merges_bt_eval_internal_btql_without_overriding_explicit_keys(self):
+        """Test that explicit BTQL keys override bt eval runtime BTQL."""
         from braintrust.logger import init_dataset
 
         monkeypatch = pytest.MonkeyPatch()
@@ -3512,7 +3512,10 @@ class TestDatasetInternalBtql(TestCase):
                 state=MagicMock(),
             )
 
-            self.assertEqual(dataset._internal_btql, {"filter": "metadata.kind = 'synthetic'", "sample": 2})
+            self.assertEqual(
+                dataset._internal_btql,
+                {"filter": "metadata.kind = 'synthetic'", "sample": 2, "limit": 10},
+            )
         finally:
             monkeypatch.undo()
 

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -3456,12 +3456,12 @@ class TestJSONAttachment(TestCase):
 class TestDatasetInternalBtql(TestCase):
     """Test that _internal_btql parameters (especially limit) are properly passed through to BTQL queries."""
 
-    def test_init_dataset_applies_bt_eval_sample_runtime_value(self):
-        """Test that bt eval --sample is injected into dataset BTQL."""
+    def test_init_dataset_applies_bt_eval_internal_btql_runtime_value(self):
+        """Test that bt eval runtime BTQL is injected into dataset BTQL."""
         from braintrust.logger import init_dataset
 
         monkeypatch = pytest.MonkeyPatch()
-        monkeypatch.setattr(builtins, "__bt_eval_sample_rate", 5, raising=False)
+        monkeypatch.setattr(builtins, "__bt_eval_internal_btql", {"sample": 5}, raising=False)
         try:
             dataset = init_dataset(project="test-project", name="test-dataset", use_output=False, state=MagicMock())
 
@@ -3469,12 +3469,12 @@ class TestDatasetInternalBtql(TestCase):
         finally:
             monkeypatch.undo()
 
-    def test_init_dataset_merges_bt_eval_sample_with_internal_btql(self):
-        """Test that bt eval --sample is added to existing BTQL filters."""
+    def test_init_dataset_merges_bt_eval_internal_btql_with_internal_btql(self):
+        """Test that bt eval runtime BTQL is added to existing BTQL filters."""
         from braintrust.logger import init_dataset
 
         monkeypatch = pytest.MonkeyPatch()
-        monkeypatch.setattr(builtins, "__bt_eval_sample_rate", 5, raising=False)
+        monkeypatch.setattr(builtins, "__bt_eval_internal_btql", {"sample": 5, "limit": 10}, raising=False)
         try:
             internal_btql = {"where": {"op": "eq", "left": "metadata.kind", "right": "synthetic"}}
             dataset = init_dataset(
@@ -3487,18 +3487,22 @@ class TestDatasetInternalBtql(TestCase):
 
             self.assertEqual(
                 dataset._internal_btql,
-                {"where": {"op": "eq", "left": "metadata.kind", "right": "synthetic"}, "sample": 5},
+                {
+                    "where": {"op": "eq", "left": "metadata.kind", "right": "synthetic"},
+                    "sample": 5,
+                    "limit": 10,
+                },
             )
             self.assertEqual(internal_btql, {"where": {"op": "eq", "left": "metadata.kind", "right": "synthetic"}})
         finally:
             monkeypatch.undo()
 
     def test_init_dataset_preserves_explicit_internal_btql_sample(self):
-        """Test that an explicit BTQL sample overrides bt eval --sample."""
+        """Test that an explicit BTQL sample overrides bt eval runtime BTQL."""
         from braintrust.logger import init_dataset
 
         monkeypatch = pytest.MonkeyPatch()
-        monkeypatch.setattr(builtins, "__bt_eval_sample_rate", 5, raising=False)
+        monkeypatch.setattr(builtins, "__bt_eval_internal_btql", {"sample": 5, "limit": 10}, raising=False)
         try:
             dataset = init_dataset(
                 project="test-project",
@@ -3512,12 +3516,12 @@ class TestDatasetInternalBtql(TestCase):
         finally:
             monkeypatch.undo()
 
-    def test_init_dataset_keeps_btql_unchanged_without_eval_sample_runtime_value(self):
-        """Test that ordinary init_dataset calls are unchanged outside bt eval --sample."""
+    def test_init_dataset_keeps_btql_unchanged_without_eval_internal_btql_runtime_value(self):
+        """Test that ordinary init_dataset calls are unchanged without runtime BTQL."""
         from braintrust.logger import init_dataset
 
         monkeypatch = pytest.MonkeyPatch()
-        monkeypatch.delattr(builtins, "__bt_eval_sample_rate", raising=False)
+        monkeypatch.delattr(builtins, "__bt_eval_internal_btql", raising=False)
         try:
             dataset = init_dataset(project="test-project", name="test-dataset", use_output=False, state=MagicMock())
 
@@ -3525,12 +3529,12 @@ class TestDatasetInternalBtql(TestCase):
         finally:
             monkeypatch.undo()
 
-    def test_init_dataset_forwards_bt_eval_sample_runtime_value_to_fetch(self):
-        """Test that bt eval --sample is included in fetched dataset BTQL."""
+    def test_init_dataset_forwards_bt_eval_internal_btql_runtime_value_to_fetch(self):
+        """Test that bt eval runtime BTQL is included in fetched dataset BTQL."""
         from braintrust.logger import init_dataset
 
         monkeypatch = pytest.MonkeyPatch()
-        monkeypatch.setattr(builtins, "__bt_eval_sample_rate", 5, raising=False)
+        monkeypatch.setattr(builtins, "__bt_eval_internal_btql", {"sample": 5}, raising=False)
         try:
             mock_state = MagicMock()
             mock_state.org_id = "test-org"

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -1,6 +1,7 @@
 # pyright: reportUnknownVariableType=false
 # pyright: reportPrivateUsage=false
 import asyncio
+import builtins
 import json
 import logging
 import os
@@ -3454,6 +3455,106 @@ class TestJSONAttachment(TestCase):
 
 class TestDatasetInternalBtql(TestCase):
     """Test that _internal_btql parameters (especially limit) are properly passed through to BTQL queries."""
+
+    def test_init_dataset_applies_bt_eval_sample_runtime_value(self):
+        """Test that bt eval --sample is injected into dataset BTQL."""
+        from braintrust.logger import init_dataset
+
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(builtins, "__bt_eval_sample_rate", 5, raising=False)
+        try:
+            dataset = init_dataset(project="test-project", name="test-dataset", use_output=False, state=MagicMock())
+
+            self.assertEqual(dataset._internal_btql, {"sample": 5})
+        finally:
+            monkeypatch.undo()
+
+    def test_init_dataset_merges_bt_eval_sample_with_internal_btql(self):
+        """Test that bt eval --sample is added to existing BTQL filters."""
+        from braintrust.logger import init_dataset
+
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(builtins, "__bt_eval_sample_rate", 5, raising=False)
+        try:
+            internal_btql = {"where": {"op": "eq", "left": "metadata.kind", "right": "synthetic"}}
+            dataset = init_dataset(
+                project="test-project",
+                name="test-dataset",
+                use_output=False,
+                _internal_btql=internal_btql,
+                state=MagicMock(),
+            )
+
+            self.assertEqual(
+                dataset._internal_btql,
+                {"where": {"op": "eq", "left": "metadata.kind", "right": "synthetic"}, "sample": 5},
+            )
+            self.assertEqual(internal_btql, {"where": {"op": "eq", "left": "metadata.kind", "right": "synthetic"}})
+        finally:
+            monkeypatch.undo()
+
+    def test_init_dataset_preserves_explicit_internal_btql_sample(self):
+        """Test that an explicit BTQL sample overrides bt eval --sample."""
+        from braintrust.logger import init_dataset
+
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(builtins, "__bt_eval_sample_rate", 5, raising=False)
+        try:
+            dataset = init_dataset(
+                project="test-project",
+                name="test-dataset",
+                use_output=False,
+                _internal_btql={"filter": "metadata.kind = 'synthetic'", "sample": 2},
+                state=MagicMock(),
+            )
+
+            self.assertEqual(dataset._internal_btql, {"filter": "metadata.kind = 'synthetic'", "sample": 2})
+        finally:
+            monkeypatch.undo()
+
+    def test_init_dataset_keeps_btql_unchanged_without_eval_sample_runtime_value(self):
+        """Test that ordinary init_dataset calls are unchanged outside bt eval --sample."""
+        from braintrust.logger import init_dataset
+
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.delattr(builtins, "__bt_eval_sample_rate", raising=False)
+        try:
+            dataset = init_dataset(project="test-project", name="test-dataset", use_output=False, state=MagicMock())
+
+            self.assertIsNone(dataset._internal_btql)
+        finally:
+            monkeypatch.undo()
+
+    def test_init_dataset_forwards_bt_eval_sample_runtime_value_to_fetch(self):
+        """Test that bt eval --sample is included in fetched dataset BTQL."""
+        from braintrust.logger import init_dataset
+
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(builtins, "__bt_eval_sample_rate", 5, raising=False)
+        try:
+            mock_state = MagicMock()
+            mock_state.org_id = "test-org"
+
+            mock_app_conn = MagicMock()
+            mock_app_conn.post_json.return_value = {
+                "project": {"id": "test-project-id", "name": "test-project"},
+                "dataset": {"id": "test-dataset-id", "name": "test-dataset"},
+            }
+            mock_state.app_conn.return_value = mock_app_conn
+
+            mock_api_conn = MagicMock()
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"data": [], "cursor": None}
+            mock_api_conn.post.return_value = mock_response
+            mock_state.api_conn.return_value = mock_api_conn
+
+            dataset = init_dataset(project="test-project", name="test-dataset", use_output=False, state=mock_state)
+            list(dataset.fetch())
+
+            query_json = mock_api_conn.post.call_args[1]["json"]["query"]
+            self.assertEqual(query_json["sample"], 5)
+        finally:
+            monkeypatch.undo()
 
     @patch("braintrust.logger.BraintrustState")
     def test_dataset_internal_btql_limit_not_overwritten(self, mock_state_class):


### PR DESCRIPTION
Builds on https://github.com/braintrustdata/bt/pull/247

When doing `init_dataset()` with the `--sample N` flag, it will sample the rows.