### PR TITLE
chore: update Python development toolchain

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         exclude: (queryscript/tests/.*\.(expected|test)|.*cassette.*\.ya?ml)$
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.7
+    rev: v0.15.21
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-python 3.14.3
-pre-commit 4.2.0
-uv 0.11.6
+python 3.14.6
+pre-commit 4.6.0
+uv 0.11.28

--- a/mise.toml
+++ b/mise.toml
@@ -11,7 +11,7 @@ _.python.venv = { path = "py/.venv", create = true, uv_create_args = ['--seed']}
 _.file = ".env"
 
 [tools]
-ruff = "0.12.7"
+ruff = "0.15.21"
 
 [hooks]
 postinstall = "make install-deps"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -269,7 +269,7 @@ dev = [
     {include-group = "test"},
     {include-group = "build"},
     "nox==2026.2.9",
-    "pre-commit==4.5.1",
+    "pre-commit==4.6.0",
     "pylint==4.0.5",
     "pyperf==2.10.0",
 ]

--- a/py/src/braintrust/integrations/litellm/test_litellm.py
+++ b/py/src/braintrust/integrations/litellm/test_litellm.py
@@ -687,8 +687,10 @@ def test_litellm_tool_calls(memory_logger):
             "metadata": {
                 "model": TEST_MODEL,
                 "provider": "litellm",
-                "tools": lambda tools_list: len(tools_list) == 1
-                and any(tool.get("function", {}).get("name") == "get_weather" for tool in tools_list),
+                "tools": lambda tools_list: (
+                    len(tools_list) == 1
+                    and any(tool.get("function", {}).get("name") == "get_weather" for tool in tools_list)
+                ),
             },
             "input": lambda inp: "What's the weather in New York?" in str(inp),
             "metrics": lambda m: assert_metrics_are_valid(m, start, end) is None,

--- a/py/src/braintrust/integrations/openai/test_openai.py
+++ b/py/src/braintrust/integrations/openai/test_openai.py
@@ -2100,9 +2100,11 @@ def test_openai_parallel_tool_calls(memory_logger):
                         "model": TEST_MODEL,
                         "provider": "openai",
                         "stream": stream,
-                        "tools": lambda tools_list: len(tools_list) == 2
-                        and any(tool.get("function", {}).get("name") == "get_weather" for tool in tools_list)
-                        and any(tool.get("function", {}).get("name") == "get_time" for tool in tools_list),
+                        "tools": lambda tools_list: (
+                            len(tools_list) == 2
+                            and any(tool.get("function", {}).get("name") == "get_weather" for tool in tools_list)
+                            and any(tool.get("function", {}).get("name") == "get_time" for tool in tools_list)
+                        ),
                     },
                     "input": lambda inp: "What's the weather in New York and the time in Tokyo?" in str(inp),
                     "metrics": lambda m: assert_metrics_are_valid(m, start, end) is None,

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -933,11 +933,13 @@ class TestLogger(TestCase):
         )
 
         rendered = render_message(
-            lambda template: template.replace("{{item}}", "document")
-            .replace("{{image_url}}", "https://example.com/image.png")
-            .replace("{{file_data}}", "base64data")
-            .replace("{{file_id}}", "file-456")
-            .replace("{{filename}}", "report.pdf"),
+            lambda template: (
+                template.replace("{{item}}", "document")
+                .replace("{{image_url}}", "https://example.com/image.png")
+                .replace("{{file_data}}", "base64data")
+                .replace("{{file_id}}", "file-456")
+                .replace("{{filename}}", "report.pdf")
+            ),
             message,
         )
 

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -920,7 +920,7 @@ provides-extras = ["cli", "doc", "openai-agents", "otel", "performance", "tempor
 build = [{ name = "setuptools", specifier = ">=82.0.1" }]
 dev = [
     { name = "nox", specifier = "==2026.2.9" },
-    { name = "pre-commit", specifier = "==4.5.1" },
+    { name = "pre-commit", specifier = "==4.6.0" },
     { name = "pylint", specifier = "==4.0.5" },
     { name = "pyperf", specifier = "==2.10.0" },
     { name = "pytest", specifier = "==9.1.1" },
@@ -5460,7 +5460,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.5.1"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -5469,9 +5469,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bump Python, uv, pre-commit, and Ruff to their latest pinned versions. Apply the formatting changes required by the newer Ruff release.