### PR TITLE
fix(livekit): disable audio attachments by default

### DIFF
--- a/py/src/braintrust/integrations/livekit_agents/__init__.py
+++ b/py/src/braintrust/integrations/livekit_agents/__init__.py
@@ -5,9 +5,9 @@ from .patchers import wrap_livekit_agents
 def setup_livekit_agents() -> bool:
     """Set up LiveKit Agents tracing.
 
-    Set ``BRAINTRUST_CAPTURE_AGENT_AUDIO_ATTACHMENTS=false`` to omit agent
-    playback audio attachments while preserving the ``agent_speaking`` spans
-    and transcripts.
+    Agent playback audio attachments are disabled by default. Set
+    ``BRAINTRUST_CAPTURE_AGENT_AUDIO_ATTACHMENTS=true`` to include them on
+    ``agent_speaking`` spans.
     """
     return LiveKitAgentsIntegration.setup()
 

--- a/py/src/braintrust/integrations/livekit_agents/test_livekit_agents.py
+++ b/py/src/braintrust/integrations/livekit_agents/test_livekit_agents.py
@@ -225,7 +225,7 @@ async def test_livekit_agents_agent_audio_capture_respects_generic_env(monkeypat
 
     monkeypatch.delenv("BRAINTRUST_CAPTURE_AGENT_AUDIO_ATTACHMENTS", raising=False)
     assert await tracing.traced_audio_output_capture_frame(capture_frame, output, (frame,), {}) is frame
-    assert bytes(getattr(output, tracing._PLAYBACK_AUDIO_ATTR)) == frame.data
+    assert getattr(output, tracing._PLAYBACK_AUDIO_ATTR, None) is None
 
     monkeypatch.setenv("BRAINTRUST_CAPTURE_AGENT_AUDIO_ATTACHMENTS", "false")
     assert await tracing.traced_audio_output_capture_frame(capture_frame, output, (frame,), {}) is frame
@@ -238,7 +238,8 @@ async def test_livekit_agents_agent_audio_capture_respects_generic_env(monkeypat
 
 @pytest.mark.asyncio
 @pytest.mark.vcr
-async def test_livekit_agents_agent_speaking_e2e(memory_logger, livekit_server):
+async def test_livekit_agents_agent_speaking_e2e(memory_logger, livekit_server, monkeypatch):
+    monkeypatch.setenv("BRAINTRUST_CAPTURE_AGENT_AUDIO_ATTACHMENTS", "true")
     assert setup_livekit_agents()
 
     from livekit.agents import Agent, AgentSession

--- a/py/src/braintrust/integrations/livekit_agents/tracing.py
+++ b/py/src/braintrust/integrations/livekit_agents/tracing.py
@@ -440,7 +440,7 @@ async def traced_audio_output_capture_frame(
     if getattr(instance, _PLAYBACK_HANDLER_ATTACHED_ATTR, False):
         if getattr(instance, _PLAYBACK_START_ATTR, None) is None:
             setattr(instance, _PLAYBACK_START_ATTR, time.time())
-        if BraintrustEnv.CAPTURE_AGENT_AUDIO_ATTACHMENTS.get(True):
+        if BraintrustEnv.CAPTURE_AGENT_AUDIO_ATTACHMENTS.get(False):
             _capture_playback_audio(instance, args[0] if args else kwargs.get("frame"))
         else:
             _clear_playback_audio(instance)
@@ -680,7 +680,7 @@ def _pop_playback_audio(obj: Any) -> Attachment | None:
     audio = getattr(obj, _PLAYBACK_AUDIO_ATTR, None)
     metadata = getattr(obj, _PLAYBACK_AUDIO_METADATA_ATTR, None) or {}
     _clear_playback_audio(obj)
-    if not BraintrustEnv.CAPTURE_AGENT_AUDIO_ATTACHMENTS.get(True) or not audio:
+    if not BraintrustEnv.CAPTURE_AGENT_AUDIO_ATTACHMENTS.get(False) or not audio:
         return None
     sample_rate = metadata.get("sample_rate")
     num_channels = metadata.get("num_channels")


### PR DESCRIPTION
## Summary

- disable LiveKit agent playback audio attachments by default
- allow users to opt in with `BRAINTRUST_CAPTURE_AGENT_AUDIO_ATTACHMENTS=true`
- preserve `agent_speaking` spans and synchronized transcripts when attachments are disabled
- update the LiveKit setup documentation and regression coverage

This PR is stacked on #543, which introduces the generic audio attachment environment controls.

## Validation

- `nox -s "test_livekit_agents(latest)" -- -k "agent_audio_capture_respects_generic_env or agent_speaking_e2e"`
- `nox -s "test_livekit_agents(1.3.1)" -- -k "agent_audio_capture_respects_generic_env"`
- pre-commit checks on the changed files
- pylint on the changed files
