### PR TITLE
fix: Preserve custom PYTHON_ENV span origin

### DIFF
--- a/py/src/braintrust/span_origin.py
+++ b/py/src/braintrust/span_origin.py
@@ -120,4 +120,4 @@ def _deployment_mode(value: str | None) -> SpanOriginEnvironment | None:
         return {"type": "server", "name": normalized}
     if normalized in ("development", "local"):
         return {"type": "local", "name": normalized}
-    return None
+    return {"name": value}

--- a/py/src/braintrust/test_otel.py
+++ b/py/src/braintrust/test_otel.py
@@ -177,6 +177,43 @@ def test_detect_environment_preserves_explicit_name_without_type(monkeypatch):
     assert detect_environment() == {"name": "staging"}
 
 
+def test_detect_environment_preserves_custom_python_env(monkeypatch):
+    from braintrust.span_origin import detect_environment
+
+    for key in (
+        "BRAINTRUST_ENVIRONMENT_TYPE",
+        "BRAINTRUST_ENVIRONMENT_NAME",
+        "GITHUB_ACTIONS",
+        "GITLAB_CI",
+        "CIRCLECI",
+        "BUILDKITE",
+        "JENKINS_URL",
+        "JENKINS_HOME",
+        "TF_BUILD",
+        "TEAMCITY_VERSION",
+        "TRAVIS",
+        "BITBUCKET_BUILD_NUMBER",
+        "CI",
+        "VERCEL",
+        "NETLIFY",
+        "ECS_CONTAINER_METADATA_URI",
+        "ECS_CONTAINER_METADATA_URI_V4",
+        "AWS_EXECUTION_ENV",
+        "AWS_LAMBDA_FUNCTION_NAME",
+        "K_SERVICE",
+        "FUNCTION_TARGET",
+        "KUBERNETES_SERVICE_HOST",
+        "DYNO",
+        "FLY_APP_NAME",
+        "RAILWAY_ENVIRONMENT",
+        "RENDER_SERVICE_NAME",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("PYTHON_ENV", "preview")
+
+    assert detect_environment() == {"name": "preview"}
+
+
 def test_detect_environment_classifies_lambda_when_lambda_specific(monkeypatch):
     from braintrust.span_origin import detect_environment
 


### PR DESCRIPTION
## Summary
- Preserve custom PYTHON_ENV values as span origin environment names instead of dropping them.
- Add regression coverage for PYTHON_ENV=preview after clearing higher-priority environment signals.

## Validation
- uv run pytest src/braintrust/test_otel.py -k "detect_environment"
- git diff --check

Ruff was not available in the current uv environment (`Failed to spawn: ruff`).