### PR TITLE
fix: normalize list score dicts in remote evals

### DIFF
--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -1463,17 +1463,17 @@ async def _run_evaluator_internal_impl(
             if isinstance(result, Iterable) and not isinstance(result, (str, bytes, Mapping)):
                 normalized_scores = []
                 for s in result:
+                    original_score = s
+                    score_error = None
                     if isinstance(s, dict):
                         try:
                             s = Score.from_dict(s)
                         except Exception as e:
-                            raise ValueError(
-                                f"When returning an array of scores, each score must be a valid Score object. Got: {s}"
-                            ) from e
-                    if not is_score(s):
+                            score_error = e
+                    if score_error is not None or not is_score(s):
                         raise ValueError(
-                            f"When returning an array of scores, each score must be a valid Score object. Got: {s}"
-                        )
+                            f"When returning an array of scores, each score must be a valid Score object. Got: {original_score}"
+                        ) from score_error
                     normalized_scores.append(s)
                 result = normalized_scores
             elif is_score(result):

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -1461,12 +1461,21 @@ async def _run_evaluator_internal_impl(
                     raise ValueError(f"When returning a dict, it must be a valid Score object. Got: {result}") from e
 
             if isinstance(result, Iterable) and not isinstance(result, (str, bytes, Mapping)):
+                normalized_scores = []
                 for s in result:
+                    if isinstance(s, dict):
+                        try:
+                            s = Score.from_dict(s)
+                        except Exception as e:
+                            raise ValueError(
+                                f"When returning an array of scores, each score must be a valid Score object. Got: {s}"
+                            ) from e
                     if not is_score(s):
                         raise ValueError(
                             f"When returning an array of scores, each score must be a valid Score object. Got: {s}"
                         )
-                result = list(result)
+                    normalized_scores.append(s)
+                result = normalized_scores
             elif is_score(result):
                 result = [result]
             else:

--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -1324,6 +1324,19 @@ def _build_classification_span_output(
     return grouped_output
 
 
+def _normalize_score(value: Any, error_message: str) -> ScoreLike:
+    original_value = value
+    if isinstance(value, dict):
+        try:
+            value = Score.from_dict(value)
+        except Exception as e:
+            raise ValueError(f"{error_message} Got: {original_value}") from e
+
+    if not is_score(value):
+        raise ValueError(f"{error_message} Got: {original_value}")
+    return value
+
+
 def _validate_classification_result(value: Any, classifier_name: str) -> Classification:
     if isinstance(value, Mapping):
         if not value:
@@ -1455,27 +1468,16 @@ async def _run_evaluator_internal_impl(
 
             result = await call_user_fn(event_loop, score, **kwargs)
             if isinstance(result, dict):
-                try:
-                    result = Score.from_dict(result)
-                except Exception as e:
-                    raise ValueError(f"When returning a dict, it must be a valid Score object. Got: {result}") from e
+                result = _normalize_score(result, "When returning a dict, it must be a valid Score object.")
 
             if isinstance(result, Iterable) and not isinstance(result, (str, bytes, Mapping)):
-                normalized_scores = []
-                for s in result:
-                    original_score = s
-                    score_error = None
-                    if isinstance(s, dict):
-                        try:
-                            s = Score.from_dict(s)
-                        except Exception as e:
-                            score_error = e
-                    if score_error is not None or not is_score(s):
-                        raise ValueError(
-                            f"When returning an array of scores, each score must be a valid Score object. Got: {original_score}"
-                        ) from score_error
-                    normalized_scores.append(s)
-                result = normalized_scores
+                result = [
+                    _normalize_score(
+                        score,
+                        "When returning an array of scores, each score must be a valid Score object.",
+                    )
+                    for score in result
+                ]
             elif is_score(result):
                 result = [result]
             else:

--- a/py/src/braintrust/test_framework.py
+++ b/py/src/braintrust/test_framework.py
@@ -297,6 +297,46 @@ async def test_run_evaluator_with_many_scorers():
 
 
 @pytest.mark.asyncio
+async def test_run_evaluator_normalizes_list_of_dict_scores():
+    data = [
+        EvalCase(input=1, expected=1),
+        EvalCase(input=2, expected=2),
+    ]
+
+    def simple_task(input_value):
+        return input_value
+
+    def list_dict_scorer(input_value, output, expected):
+        return [
+            {"name": "per_result", "score": 1.0},
+            {"name": "summary_only", "score": 1.0},
+        ]
+
+    evaluator = Evaluator(
+        project_name="test-project",
+        eval_name="test-list-dict-scorer",
+        data=data,
+        task=simple_task,
+        scores=[list_dict_scorer],
+        experiment_name=None,
+        metadata=None,
+    )
+
+    result = await run_evaluator(None, evaluator, None, [])
+
+    assert isinstance(result, EvalResultWithSummary)
+    assert len(result.results) == 2
+
+    for eval_result in result.results:
+        assert eval_result.scores["per_result"] == 1.0
+        assert eval_result.scores["summary_only"] == 1.0
+
+    assert result.summary.project_name == "test-project"
+    assert result.summary.scores["per_result"].score == 1.0
+    assert result.summary.scores["summary_only"].score == 1.0
+
+
+@pytest.mark.asyncio
 @pytest.mark.skipif(
     sys.version_info < (3, 14),
     reason="PEP 649 lazy annotation evaluation is 3.14+",


### PR DESCRIPTION
## Context

Valid multi-score remote scorer results from remote eval scorers are rejected. Remote eval scorers can return `list[Score]`, but that result crosses an HTTP/JSON boundary and the caller receives `list[dict]` rather than real `Score` objects. `await_or_run_scorer` normalizes a single score dict with `Score.from_dict()`, but is missing normalization for `list[dict]` responses. 
  
## Changes

  - Normalize dict entries inside scorer result lists with `Score.from_dict()`.
  - Keep existing validation for malformed score entries.
  - Add regression coverage for a scorer returning a list of score dicts.
  - Verify both per-result scores and summary scores are populated correctly.

  ## Testing

  * Added `test_run_evaluator_normalizes_list_of_dict_scores`
    - creates an evaluator with two data rows
    - uses a scorer that returns a list of two score dicts:
      - `{"name": "per_result", "score": 1.0}`
      - `"name": "summary_only", "score": 1.0}`
    - runs the evaluator locally with `run_evaluator(...)`
    - asserts each eval result contains both scores
    - asserts the final summary contains both score names with score 1.0

* Ran the focused core regression test
* Ran a local smoke test where a scorer returns multiple score dicts, confirming the eval completes and emits both expected scores.