### PR TITLE
fix: avoid duplicate spans when a full fetch follows a typed fetch

### DIFF
--- a/py/src/braintrust/test_trace.py
+++ b/py/src/braintrust/test_trace.py
@@ -42,6 +42,28 @@ class TestCachedSpanFetcher:
         assert {s.span_id for s in result} == {"span-1", "span-2", "span-3"}
 
     @pytest.mark.asyncio
+    async def test_fetch_all_after_typed_fetch_has_no_duplicates(self):
+        """A typed fetch followed by a full fetch must not duplicate spans."""
+        all_spans = [
+            make_span("fn-1", "function"),
+            make_span("llm-1", "llm"),
+            make_span("llm-2", "llm"),
+        ]
+
+        async def fetch_fn(span_type):
+            if span_type:
+                return [s for s in all_spans if s.span_attributes["type"] in span_type]
+            return all_spans
+
+        fetcher = CachedSpanFetcher(fetch_fn=fetch_fn)
+        await fetcher.get_spans(["llm"])
+        result = await fetcher.get_spans()
+
+        span_ids = [s.span_id for s in result]
+        assert sorted(span_ids) == ["fn-1", "llm-1", "llm-2"]
+        assert len(span_ids) == len(set(span_ids)), f"duplicate spans: {span_ids}"
+
+    @pytest.mark.asyncio
     async def test_fetch_preserves_span_result_fields(self):
         """Test that fetched spans preserve fields needed for full trace attachments."""
         mock_spans = [

--- a/py/src/braintrust/trace.py
+++ b/py/src/braintrust/trace.py
@@ -260,6 +260,10 @@ class CachedSpanFetcher:
 
         # If no filter requested, fetch everything
         if not span_type or len(span_type) == 0:
+            # A full fetch is authoritative; reset the per-type cache first so a
+            # prior typed fetch's spans are not duplicated by re-fetching them
+            # (_fetch_spans appends).
+            self._span_cache = {}
             await self._fetch_spans(None)
             if self._span_cache:  # Only cache if we got results
                 self._all_fetched = True


### PR DESCRIPTION
## What

`CachedSpanFetcher.get_spans()` returns duplicate spans when a type-filtered fetch is followed by a full (unfiltered) fetch:

```python
await fetcher.get_spans(["llm"])   # caches llm-1, llm-2
await fetcher.get_spans()          # -> fn-1, llm-1, llm-1, llm-2, llm-2  ❌
```

The no-filter branch calls `_fetch_spans(None)`, which re-fetches every span, and `_fetch_spans` always **appends** into `self._span_cache[type]`. Since `llm` was already cached from the first call, its spans get appended a second time. Scorers that call `trace.get_spans([...])` and then `trace.get_spans()` get doubled results.

## Fix

A full fetch returns the authoritative complete set, so reset the per-type cache before it:

```python
if not span_type or len(span_type) == 0:
    self._span_cache = {}
    await self._fetch_spans(None)
    ...
```

The typed-fetch path is unchanged (it only fetches types not already cached, so it never double-appends). An alternative would be to make `_fetch_spans` replace per-type lists instead of appending; I went with the smaller, more localized change, but happy to switch if you'd prefer that.

## Testing

Added `test_fetch_all_after_typed_fetch_has_no_duplicates` to `TestCachedSpanFetcher` using the existing offline `fetch_fn=` injection (no API key/network). `pytest -k CachedSpanFetcher` → **17 passed**; the new test fails on `main` and passes with the fix.