### PR TITLE
fix: function invocation 405s on EU/self-hosted (strip /v1/proxy from proxy_conn)

### DIFF
--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -382,6 +382,18 @@ class _NoopSpan(Span):
 NOOP_SPAN: Span = _NoopSpan()
 NOOP_SPAN_PERMALINK = "https://www.braintrust.dev/noop-span"
 
+_V1_PROXY_SUFFIX = "/v1/proxy"
+
+
+def _normalize_proxy_conn_url(proxy_url: str) -> str:
+    # proxy_url may point at the universal proxy (`{api_url}/v1/proxy`) for
+    # EU/self-hosted orgs, but proxy_conn only targets Braintrust API endpoints
+    # (e.g. function/invoke, function/sandbox-list) served at the API host root.
+    # Drop the suffix so these requests resolve on all data planes.
+    if proxy_url.endswith(_V1_PROXY_SUFFIX):
+        return proxy_url[: -len(_V1_PROXY_SUFFIX)]
+    return proxy_url
+
 
 class BraintrustState:
     def __init__(self):
@@ -609,7 +621,7 @@ class BraintrustState:
         if not self._proxy_conn:
             if not self.proxy_url:
                 raise RuntimeError("Must initialize proxy_url before requesting proxy_conn")
-            self._proxy_conn = HTTPConnection(self.proxy_url, adapter=_http_adapter)
+            self._proxy_conn = HTTPConnection(_normalize_proxy_conn_url(self.proxy_url), adapter=_http_adapter)
         return self._proxy_conn
 
     def user_info(self) -> Mapping[str, Any]:

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -3868,6 +3868,20 @@ def test_check_org_info_with_git_metadata_uses_server_settings():
     assert set(state.git_metadata_settings.fields) == {"commit", "branch"}
 
 
+def test_proxy_conn_strips_v1_proxy_suffix():
+    """EU/self-hosted proxy_url ends in /v1/proxy; proxy_conn must target the API host root."""
+    state = BraintrustState()
+    state.proxy_url = "https://api-eu.braintrust.dev/v1/proxy"
+    assert state.proxy_conn().base_url == "https://api-eu.braintrust.dev"
+
+
+def test_proxy_conn_leaves_bare_host_unchanged():
+    """A bare proxy host (US default) is used as-is."""
+    state = BraintrustState()
+    state.proxy_url = "https://api.braintrust.dev"
+    assert state.proxy_conn().base_url == "https://api.braintrust.dev"
+
+
 def test_get_repo_info_without_settings_returns_none():
     """Direct call to get_repo_info with settings=None should return None."""
     assert get_repo_info(None) is None


### PR DESCRIPTION
## Issue

Function invocation on EU (and self-hosted) data planes fails with **`405 Method POST not supported`** (Pylon #18531; originally reported on the TypeScript SDK, but the Python SDK has the identical bug).

`function/invoke`, `function/sandbox-list`, and `function/code` are all POSTed through `proxy_conn`. For EU/self-hosted orgs the login response sets `proxy_url = {api_url}/v1/proxy`, but these `function/*` endpoints are served at the **API host root**, not under `/v1/proxy`. So the SDK posts to `.../v1/proxy/function/invoke` → 405.

US multi-tenant orgs avoid this by accident: their stored `proxy_url` is null, so login falls back to the bare `api_url` (no `/v1/proxy`), which routes correctly.

## Repro on current version

Login on an EU org returns `proxy_url = https://api-eu.braintrust.dev/v1/proxy`, and `proxy_conn().post("function/invoke", ...)` posts under it:

| POST target | Result |
|---|---|
| `api-eu.braintrust.dev/v1/proxy/function/invoke` (current SDK) | **405 Method POST not supported** |
| `api-eu.braintrust.dev/function/invoke` (API host root) | 400 — routed, POST accepted |

## Fix

Normalize the `proxy_conn` base URL by stripping a trailing `/v1/proxy`, so `function/*` requests resolve at the API host root on every data plane. `state.proxy_url` is left untouched.

## No endpoint-level regression

Every endpoint that flows through `proxy_conn` was probed against both bases — all route at the bare host, all 405 under `/v1/proxy` today:

| Endpoint | bare host | `/v1/proxy` |
|---|---|---|
| `function/invoke` | 400 ✓ routed | 405 ✗ |
| `function/sandbox-list` | 500 ✓ routed | 405 ✗ |
| `function/code` | 400 ✓ routed | 405 ✗ |

The OpenAI-compatible proxy path (chat/completions) does **not** go through `proxy_conn`, so the `/v1/proxy` suffix it relies on is unaffected.

## Tests

Added `proxy_conn` normalization tests in `test_logger.py`. Verified end-to-end against a live EU org: login returns `.../v1/proxy`, `proxy_conn().base_url` now resolves to the bare host.

## Note

A server-side fix (not stamping `/v1/proxy` into `org.proxy_url` for EU/self-hosted, matching US) would also fix already-released SDK versions; this SDK change helps users who upgrade.
