### PR TITLE
Add Trustabl security scanning to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you're building an accessible framework for Python developers to interact with Braintrust's AI evaluation features. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [HIGH] Session permission mode bypasses approvals
What it means: A ClaudeAgentOptions(.py file) is configured for session_permission_mode=True without any explicit approval mechanism or safeguard. This could lead to unauthorized access to sensitive information or actions if an attacker gains control of the agent. 2. [HIGH] Agent uses web search built-in without before_tool_callback
File: integrations/adk-py/examples/parallel/agent.py
What it means: This LlmAgent is wired with a web search built-in (the google_search instance, GoogleSearchTool, or VertexAiSearchTool) but has no before_tool_callback.  This lack of oversight could allow malicious websites to be accessed or injected into the agent's responses, compromising security and data integrity.

3. [HIGH] Agent uses web search built-in without before_tool_callback
File: integrations/adk-py/examples/parallel/agent.py
What it means: This LlmAgent is wired with a web search built-in (the google_search instance, GoogleSearchTool, or VertexAiSearchTool) but has no before_tool_callback.  This lack of oversight could allow malicious websites to be accessed or injected into the agent's responses, compromising security and data integrity.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)