### PR TITLE
fix: eval parameters omit null description

### DIFF
--- a/py/src/braintrust/parameters.py
+++ b/py/src/braintrust/parameters.py
@@ -12,6 +12,7 @@ from typing_extensions import NotRequired, TypeGuard
 from .generated_types import PromptBlockDataNullish, PromptOptionsNullish
 from .prompt import PromptData
 from .serializable_data_class import SerializableDataClass
+from .util import clean_nones
 
 
 if TYPE_CHECKING:
@@ -424,19 +425,23 @@ def serialize_eval_parameters(parameters: EvalParameters) -> dict[str, Any]:
 
     for name, schema in parameters.items():
         if _is_prompt_parameter(schema):
-            prompt_parameter_data: dict[str, Any] = {"type": "prompt"}
-            prompt_description = schema.get("description")
-            if prompt_description is not None:
-                prompt_parameter_data["description"] = prompt_description
+            prompt_parameter_data = clean_nones(
+                {
+                    "type": "prompt",
+                    "description": schema.get("description"),
+                }
+            )
             prompt_default = schema.get("default")
             if prompt_default is not None:
                 prompt_parameter_data["default"] = _prompt_data_to_dict(prompt_default)
             result[name] = prompt_parameter_data
         elif _is_model_parameter(schema):
-            model_parameter_data: dict[str, Any] = {"type": "model"}
-            model_description = schema.get("description")
-            if model_description is not None:
-                model_parameter_data["description"] = model_description
+            model_parameter_data = clean_nones(
+                {
+                    "type": "model",
+                    "description": schema.get("description"),
+                }
+            )
             model_default = schema.get("default")
             if model_default is not None:
                 model_parameter_data["default"] = model_default
@@ -448,13 +453,13 @@ def serialize_eval_parameters(parameters: EvalParameters) -> dict[str, Any]:
             }
         else:
             schema_json = _serialize_pydantic_parameter_schema(schema)
-            data_parameter_data: dict[str, Any] = {
-                "type": "data",
-                "schema": schema_json,
-            }
-            data_description = schema_json.get("description")
-            if data_description is not None:
-                data_parameter_data["description"] = data_description
+            data_parameter_data = clean_nones(
+                {
+                    "type": "data",
+                    "schema": schema_json,
+                    "description": schema_json.get("description"),
+                }
+            )
             if "default" in schema_json:
                 data_parameter_data["default"] = schema_json["default"]
             result[name] = data_parameter_data

--- a/py/src/braintrust/parameters.py
+++ b/py/src/braintrust/parameters.py
@@ -424,19 +424,19 @@ def serialize_eval_parameters(parameters: EvalParameters) -> dict[str, Any]:
 
     for name, schema in parameters.items():
         if _is_prompt_parameter(schema):
-            prompt_parameter_data: dict[str, Any] = {
-                "type": "prompt",
-                "description": schema.get("description"),
-            }
+            prompt_parameter_data: dict[str, Any] = {"type": "prompt"}
+            prompt_description = schema.get("description")
+            if prompt_description is not None:
+                prompt_parameter_data["description"] = prompt_description
             prompt_default = schema.get("default")
             if prompt_default is not None:
                 prompt_parameter_data["default"] = _prompt_data_to_dict(prompt_default)
             result[name] = prompt_parameter_data
         elif _is_model_parameter(schema):
-            model_parameter_data: dict[str, Any] = {
-                "type": "model",
-                "description": schema.get("description"),
-            }
+            model_parameter_data: dict[str, Any] = {"type": "model"}
+            model_description = schema.get("description")
+            if model_description is not None:
+                model_parameter_data["description"] = model_description
             model_default = schema.get("default")
             if model_default is not None:
                 model_parameter_data["default"] = model_default
@@ -451,8 +451,10 @@ def serialize_eval_parameters(parameters: EvalParameters) -> dict[str, Any]:
             data_parameter_data: dict[str, Any] = {
                 "type": "data",
                 "schema": schema_json,
-                "description": schema_json.get("description"),
             }
+            data_description = schema_json.get("description")
+            if data_description is not None:
+                data_parameter_data["description"] = data_description
             if "default" in schema_json:
                 data_parameter_data["default"] = schema_json["default"]
             result[name] = data_parameter_data

--- a/py/src/braintrust/test_parameters.py
+++ b/py/src/braintrust/test_parameters.py
@@ -637,12 +637,28 @@ def test_prompt_parameter_defaults_omit_none_values_from_dict():
     _assert_no_none_values(default)
 
 
-@pytest.mark.skipif(not HAS_PYDANTIC, reason="pydantic not installed")
 def test_serialize_eval_parameters_omits_description_when_absent():
-    from pydantic import BaseModel
+    class _FakeField:
+        required = False
 
-    class TemplateParam(BaseModel):
-        value: str = "default template"
+    class TemplateParam:
+        __fields__ = {"value": _FakeField()}
+
+        @classmethod
+        def parse_obj(cls, value):
+            return value
+
+        @classmethod
+        def schema(cls):
+            return {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "default": "default template",
+                    }
+                },
+            }
 
     serialized = serialize_eval_parameters(
         {

--- a/py/src/braintrust/test_parameters.py
+++ b/py/src/braintrust/test_parameters.py
@@ -635,3 +635,26 @@ def test_prompt_parameter_defaults_omit_none_values_from_dict():
     assert "function_call" not in default["prompt"]["messages"][0]
     assert "tool_calls" not in default["prompt"]["messages"][0]
     _assert_no_none_values(default)
+
+
+@pytest.mark.skipif(not HAS_PYDANTIC, reason="pydantic not installed")
+def test_serialize_eval_parameters_omits_description_when_absent():
+    from pydantic import BaseModel
+
+    class TemplateParam(BaseModel):
+        value: str = "default template"
+
+    serialized = serialize_eval_parameters(
+        {
+            "template": TemplateParam,
+            "main": {"type": "prompt"},
+            "judge_model": {"type": "model"},
+        }
+    )
+
+    assert serialized["template"]["type"] == "data"
+    assert serialized["template"]["default"] == "default template"
+    assert serialized["main"]["type"] == "prompt"
+    assert serialized["judge_model"]["type"] == "model"
+    for name in ("template", "main", "judge_model"):
+        assert "description" not in serialized[name]


### PR DESCRIPTION
resolves https://linear.app/braintrustdata/issue/SDK-92/remote-eval-params-with-no-description-serialize-description-null

## Summary

Remote eval dev mode (`braintrust eval <file> --dev`) hid **all** evals in the playground UI when any eval declared a parameter without a `description`.

All three branches of `serialize_eval_parameters` (prompt, model, data) emitted `"description": null` when unset. The playground's zod schema only accepts a string or an absent key, and it validates the whole `/list` response in one
`safeParse` — so one description-less parameter hid every eval on the endpoint.

Fix: include `description` only when it's not `None`, same as `default` already is. #508 fixed this pattern for prompt defaults; `description` was missed.

## Test 
With proposed change the remote eval is detected:
<img width="457" height="291" alt="Screenshot 2026-07-22 at 2 13 25 PM" src="https://github.com/user-attachments/assets/ade8ce11-2843-4b25-a291-dc6a447671e0" />

Same remote eval running in 0.30.1 is not detected:
<img width="1746" height="600" alt="image" src="https://github.com/user-attachments/assets/47409355-fcf2-4c29-8de9-1aeaa6b99099" />
