### PR TITLE
fix(claude_agent_sdk): stop assigning query usage to the final call

### DIFF
--- a/py/src/braintrust/integrations/anthropic/_utils.py
+++ b/py/src/braintrust/integrations/anthropic/_utils.py
@@ -53,11 +53,18 @@ def _set_numeric_metric(metrics: dict[str, float], name: str, value: Any) -> Non
         metrics[name] = float(value)
 
 
-def extract_anthropic_usage(usage: Any) -> tuple[dict[str, float], dict[str, Any]]:
+def extract_anthropic_usage(
+    usage: Any,
+    *,
+    include_output: bool = True,
+    include_legacy_cache_creation: bool = True,
+) -> tuple[dict[str, float], dict[str, Any]]:
     """Extract normalized metrics and allowlisted metadata from Anthropic usage.
 
     Numeric usage fields are converted into Braintrust metrics. Allowlisted
     non-numeric fields are attached as span metadata with a ``usage_`` prefix.
+    Anthropic's per-TTL cache creation breakdown supersedes the legacy aggregate
+    metric, and totals are emitted only when completion usage is known.
     """
     usage = _try_to_dict(usage)
     if usage is None:
@@ -66,6 +73,10 @@ def extract_anthropic_usage(usage: Any) -> tuple[dict[str, float], dict[str, Any
     metrics: dict[str, float] = {}
     metadata: dict[str, Any] = {}
     for source_name, metric_name in _ANTHROPIC_USAGE_METRIC_FIELDS:
+        if metric_name == "completion_tokens" and not include_output:
+            continue
+        if metric_name == "prompt_cache_creation_tokens" and not include_legacy_cache_creation:
+            continue
         _set_numeric_metric(metrics, metric_name, usage.get(source_name))
 
     cache_creation = _try_to_dict(usage.get("cache_creation"))
@@ -77,22 +88,36 @@ def extract_anthropic_usage(usage: Any) -> tuple[dict[str, float], dict[str, Any
                 metrics[metric_name] = float(value)
                 cache_creation_breakdown.append(float(value))
 
+    if cache_creation_breakdown:
+        metrics.pop("prompt_cache_creation_tokens", None)
+
     server_tool_use = _try_to_dict(usage.get("server_tool_use"))
     if server_tool_use is not None:
         for source_name, value in server_tool_use.items():
             _set_numeric_metric(metrics, f"server_tool_use_{source_name}", value)
 
-    if "prompt_cache_creation_tokens" not in metrics and cache_creation_breakdown:
-        metrics["prompt_cache_creation_tokens"] = sum(cache_creation_breakdown)
-
-    if metrics:
+    has_prompt_usage = any(
+        metric_name in metrics
+        for metric_name in (
+            "prompt_tokens",
+            "prompt_cached_tokens",
+            "prompt_cache_creation_tokens",
+            "prompt_cache_creation_5m_tokens",
+            "prompt_cache_creation_1h_tokens",
+        )
+    )
+    if has_prompt_usage:
+        effective_cache_creation_tokens = (
+            sum(cache_creation_breakdown)
+            if cache_creation_breakdown
+            else metrics.get("prompt_cache_creation_tokens", 0)
+        )
         total_prompt_tokens = (
-            metrics.get("prompt_tokens", 0)
-            + metrics.get("prompt_cached_tokens", 0)
-            + metrics.get("prompt_cache_creation_tokens", 0)
+            metrics.get("prompt_tokens", 0) + metrics.get("prompt_cached_tokens", 0) + effective_cache_creation_tokens
         )
         metrics["prompt_tokens"] = total_prompt_tokens
-        metrics["tokens"] = total_prompt_tokens + metrics.get("completion_tokens", 0)
+        if "completion_tokens" in metrics:
+            metrics["tokens"] = total_prompt_tokens + metrics["completion_tokens"]
 
     for name, value in usage.items():
         if name in _ANTHROPIC_USAGE_METADATA_FIELDS and value is not None:

--- a/py/src/braintrust/integrations/anthropic/test_anthropic.py
+++ b/py/src/braintrust/integrations/anthropic/test_anthropic.py
@@ -376,7 +376,6 @@ def test_extract_anthropic_usage_supports_to_dict_only_objects():
         "prompt_tokens": 21.0,
         "completion_tokens": 7.0,
         "prompt_cached_tokens": 3.0,
-        "prompt_cache_creation_tokens": 7.0,
         "prompt_cache_creation_5m_tokens": 2.0,
         "prompt_cache_creation_1h_tokens": 5.0,
         "server_tool_use_web_search_requests": 2.0,
@@ -410,7 +409,7 @@ def test_anthropic_messages_create_prompt_cache_5m_metrics(memory_logger):
 
     span = find_span_by_name(memory_logger.pop(), "anthropic.messages.create")
     assert span["output"]["role"] == response.role
-    assert span["metrics"]["prompt_cache_creation_tokens"] == response.usage.cache_creation_input_tokens
+    assert "prompt_cache_creation_tokens" not in span["metrics"]
     assert (
         span["metrics"]["prompt_cache_creation_5m_tokens"] == response.usage.cache_creation.ephemeral_5m_input_tokens
     )
@@ -442,7 +441,7 @@ def test_anthropic_messages_create_prompt_cache_1h_metrics(memory_logger):
 
     span = find_span_by_name(memory_logger.pop(), "anthropic.messages.create")
     assert span["output"]["role"] == response.role
-    assert span["metrics"]["prompt_cache_creation_tokens"] == response.usage.cache_creation_input_tokens
+    assert "prompt_cache_creation_tokens" not in span["metrics"]
     assert (
         span["metrics"]["prompt_cache_creation_5m_tokens"] == response.usage.cache_creation.ephemeral_5m_input_tokens
     )
@@ -851,7 +850,7 @@ async def test_anthropic_messages_streaming_async(memory_logger):
     assert metrics["completion_tokens"] == usage.output_tokens
     assert metrics["tokens"] == usage.input_tokens + usage.output_tokens
     assert metrics["prompt_cached_tokens"] == usage.cache_read_input_tokens
-    assert metrics["prompt_cache_creation_tokens"] == usage.cache_creation_input_tokens
+    _assert_cache_creation_metrics(metrics, usage)
     assert log["metadata"]["model"] == MODEL
     assert log["metadata"]["max_tokens"] == 1024
 
@@ -933,7 +932,7 @@ def test_anthropic_messages_streaming_sync(memory_logger):
     assert log["metrics"]["completion_tokens"] == usage.output_tokens
     assert log["metrics"]["tokens"] == usage.input_tokens + usage.output_tokens
     assert log["metrics"]["prompt_cached_tokens"] == usage.cache_read_input_tokens
-    assert log["metrics"]["prompt_cache_creation_tokens"] == usage.cache_creation_input_tokens
+    _assert_cache_creation_metrics(log["metrics"], usage)
 
 
 @pytest.mark.vcr
@@ -973,7 +972,7 @@ def test_anthropic_messages_streaming_sync_text_stream(memory_logger):
     assert log["metrics"]["completion_tokens"] == usage.output_tokens
     assert log["metrics"]["tokens"] == usage.input_tokens + usage.output_tokens
     assert log["metrics"]["prompt_cached_tokens"] == usage.cache_read_input_tokens
-    assert log["metrics"]["prompt_cache_creation_tokens"] == usage.cache_creation_input_tokens
+    _assert_cache_creation_metrics(log["metrics"], usage)
 
 
 @pytest.mark.vcr
@@ -1014,7 +1013,7 @@ async def test_anthropic_messages_streaming_async_text_stream(memory_logger):
     assert log["metrics"]["completion_tokens"] == usage.output_tokens
     assert log["metrics"]["tokens"] == usage.input_tokens + usage.output_tokens
     assert log["metrics"]["prompt_cached_tokens"] == usage.cache_read_input_tokens
-    assert log["metrics"]["prompt_cache_creation_tokens"] == usage.cache_creation_input_tokens
+    _assert_cache_creation_metrics(log["metrics"], usage)
 
 
 @pytest.mark.vcr
@@ -1117,6 +1116,30 @@ def test_anthropic_messages_sync_server_tool_spans(memory_logger):
     }
     assert tool_span["span_parents"] == [llm_span["span_id"]]
     assert tool_span["root_span_id"] == llm_span["root_span_id"]
+
+
+def _assert_cache_creation_metrics(metrics, usage):
+    cache_creation = getattr(usage, "cache_creation", None)
+    if cache_creation is None:
+        assert metrics["prompt_cache_creation_tokens"] == usage.cache_creation_input_tokens
+        return
+
+    if isinstance(cache_creation, dict):
+        ephemeral_5m = cache_creation.get("ephemeral_5m_input_tokens")
+        ephemeral_1h = cache_creation.get("ephemeral_1h_input_tokens")
+    else:
+        ephemeral_5m = getattr(cache_creation, "ephemeral_5m_input_tokens", None)
+        ephemeral_1h = getattr(cache_creation, "ephemeral_1h_input_tokens", None)
+
+    if ephemeral_5m is None and ephemeral_1h is None:
+        assert metrics["prompt_cache_creation_tokens"] == usage.cache_creation_input_tokens
+        return
+
+    assert "prompt_cache_creation_tokens" not in metrics
+    if ephemeral_5m is not None:
+        assert metrics["prompt_cache_creation_5m_tokens"] == ephemeral_5m
+    if ephemeral_1h is not None:
+        assert metrics["prompt_cache_creation_1h_tokens"] == ephemeral_1h
 
 
 def _assert_metrics_are_valid(metrics, start, end):
@@ -1467,7 +1490,7 @@ def test_setup_creates_spans(memory_logger):
         usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens
     )
     assert metrics["completion_tokens"] == usage.output_tokens
-    assert metrics["prompt_cache_creation_tokens"] == usage.cache_creation_input_tokens
+    assert "prompt_cache_creation_tokens" not in metrics
     assert metrics["prompt_cache_creation_5m_tokens"] == ephemeral_5m
     assert metrics["prompt_cache_creation_1h_tokens"] == ephemeral_1h
     assert "service_tier" not in metrics
@@ -1498,7 +1521,7 @@ def test_extract_anthropic_usage_preserves_nested_numeric_fields():
     assert metrics["prompt_tokens"] == 15
     assert metrics["completion_tokens"] == 12
     assert metrics["tokens"] == 27
-    assert metrics["prompt_cache_creation_tokens"] == 7
+    assert "prompt_cache_creation_tokens" not in metrics
     assert metrics["prompt_cache_creation_5m_tokens"] == 3
     assert metrics["prompt_cache_creation_1h_tokens"] == 4
     assert metrics["server_tool_use_web_search_requests"] == 2

--- a/py/src/braintrust/integrations/claude_agent_sdk/_test_transport.py
+++ b/py/src/braintrust/integrations/claude_agent_sdk/_test_transport.py
@@ -86,6 +86,8 @@ def _normalize_for_match(value: Any) -> Any:
         return [_normalize_for_match(item) for item in value]
     if isinstance(value, dict):
         normalized = {key: _normalize_for_match(item) for key, item in value.items()}
+        if normalized.get("type") == "user" and isinstance(normalized.get("session_id"), str):
+            normalized["session_id"] = "SESSION_ID"
         if normalized.get("type") == "control_request" and isinstance(normalized.get("request_id"), str):
             normalized["request_id"] = "CONTROL_REQUEST_ID"
         return normalized
@@ -116,8 +118,13 @@ def _compact_initialize_message_for_storage(value: dict[str, Any]) -> dict[str, 
         return value
 
     compact_result: dict[str, Any] = {}
-    if "account" in result:
-        compact_result["account"] = result["account"]
+    account = result.get("account")
+    if isinstance(account, dict):
+        compact_result["account"] = {
+            key: account[key]
+            for key in ("apiKeySource", "apiProvider", "subscriptionType", "tokenSource")
+            if key in account
+        }
 
     for key in ("available_output_styles", "commands", "models", "agents"):
         if key in result:
@@ -185,7 +192,7 @@ def _sanitize_url_string(value: str) -> str:
     return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query, doseq=True), parts.fragment))
 
 
-_PATH_RE = re.compile(r"(?:(?:/Users|/home)/[^\s\"']+|[A-Za-z]:\\\\[^\s\"']+)")
+_PATH_RE = re.compile(r"(?:(?:/Users|/home|/private/(?:tmp|var)|/tmp)/[^\s\"']+|[A-Za-z]:\\\\[^\s\"']+)")
 _AUTH_BEARER_RE = re.compile(r"Bearer\s+[A-Za-z0-9._-]+")
 _API_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]+\b")
 _SENSITIVE_FIELDS = {

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/0.1.10/test_calculator_with_multiple_operations.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/0.1.10/test_calculator_with_multiple_operations.json
@@ -10,7 +10,7 @@
             "hooks": null,
             "subtype": "initialize"
           },
-          "request_id": "req_1_cd69d436",
+          "request_id": "req_1_311ca38d",
           "type": "control_request"
         }
       }
@@ -35,7 +35,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "3c1926e5-9e80-4dab-893e-d382baf5b819",
+        "request_id": "e7bae3c0-c81e-4311-92c1-0e7b867b8484",
         "type": "control_request"
       }
     },
@@ -45,7 +45,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "3c1926e5-9e80-4dab-893e-d382baf5b819",
+            "request_id": "e7bae3c0-c81e-4311-92c1-0e7b867b8484",
             "response": {
               "mcp_response": {
                 "id": 0,
@@ -72,11 +72,11 @@
       "op": "read",
       "payload": {
         "response": {
-          "request_id": "req_1_cd69d436",
+          "request_id": "req_1_311ca38d",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
-              "tokenSource": "none"
+              "tokenSource": "claude.ai"
             },
             "available_output_styles": [],
             "commands": [],
@@ -93,7 +93,7 @@
         "kind": "json",
         "value": {
           "message": {
-            "content": "What is 15 multiplied by 7? Then subtract 5 from the result.",
+            "content": "What is 15 multiplied by 7? Then subtract 5 from the result. You must use the calculator MCP tool for both operations in order; do not calculate directly.",
             "role": "user"
           },
           "parent_tool_use_id": null,
@@ -113,7 +113,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "1c8c3717-17c1-4ae3-a2f6-39771f36f18b",
+        "request_id": "767e0d68-191c-4bce-9947-0fffbfe9acb6",
         "type": "control_request"
       }
     },
@@ -123,7 +123,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "1c8c3717-17c1-4ae3-a2f6-39771f36f18b",
+            "request_id": "767e0d68-191c-4bce-9947-0fffbfe9acb6",
             "response": {
               "mcp_response": {
                 "jsonrpc": "2.0",
@@ -156,7 +156,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "2a7e002e-e02d-42a3-a84e-23a41ee500f2",
+        "request_id": "4e62e81f-b8b3-4601-8e81-3f383c7ee668",
         "type": "control_request"
       }
     },
@@ -166,7 +166,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "2a7e002e-e02d-42a3-a84e-23a41ee500f2",
+            "request_id": "4e62e81f-b8b3-4601-8e81-3f383c7ee668",
             "response": {
               "mcp_response": {
                 "id": 0,
@@ -201,7 +201,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "0f03ca4b-ba52-479d-a051-111bba2be5ec",
+        "request_id": "b3b6a787-1af0-48f3-8e8f-ebaa0c132e3b",
         "type": "control_request"
       }
     },
@@ -211,7 +211,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "0f03ca4b-ba52-479d-a051-111bba2be5ec",
+            "request_id": "b3b6a787-1af0-48f3-8e8f-ebaa0c132e3b",
             "response": {
               "mcp_response": {
                 "id": 1,
@@ -271,7 +271,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "cffa2b30-b5c7-4b0e-a883-6b0e69679f3e",
+        "request_id": "f7b1d7ec-c1cf-4435-a23f-c0d1ce0f49d5",
         "type": "control_request"
       }
     },
@@ -281,7 +281,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "cffa2b30-b5c7-4b0e-a883-6b0e69679f3e",
+            "request_id": "f7b1d7ec-c1cf-4435-a23f-c0d1ce0f49d5",
             "response": {
               "mcp_response": {
                 "jsonrpc": "2.0",
@@ -306,7 +306,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "f5c19911-84a8-449e-a861-1698c484e380",
+        "request_id": "2af50c4d-e202-4f4e-adb2-ddb99bb63de0",
         "type": "control_request"
       }
     },
@@ -316,7 +316,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "f5c19911-84a8-449e-a861-1698c484e380",
+            "request_id": "2af50c4d-e202-4f4e-adb2-ddb99bb63de0",
             "response": {
               "mcp_response": {
                 "id": 1,
@@ -387,7 +387,7 @@
         "output_style": "default",
         "permissionMode": "bypassPermissions",
         "plugins": [],
-        "session_id": "6cce7dbe-8a4c-409a-b401-8c36a0e57b66",
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
         "skills": [],
         "slash_commands": [
           "compact",
@@ -422,7 +422,97 @@
           "mcp__calculator__calculator"
         ],
         "type": "system",
-        "uuid": "5aa2f6fd-940e-4953-b97e-7de29a5f79c0"
+        "uuid": "2a0fe665-dd5b-4c08-bb19-b879d071c1ce"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "message": {
+            "content": [
+              {
+                "text": "",
+                "type": "text"
+              }
+            ],
+            "id": "msg_011CduQMCBKLgcbrQXybxWJf",
+            "model": "claude-haiku-4-5-20251001",
+            "role": "assistant",
+            "stop_details": null,
+            "stop_reason": null,
+            "stop_sequence": null,
+            "type": "message",
+            "usage": {
+              "cache_creation": {
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 383
+              },
+              "cache_creation_input_tokens": 383,
+              "cache_read_input_tokens": 13675,
+              "inference_geo": "not_available",
+              "input_tokens": 3,
+              "output_tokens": 2,
+              "service_tier": "standard"
+            }
+          },
+          "type": "message_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "f680095f-f3ae-4c0d-a1d9-dd2c4110cc47"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "text": "",
+            "type": "text"
+          },
+          "index": 0,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "38d1d4ca-4e4d-44cc-a1e6-984276d7f33c"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "text": "I'll",
+            "type": "text_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "75c10ba0-835d-4bcb-af86-e3d0fd11ab5d"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "text": " help you calculate this using the calculator tool. Let me start with 15 multiplied by 7.",
+            "type": "text_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "5e8951a3-db31-405b-954b-8d0ca887456e"
       }
     },
     {
@@ -431,12 +521,12 @@
         "message": {
           "content": [
             {
-              "text": "I'll help you with those calculations. Let me start by multiplying 15 by 7, and then I'll subtract 5 from the result.",
+              "text": "I'll help you calculate this using the calculator tool. Let me start with 15 multiplied by 7.",
               "type": "text"
             }
           ],
           "context_management": null,
-          "id": "msg_017ojC4Qh5xsmVhPr8SQ5kWt",
+          "id": "msg_011CduQMCBKLgcbrQXybxWJf",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -446,20 +536,191 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 0
+              "ephemeral_5m_input_tokens": 383
             },
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 14015,
+            "cache_creation_input_tokens": 383,
+            "cache_read_input_tokens": 13675,
             "inference_geo": "not_available",
             "input_tokens": 3,
-            "output_tokens": 5,
+            "output_tokens": 2,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "6cce7dbe-8a4c-409a-b401-8c36a0e57b66",
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
         "type": "assistant",
-        "uuid": "097e5eee-a4c9-4c7c-9d80-2499b3267a7c"
+        "uuid": "cfcd8cfe-9962-40ad-9745-bf8cd8472cd2"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "index": 0,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "ba76d6da-c63a-4d82-bdc1-44d19089e630"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "caller": {
+              "type": "direct"
+            },
+            "id": "toolu_01FGRwJmZ64RjveiZnvXu6FL",
+            "input": {},
+            "name": "mcp__calculator__calculator",
+            "type": "tool_use"
+          },
+          "index": 1,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "32b33f49-678c-4c15-893a-908380c004db"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "7e469b37-6645-41d5-91a7-622c68b0f377"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "{\"o",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "8d276c3e-beb1-4fdf-be6d-7fa7f0a0480a"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "perat",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "1316c0e6-1399-47ed-a005-034ff4e283b2"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "ion\": \"multi",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "08675199-e172-4836-9ac8-e6c06d8b2715"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "ply\"",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "6441f23d-f100-4c7f-97d5-03312048fb11"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": ", \"a\": 15",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "963053d5-116f-4d93-933b-0ceaca85c69e"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": ", \"b\"",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "fc7121d1-f008-4e6b-a785-65da36fcea62"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": ": 7}",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "168066cb-7bf3-40be-bc12-1db11e6a9537"
       }
     },
     {
@@ -471,7 +732,7 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01UYTzcxim9GLCMvGBaNWF7n",
+              "id": "toolu_01FGRwJmZ64RjveiZnvXu6FL",
               "input": {
                 "a": 15,
                 "b": 7,
@@ -482,7 +743,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_017ojC4Qh5xsmVhPr8SQ5kWt",
+          "id": "msg_011CduQMCBKLgcbrQXybxWJf",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -492,20 +753,68 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 0
+              "ephemeral_5m_input_tokens": 383
             },
-            "cache_creation_input_tokens": 0,
-            "cache_read_input_tokens": 14015,
+            "cache_creation_input_tokens": 383,
+            "cache_read_input_tokens": 13675,
             "inference_geo": "not_available",
             "input_tokens": 3,
-            "output_tokens": 5,
+            "output_tokens": 115,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "6cce7dbe-8a4c-409a-b401-8c36a0e57b66",
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
         "type": "assistant",
-        "uuid": "15029105-1b58-4184-957e-f9931c181ed7"
+        "uuid": "ec20736f-3ea0-4989-ac80-f2c704b4c17d"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "index": 1,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "5ff54556-6970-40f1-bb2d-7f7b792f242a"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "stop_details": null,
+            "stop_reason": "tool_use",
+            "stop_sequence": null
+          },
+          "type": "message_delta",
+          "usage": {
+            "cache_creation_input_tokens": 383,
+            "cache_read_input_tokens": 13675,
+            "input_tokens": 3,
+            "output_tokens": 115
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "0582ef70-f525-484d-af52-7ac78d13117e"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "type": "message_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "b7a2175e-bd93-42e8-af92-81d483a1e5b9"
       }
     },
     {
@@ -518,7 +827,7 @@
             "method": "tools/call",
             "params": {
               "_meta": {
-                "claudecode/toolUseId": "toolu_01UYTzcxim9GLCMvGBaNWF7n"
+                "claudecode/toolUseId": "toolu_01FGRwJmZ64RjveiZnvXu6FL"
               },
               "arguments": {
                 "a": 15,
@@ -531,7 +840,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "1d58d6de-0dc8-4bef-a483-9fe98afab7eb",
+        "request_id": "1ec1e88c-0593-4db3-ad1d-92450a7f5acf",
         "type": "control_request"
       }
     },
@@ -541,7 +850,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "1d58d6de-0dc8-4bef-a483-9fe98afab7eb",
+            "request_id": "1ec1e88c-0593-4db3-ad1d-92450a7f5acf",
             "response": {
               "mcp_response": {
                 "id": 2,
@@ -574,14 +883,14 @@
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01UYTzcxim9GLCMvGBaNWF7n",
+              "tool_use_id": "toolu_01FGRwJmZ64RjveiZnvXu6FL",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "6cce7dbe-8a4c-409a-b401-8c36a0e57b66",
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
         "tool_use_result": [
           {
             "text": "The result of multiply(15, 7) is 105",
@@ -589,7 +898,97 @@
           }
         ],
         "type": "user",
-        "uuid": "26838bef-b2fd-4de5-901d-f760155a863f"
+        "uuid": "46e3fc12-ffd2-45b4-9743-3dabab7467b1"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "message": {
+            "content": [
+              {
+                "text": "Great",
+                "type": "text"
+              }
+            ],
+            "id": "msg_011CduQMHW3gFBjGWgQRmris",
+            "model": "claude-haiku-4-5-20251001",
+            "role": "assistant",
+            "stop_details": null,
+            "stop_reason": null,
+            "stop_sequence": null,
+            "type": "message",
+            "usage": {
+              "cache_creation": {
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 137
+              },
+              "cache_creation_input_tokens": 137,
+              "cache_read_input_tokens": 14058,
+              "inference_geo": "not_available",
+              "input_tokens": 6,
+              "output_tokens": 1,
+              "service_tier": "standard"
+            }
+          },
+          "type": "message_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "e1d09834-4cd9-483a-8fb6-43b42ec1b487"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "text": "",
+            "type": "text"
+          },
+          "index": 0,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "2db39510-602e-44df-8518-0c75439d9e07"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "text": "Great",
+            "type": "text_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "2e1b8548-2747-4517-9ec3-bdc61c25c1c6"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "text": "! Now I'll subtract 5 from that result (105):",
+            "type": "text_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "a8c65a43-3ed8-46d3-afcc-c036292c1c71"
       }
     },
     {
@@ -598,12 +997,12 @@
         "message": {
           "content": [
             {
-              "text": "Now let me subtract 5 from that result:",
+              "text": "Great! Now I'll subtract 5 from that result (105):",
               "type": "text"
             }
           ],
           "context_management": null,
-          "id": "msg_014Xdi9WBT6VGpsUHF62uocL",
+          "id": "msg_011CduQMHW3gFBjGWgQRmris",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -613,20 +1012,208 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 146
+              "ephemeral_5m_input_tokens": 137
             },
-            "cache_creation_input_tokens": 146,
-            "cache_read_input_tokens": 14015,
+            "cache_creation_input_tokens": 137,
+            "cache_read_input_tokens": 14058,
             "inference_geo": "not_available",
             "input_tokens": 6,
-            "output_tokens": 2,
+            "output_tokens": 1,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "6cce7dbe-8a4c-409a-b401-8c36a0e57b66",
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
         "type": "assistant",
-        "uuid": "bdaa6cb2-1c19-4ad4-a73a-172d36072d7c"
+        "uuid": "e627d275-ce64-4488-bddd-8c470e39b3d9"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "index": 0,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "3b88d050-7535-4923-86a8-4cd247cd295a"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "caller": {
+              "type": "direct"
+            },
+            "id": "toolu_019QJe6Zty4sMZTshcsgh86p",
+            "input": {},
+            "name": "mcp__calculator__calculator",
+            "type": "tool_use"
+          },
+          "index": 1,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "1287859a-d100-4f65-9ba3-9bde972dc6db"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "f2887f78-9a4e-482a-821d-0beb0d4f647e"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "{\"operat",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "487bb318-d7f6-4396-be1c-ee5f5e387f99"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "ion\": \"subt",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "66d69615-e623-4540-b01c-3e0fa53b971a"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "rac",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "547eca19-8817-4baa-aa5b-1b0edb7a0504"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "t\"",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "cbaf7622-93fd-4287-94ba-122948974a26"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": ", \"a\": 1",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "6e799f96-cbc2-4de9-bbe1-8eef2b2c9398"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "05",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "c0332510-7b17-4585-bc26-c04284e04ef7"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": ", \"b\"",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "b679f7dc-da5d-4984-b441-fd7748ba80b9"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": ": 5}",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "a760f54b-0307-41f6-8906-cbb13dccdabb"
       }
     },
     {
@@ -638,7 +1225,7 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01GmLKPpMFBaikbxxb1b3jEp",
+              "id": "toolu_019QJe6Zty4sMZTshcsgh86p",
               "input": {
                 "a": 105,
                 "b": 5,
@@ -649,7 +1236,7 @@
             }
           ],
           "context_management": null,
-          "id": "msg_014Xdi9WBT6VGpsUHF62uocL",
+          "id": "msg_011CduQMHW3gFBjGWgQRmris",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -659,20 +1246,68 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 146
+              "ephemeral_5m_input_tokens": 137
             },
-            "cache_creation_input_tokens": 146,
-            "cache_read_input_tokens": 14015,
+            "cache_creation_input_tokens": 137,
+            "cache_read_input_tokens": 14058,
             "inference_geo": "not_available",
             "input_tokens": 6,
-            "output_tokens": 2,
+            "output_tokens": 106,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "6cce7dbe-8a4c-409a-b401-8c36a0e57b66",
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
         "type": "assistant",
-        "uuid": "6f9439e9-bfa1-4ce0-862f-74ee7f2c3acd"
+        "uuid": "25efbce4-d774-4050-855c-9f645dde5120"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "index": 1,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "eb7a309d-9f2e-476a-a070-6b72e42f3cbc"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "stop_details": null,
+            "stop_reason": "tool_use",
+            "stop_sequence": null
+          },
+          "type": "message_delta",
+          "usage": {
+            "cache_creation_input_tokens": 137,
+            "cache_read_input_tokens": 14058,
+            "input_tokens": 6,
+            "output_tokens": 106
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "a547ed22-e8bb-40f3-9f24-a8d126cb1c4b"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "type": "message_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "638dfd79-f92c-461f-9e90-f631cd8019c4"
       }
     },
     {
@@ -685,7 +1320,7 @@
             "method": "tools/call",
             "params": {
               "_meta": {
-                "claudecode/toolUseId": "toolu_01GmLKPpMFBaikbxxb1b3jEp"
+                "claudecode/toolUseId": "toolu_019QJe6Zty4sMZTshcsgh86p"
               },
               "arguments": {
                 "a": 105,
@@ -698,7 +1333,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "e9a6955d-f43f-4df5-94cc-e0622e9dad2c",
+        "request_id": "5a8e069c-6420-489a-bcc2-bdc7969f10fa",
         "type": "control_request"
       }
     },
@@ -708,7 +1343,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "e9a6955d-f43f-4df5-94cc-e0622e9dad2c",
+            "request_id": "5a8e069c-6420-489a-bcc2-bdc7969f10fa",
             "response": {
               "mcp_response": {
                 "id": 3,
@@ -741,14 +1376,14 @@
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01GmLKPpMFBaikbxxb1b3jEp",
+              "tool_use_id": "toolu_019QJe6Zty4sMZTshcsgh86p",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "6cce7dbe-8a4c-409a-b401-8c36a0e57b66",
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
         "tool_use_result": [
           {
             "text": "The result of subtract(105, 5) is 100",
@@ -756,7 +1391,131 @@
           }
         ],
         "type": "user",
-        "uuid": "32a6d4ee-bd38-4f23-b45f-012a8e110176"
+        "uuid": "48373173-5de7-42a3-9516-93d6f4c83781"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "message": {
+            "content": [
+              {
+                "text": "Perfect! Here's",
+                "type": "text"
+              }
+            ],
+            "id": "msg_011CduQMNd7y6K7bVpZVqccc",
+            "model": "claude-haiku-4-5-20251001",
+            "role": "assistant",
+            "stop_details": null,
+            "stop_reason": null,
+            "stop_sequence": null,
+            "type": "message",
+            "usage": {
+              "cache_creation": {
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 131
+              },
+              "cache_creation_input_tokens": 131,
+              "cache_read_input_tokens": 14195,
+              "inference_geo": "not_available",
+              "input_tokens": 6,
+              "output_tokens": 4,
+              "service_tier": "standard"
+            }
+          },
+          "type": "message_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "13e774e0-6d4e-46b4-8e69-8aae7028e651"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "text": "",
+            "type": "text"
+          },
+          "index": 0,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "43a56949-4735-498d-8b9b-6bad0ad545c4"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "text": "Perfect! Here's",
+            "type": "text_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "257b7fe8-b3f4-4678-be2e-86d2a841ce00"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "text": " the",
+            "type": "text_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "bfea0271-4929-43fb-8425-038cbe539b8c"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "text": " step",
+            "type": "text_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "418ccf9f-43e7-4853-90f3-6fe1bc9b6db5"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "text": "-by-step solution:\n\n1. **15 \u00d7 7 = 105**\n2. **105 - 5 = 100**\n\nThe final answer is **100**.",
+            "type": "text_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "9d9f6c42-b85f-4de2-ba12-a2063cee0d01"
       }
     },
     {
@@ -765,77 +1524,125 @@
         "message": {
           "content": [
             {
-              "text": "**The answer is 100.**\n\nHere's the breakdown:\n- 15 \u00d7 7 = 105\n- 105 - 5 = 100",
+              "text": "Perfect! Here's the step-by-step solution:\n\n1. **15 \u00d7 7 = 105**\n2. **105 - 5 = 100**\n\nThe final answer is **100**.",
               "type": "text"
             }
           ],
           "context_management": null,
-          "id": "msg_01TGd8VUAQNNvvYG97ACbhYP",
+          "id": "msg_011CduQMNd7y6K7bVpZVqccc",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
-          "stop_reason": "end_turn",
+          "stop_reason": null,
           "stop_sequence": null,
           "type": "message",
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 273
+              "ephemeral_5m_input_tokens": 131
             },
-            "cache_creation_input_tokens": 273,
-            "cache_read_input_tokens": 14015,
+            "cache_creation_input_tokens": 131,
+            "cache_read_input_tokens": 14195,
             "inference_geo": "not_available",
             "input_tokens": 6,
-            "output_tokens": 40,
+            "output_tokens": 51,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "session_id": "6cce7dbe-8a4c-409a-b401-8c36a0e57b66",
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
         "type": "assistant",
-        "uuid": "d0fbb29e-8bf1-465b-9e90-8758a8a174b9"
+        "uuid": "703782dc-2230-416e-bcea-0ec3752618fa"
       }
     },
     {
       "op": "read",
       "payload": {
-        "duration_api_ms": 6148,
-        "duration_ms": 3770,
+        "event": {
+          "index": 0,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "e73c5989-e24a-4d93-9a14-f3d699ab903d"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "stop_details": null,
+            "stop_reason": "end_turn",
+            "stop_sequence": null
+          },
+          "type": "message_delta",
+          "usage": {
+            "cache_creation_input_tokens": 131,
+            "cache_read_input_tokens": 14195,
+            "input_tokens": 6,
+            "output_tokens": 51
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "6a6eb02e-ae88-423e-bb13-f08084357319"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "type": "message_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
+        "type": "stream_event",
+        "uuid": "54ef02e3-65d4-4974-bed7-4eef11f4288d"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "duration_api_ms": 5894,
+        "duration_ms": 6019,
         "is_error": false,
         "modelUsage": {
           "claude-haiku-4-5-20251001": {
-            "cacheCreationInputTokens": 8341,
-            "cacheReadInputTokens": 42045,
+            "cacheCreationInputTokens": 651,
+            "cacheReadInputTokens": 41928,
             "contextWindow": 200000,
-            "costUSD": 0.01654375,
-            "inputTokens": 18,
-            "outputTokens": 379,
+            "costUSD": 0.00820555,
+            "inputTokens": 1099,
+            "outputTokens": 420,
             "webSearchRequests": 0
           }
         },
         "num_turns": 3,
         "permission_denials": [],
-        "result": "**The answer is 100.**\n\nHere's the breakdown:\n- 15 \u00d7 7 = 105\n- 105 - 5 = 100",
-        "session_id": "6cce7dbe-8a4c-409a-b401-8c36a0e57b66",
+        "result": "Perfect! Here's the step-by-step solution:\n\n1. **15 \u00d7 7 = 105**\n2. **105 - 5 = 100**\n\nThe final answer is **100**.",
+        "session_id": "a599f44b-263c-42f3-9573-1ded7b55ca17",
         "subtype": "success",
-        "total_cost_usd": 0.01654375,
+        "total_cost_usd": 0.00820555,
         "type": "result",
         "usage": {
           "cache_creation": {
             "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 419
+            "ephemeral_5m_input_tokens": 651
           },
-          "cache_creation_input_tokens": 419,
-          "cache_read_input_tokens": 42045,
+          "cache_creation_input_tokens": 651,
+          "cache_read_input_tokens": 41928,
           "input_tokens": 15,
-          "output_tokens": 266,
+          "output_tokens": 272,
           "server_tool_use": {
             "web_fetch_requests": 0,
             "web_search_requests": 0
           },
           "service_tier": "standard"
         },
-        "uuid": "d454327a-cc69-4a57-a83c-2285c688110b"
+        "uuid": "01019bae-de3d-4c81-8208-aaf6b4499e86"
       }
     }
   ],

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_calculator_with_multiple_operations.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_calculator_with_multiple_operations.json
@@ -10,9 +10,38 @@
             "hooks": null,
             "subtype": "initialize"
           },
-          "request_id": "req_1_91cbe10f",
+          "request_id": "req_1_794c4fca",
           "type": "control_request"
         }
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "hook_event": "SessionStart",
+        "hook_id": "05a1ba74-ad3b-4b34-9e16-d8dbbe9167c6",
+        "hook_name": "SessionStart:startup",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "hook_started",
+        "type": "system",
+        "uuid": "c0140f79-9c3a-49a8-8ef1-4a640c506632"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "exit_code": 0,
+        "hook_event": "SessionStart",
+        "hook_id": "05a1ba74-ad3b-4b34-9e16-d8dbbe9167c6",
+        "hook_name": "SessionStart:startup",
+        "outcome": "success",
+        "output": "",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "stderr": "",
+        "stdout": "",
+        "subtype": "hook_response",
+        "type": "system",
+        "uuid": "99fbd7ea-4740-4a2c-8e8a-56658098dedd"
       }
     },
     {
@@ -29,7 +58,7 @@
                 "description": "Anthropic's agentic coding tool",
                 "name": "claude-code",
                 "title": "Claude Code",
-                "version": "2.1.142",
+                "version": "2.1.221",
                 "websiteUrl": "https://claude.com/claude-code"
               },
               "protocolVersion": "2025-11-25"
@@ -38,7 +67,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "d753d656-161a-47fc-ac6c-9c8b4bca9012",
+        "request_id": "9f9d12b4-d9cd-41db-bb82-8a4710788d87",
         "type": "control_request"
       }
     },
@@ -48,7 +77,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "d753d656-161a-47fc-ac6c-9c8b4bca9012",
+            "request_id": "9f9d12b4-d9cd-41db-bb82-8a4710788d87",
             "response": {
               "mcp_response": {
                 "id": 0,
@@ -75,12 +104,12 @@
       "op": "read",
       "payload": {
         "response": {
-          "request_id": "req_1_91cbe10f",
+          "request_id": "req_1_794c4fca",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
               "apiProvider": "firstParty",
-              "tokenSource": "none"
+              "tokenSource": "claude.ai"
             },
             "agents": [],
             "available_output_styles": [],
@@ -98,7 +127,7 @@
         "kind": "json",
         "value": {
           "message": {
-            "content": "What is 15 multiplied by 7? Then subtract 5 from the result.",
+            "content": "What is 15 multiplied by 7? Then subtract 5 from the result. You must use the calculator MCP tool for both operations in order; do not calculate directly.",
             "role": "user"
           },
           "parent_tool_use_id": null,
@@ -118,7 +147,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "c3a54215-23ed-47a6-865e-29f8f069e3c4",
+        "request_id": "d63c1596-7777-4da7-a7cb-cc3495765b1c",
         "type": "control_request"
       }
     },
@@ -128,67 +157,11 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "c3a54215-23ed-47a6-865e-29f8f069e3c4",
+            "request_id": "d63c1596-7777-4da7-a7cb-cc3495765b1c",
             "response": {
               "mcp_response": {
                 "jsonrpc": "2.0",
                 "result": {}
-              }
-            },
-            "subtype": "success"
-          },
-          "type": "control_response"
-        }
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "request": {
-          "message": {
-            "id": 0,
-            "jsonrpc": "2.0",
-            "method": "initialize",
-            "params": {
-              "capabilities": {},
-              "clientInfo": {
-                "description": "Anthropic's agentic coding tool",
-                "name": "claude-code",
-                "title": "Claude Code",
-                "version": "2.1.142",
-                "websiteUrl": "https://claude.com/claude-code"
-              },
-              "protocolVersion": "2025-11-25"
-            }
-          },
-          "server_name": "calculator",
-          "subtype": "mcp_message"
-        },
-        "request_id": "f82268a6-bd01-41dc-aab9-14c0a8a9977b",
-        "type": "control_request"
-      }
-    },
-    {
-      "op": "write",
-      "payload": {
-        "kind": "json",
-        "value": {
-          "response": {
-            "request_id": "f82268a6-bd01-41dc-aab9-14c0a8a9977b",
-            "response": {
-              "mcp_response": {
-                "id": 0,
-                "jsonrpc": "2.0",
-                "result": {
-                  "capabilities": {
-                    "tools": {}
-                  },
-                  "protocolVersion": "2024-11-05",
-                  "serverInfo": {
-                    "name": "calculator",
-                    "version": "1.0.0"
-                  }
-                }
               }
             },
             "subtype": "success"
@@ -209,7 +182,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "d8fbcfa4-d04e-45d6-a393-07d6e0b02b8c",
+        "request_id": "4d80ea33-22c0-4440-84c5-d65239844f09",
         "type": "control_request"
       }
     },
@@ -219,7 +192,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "d8fbcfa4-d04e-45d6-a393-07d6e0b02b8c",
+            "request_id": "4d80ea33-22c0-4440-84c5-d65239844f09",
             "response": {
               "mcp_response": {
                 "id": 1,
@@ -271,40 +244,6 @@
     {
       "op": "read",
       "payload": {
-        "request": {
-          "message": {
-            "jsonrpc": "2.0",
-            "method": "notifications/initialized"
-          },
-          "server_name": "calculator",
-          "subtype": "mcp_message"
-        },
-        "request_id": "17eeac60-91df-4fd0-9328-41962c081c53",
-        "type": "control_request"
-      }
-    },
-    {
-      "op": "write",
-      "payload": {
-        "kind": "json",
-        "value": {
-          "response": {
-            "request_id": "17eeac60-91df-4fd0-9328-41962c081c53",
-            "response": {
-              "mcp_response": {
-                "jsonrpc": "2.0",
-                "result": {}
-              }
-            },
-            "subtype": "success"
-          },
-          "type": "control_response"
-        }
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
         "agents": [
           "claude",
           "Explore",
@@ -314,14 +253,16 @@
         ],
         "analytics_disabled": false,
         "apiKeySource": "ANTHROPIC_API_KEY",
-        "claude_code_version": "2.1.142",
+        "capabilities": [
+          "interrupt_receipt_v1",
+          "interrupt_cancel_queued_v1",
+          "msg_lifecycle_v1"
+        ],
+        "claude_code_version": "2.1.221",
         "cwd": "<REDACTED_CWD>",
+        "fast_mode_disabled_reason": "sdk_opt_in_required",
         "fast_mode_state": "off",
         "mcp_servers": [
-          {
-            "name": "braintrust",
-            "status": "connected"
-          },
           {
             "name": "linear-server",
             "status": "connected"
@@ -341,78 +282,107 @@
           {
             "name": "rust-analyzer-lsp",
             "path": "<REDACTED_PATH>",
-            "source": "rust-analyzer-lsp@claude-plugins-official"
+            "source": "rust-analyzer-lsp@claude-plugins-official",
+            "version": "1.0.0"
           }
         ],
-        "session_id": "bb4c779d-c1e5-47ef-a8f4-c29a8a4e7653",
+        "product_feedback_disabled": false,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
         "skills": [
-          "create-braintrust-demo",
           "braintrust",
+          "create-braintrust-demo",
+          "commit-message",
+          "sdk-benchmarking",
+          "sdk-ci-triage",
           "sdk-dependency-updates",
           "sdk-integrations",
           "sdk-vcr-workflows",
-          "sdk-ci-triage",
-          "commit-message",
-          "sdk-benchmarking",
+          "design-sync",
+          "dataviz",
           "update-config",
+          "verify",
           "debug",
+          "code-review",
           "simplify",
           "batch",
           "fewer-permission-prompts",
-          "loop",
-          "claude-api"
-        ],
-        "slash_commands": [
-          "create-braintrust-demo",
-          "braintrust",
-          "sdk-dependency-updates",
-          "sdk-integrations",
-          "sdk-vcr-workflows",
-          "sdk-ci-triage",
-          "commit-message",
-          "sdk-benchmarking",
-          "update-config",
-          "debug",
-          "simplify",
-          "batch",
-          "fewer-permission-prompts",
+          "doctor",
           "loop",
           "claude-api",
+          "run",
+          "run-skill-generator"
+        ],
+        "slash_commands": [
+          "braintrust",
+          "create-braintrust-demo",
+          "commit-message",
+          "sdk-benchmarking",
+          "sdk-ci-triage",
+          "sdk-dependency-updates",
+          "sdk-integrations",
+          "sdk-vcr-workflows",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "run",
+          "run-skill-generator",
+          "agents",
+          "autocompact",
           "clear",
+          "color",
           "compact",
+          "config",
           "context",
+          "effort",
+          "fast",
           "heapdump",
           "init",
+          "mcp",
+          "import",
+          "model",
+          "__remote-workflow",
+          "workflow-launch-exec",
+          "reload-skills",
+          "rename",
           "review",
           "security-review",
           "usage",
           "insights",
+          "recap",
           "goal",
+          "design",
+          "design-consent",
+          "design-revoke",
           "team-onboarding"
         ],
         "subtype": "init",
         "tools": [
           "Task",
-          "AskUserQuestion",
           "Bash",
           "CronCreate",
           "CronDelete",
           "CronList",
+          "DesignSync",
           "Edit",
-          "EnterPlanMode",
           "EnterWorktree",
-          "ExitPlanMode",
           "ExitWorktree",
-          "Glob",
-          "Grep",
-          "ListMcpResourcesTool",
           "LSP",
           "Monitor",
           "NotebookEdit",
           "PushNotification",
           "Read",
-          "ReadMcpResourceTool",
+          "ReportFindings",
           "ScheduleWakeup",
+          "SendMessage",
           "Skill",
           "TaskCreate",
           "TaskGet",
@@ -424,23 +394,19 @@
           "WebFetch",
           "WebSearch",
           "Write",
-          "mcp__braintrust__generate_permalink",
-          "mcp__braintrust__infer_schema",
-          "mcp__braintrust__list_recent_objects",
-          "mcp__braintrust__resolve_object",
-          "mcp__braintrust__search_docs",
-          "mcp__braintrust__sql_query",
-          "mcp__braintrust__summarize_experiment",
           "mcp__calculator__calculator",
           "mcp__linear-server__create_attachment",
           "mcp__linear-server__create_attachment_from_upload",
+          "mcp__linear-server__create_initiative_label",
           "mcp__linear-server__create_issue_label",
           "mcp__linear-server__delete_attachment",
           "mcp__linear-server__delete_comment",
           "mcp__linear-server__delete_customer",
           "mcp__linear-server__delete_customer_need",
+          "mcp__linear-server__delete_diff_comment",
           "mcp__linear-server__delete_status_update",
           "mcp__linear-server__extract_images",
+          "mcp__linear-server__get_agent_skill",
           "mcp__linear-server__get_attachment",
           "mcp__linear-server__get_diff",
           "mcp__linear-server__get_diff_threads",
@@ -450,14 +416,19 @@
           "mcp__linear-server__get_issue_status",
           "mcp__linear-server__get_milestone",
           "mcp__linear-server__get_project",
+          "mcp__linear-server__get_release",
+          "mcp__linear-server__get_release_note",
           "mcp__linear-server__get_status_updates",
           "mcp__linear-server__get_team",
           "mcp__linear-server__get_user",
+          "mcp__linear-server__get_workspace",
+          "mcp__linear-server__list_agent_skills",
           "mcp__linear-server__list_comments",
           "mcp__linear-server__list_customers",
           "mcp__linear-server__list_cycles",
           "mcp__linear-server__list_diffs",
           "mcp__linear-server__list_documents",
+          "mcp__linear-server__list_initiative_labels",
           "mcp__linear-server__list_initiatives",
           "mcp__linear-server__list_issue_labels",
           "mcp__linear-server__list_issue_statuses",
@@ -465,22 +436,257 @@
           "mcp__linear-server__list_milestones",
           "mcp__linear-server__list_project_labels",
           "mcp__linear-server__list_projects",
+          "mcp__linear-server__list_release_notes",
+          "mcp__linear-server__list_release_pipelines",
+          "mcp__linear-server__list_releases",
           "mcp__linear-server__list_teams",
           "mcp__linear-server__list_users",
+          "mcp__linear-server__merge_diff",
           "mcp__linear-server__prepare_attachment_upload",
+          "mcp__linear-server__resolve_diff_thread",
           "mcp__linear-server__save_comment",
           "mcp__linear-server__save_customer",
           "mcp__linear-server__save_customer_need",
+          "mcp__linear-server__save_diff_comment",
           "mcp__linear-server__save_document",
           "mcp__linear-server__save_initiative",
           "mcp__linear-server__save_issue",
           "mcp__linear-server__save_milestone",
           "mcp__linear-server__save_project",
+          "mcp__linear-server__save_release",
+          "mcp__linear-server__save_release_note",
           "mcp__linear-server__save_status_update",
-          "mcp__linear-server__search_documentation"
+          "mcp__linear-server__search_documentation",
+          "mcp__linear-server__submit_diff_review"
         ],
         "type": "system",
-        "uuid": "3f6cb2af-f837-4c20-9c65-d3533b01be5f"
+        "uuid": "32015a3b-3d26-45d7-a838-2540b983c020"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "status": "requesting",
+        "subtype": "status",
+        "type": "system",
+        "uuid": "8d6bdf95-0c47-42dd-b8da-a9cfcb785a34"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "message": {
+            "content": [],
+            "diagnostics": null,
+            "id": "msg_011CduQFwRB6kQFY7QFEMHPW",
+            "model": "claude-haiku-4-5-20251001",
+            "role": "assistant",
+            "stop_details": null,
+            "stop_reason": null,
+            "stop_sequence": null,
+            "type": "message",
+            "usage": {
+              "cache_creation": {
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 7968
+              },
+              "cache_creation_input_tokens": 7968,
+              "cache_read_input_tokens": 9310,
+              "inference_geo": "not_available",
+              "input_tokens": 10,
+              "output_tokens": 3,
+              "service_tier": "standard"
+            }
+          },
+          "type": "message_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "ttft_ms": 816,
+        "type": "stream_event",
+        "uuid": "3e953d71-4588-4419-be70-564bdc20ec4f"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "signature": "<REDACTED_SIGNATURE>",
+            "thinking": "",
+            "type": "thinking"
+          },
+          "index": 0,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "a88bc887-6945-4f4d-8fca-2da2e63c84ab"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 4,
+        "estimated_tokens_delta": 4,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "01b3a4cc-d953-4206-9a19-3a7288b4b145"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "estimated_tokens": null,
+            "thinking": "The user wants",
+            "type": "thinking_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "a530b614-2d2b-4d60-b814-b28f5a889336"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 6,
+        "estimated_tokens_delta": 2,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "6de4f574-ebc4-4471-b1cc-bcbcd5722091"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "estimated_tokens": null,
+            "thinking": " me to:",
+            "type": "thinking_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "2a9d62ef-d3e8-4b6e-aaee-986a5d608659"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 45,
+        "estimated_tokens_delta": 39,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "9d47372a-6441-4f73-8064-b490f708755c"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "estimated_tokens": null,
+            "thinking": "\n1. Multiply 15 by 7 using the calculator MCP tool\n2. Subtract 5 from the result using the calculator MCP tool\n3. I should use the tool for both operations,",
+            "type": "thinking_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "8b25aac8-1136-4689-9f04-1d7f4ad59fd1"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 78,
+        "estimated_tokens_delta": 33,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "73c00dd4-7ac2-4ff9-a3ed-0b39aa100e0b"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "estimated_tokens": null,
+            "thinking": " not calculate directly\n\nFirst, I need to load the calculator tool schema using ToolSearch since it's in the deferred tools list.",
+            "type": "thinking_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "7817d2f5-ee20-440c-a4aa-96d50b9e0e79"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "estimated_tokens": null,
+            "thinking": "",
+            "type": "thinking_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "684398ad-9f77-4665-9e02-9e0a5522dc3b"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 140,
+        "estimated_tokens_delta": 62,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "ff3b2ffc-ed62-4aba-9286-e01dce30ca46"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "signature": "<REDACTED_SIGNATURE>",
+            "type": "signature_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "853d12ad-c026-4c4a-bfd5-3eea031633c6"
       }
     },
     {
@@ -490,13 +696,13 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The user is asking me to:\n1. Calculate 15 multiplied by 7\n2. Subtract 5 from the result\n\nI have a calculator tool available (mcp__calculator__calculator) that can help with this. Let me use it.\n\nFirst, I'll multiply 15 by 7:\n15 * 7 = 105\n\nThen I'll subtract 5 from 105:\n105 - 5 = 100\n\nLet me use the calculator tool to do this.",
+              "thinking": "The user wants me to:\n1. Multiply 15 by 7 using the calculator MCP tool\n2. Subtract 5 from the result using the calculator MCP tool\n3. I should use the tool for both operations, not calculate directly\n\nFirst, I need to load the calculator tool schema using ToolSearch since it's in the deferred tools list.",
               "type": "thinking"
             }
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_01DwPD3GgcGBZcg5NdzSNXsU",
+          "id": "msg_011CduQFwRB6kQFY7QFEMHPW",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -506,21 +712,229 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 44678
+              "ephemeral_5m_input_tokens": 7968
             },
-            "cache_creation_input_tokens": 44678,
-            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 7968,
+            "cache_read_input_tokens": 9310,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 7,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "request_id": "req_011CbC7Voev5n1eRQF6cEwLi",
-        "session_id": "bb4c779d-c1e5-47ef-a8f4-c29a8a4e7653",
+        "request_id": "req_011CduQFvvekwx92jXZasRZd",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "timestamp": "2026-08-10T16:42:24.845Z",
         "type": "assistant",
-        "uuid": "e5f9f36e-a79f-43e3-b661-4c5986930b41"
+        "uuid": "5409dfb1-af92-4059-a056-ddec102a84b7"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "index": 0,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "eb5fc07e-59c3-4edc-9e5c-6cbfa9966aa5"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "text": "",
+            "type": "text"
+          },
+          "index": 1,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "56a7ff73-c13a-41b7-b7fe-31f1e1817777"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "text": "I'll use the calculator MCP tool to perform these operations. First, let me load the tool schema.",
+            "type": "text_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "741334b2-1547-4c70-a7be-7af4a5e4a374"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "I'll use the calculator MCP tool to perform these operations. First, let me load the tool schema.",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduQFwRB6kQFY7QFEMHPW",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 7968
+            },
+            "cache_creation_input_tokens": 7968,
+            "cache_read_input_tokens": 9310,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 3,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "request_id": "req_011CduQFvvekwx92jXZasRZd",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "timestamp": "2026-08-10T16:42:24.849Z",
+        "type": "assistant",
+        "uuid": "f0443f52-e96a-4855-8cf9-4349dcc2a262"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "index": 1,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "a4101812-d39f-4299-8412-54268a6e843f"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "caller": {
+              "type": "direct"
+            },
+            "id": "toolu_01TZAKVGw1q3H5Hi1gZfbgqw",
+            "input": {},
+            "name": "ToolSearch",
+            "type": "tool_use"
+          },
+          "index": 2,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "05a6379e-230a-4a82-9c4e-21ed6497b08e"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "",
+            "type": "input_json_delta"
+          },
+          "index": 2,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "40d4337c-9aa6-4371-adfe-5b20a5a3e979"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "{\"query\": \"select",
+            "type": "input_json_delta"
+          },
+          "index": 2,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "e4fe3025-e5d2-48f4-a286-220b9f69e540"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": ":mcp__calculator__calculator",
+            "type": "input_json_delta"
+          },
+          "index": 2,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "80a79c35-3a15-4dd2-bea5-ff07f9a87ab4"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "\", \"max_results\": 1",
+            "type": "input_json_delta"
+          },
+          "index": 2,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "d70f2123-b900-4ba3-a934-382bbb8cdb95"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "}",
+            "type": "input_json_delta"
+          },
+          "index": 2,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "e53e9ea8-e82c-4a68-a8b2-8a40a88f4dd6"
       }
     },
     {
@@ -532,7 +946,494 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01LpaCWLeKNFQ8yoWYMEjid1",
+              "id": "toolu_01TZAKVGw1q3H5Hi1gZfbgqw",
+              "input": {
+                "max_results": 1,
+                "query": "select:mcp__calculator__calculator"
+              },
+              "name": "ToolSearch",
+              "type": "tool_use"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduQFwRB6kQFY7QFEMHPW",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 7968
+            },
+            "cache_creation_input_tokens": 7968,
+            "cache_read_input_tokens": 9310,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 3,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "request_id": "req_011CduQFvvekwx92jXZasRZd",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "timestamp": "2026-08-10T16:42:25.212Z",
+        "type": "assistant",
+        "uuid": "f48ee775-6d44-4c92-9d3e-4d7f31668a16"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "index": 2,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "f51f2591-26ff-489a-be9b-1fccd48303a1"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "context_management": {
+            "applied_edits": []
+          },
+          "delta": {
+            "stop_details": null,
+            "stop_reason": "tool_use",
+            "stop_sequence": null
+          },
+          "type": "message_delta",
+          "usage": {
+            "cache_creation_input_tokens": 7968,
+            "cache_read_input_tokens": 9310,
+            "input_tokens": 10,
+            "iterations": [
+              {
+                "cache_creation": {
+                  "ephemeral_1h_input_tokens": 0,
+                  "ephemeral_5m_input_tokens": 7968
+                },
+                "cache_creation_input_tokens": 7968,
+                "cache_read_input_tokens": 9310,
+                "input_tokens": 10,
+                "output_tokens": 191,
+                "type": "message"
+              }
+            ],
+            "output_tokens": 191,
+            "output_tokens_details": {
+              "thinking_tokens": 86
+            }
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "780d05dc-30e0-440e-b02a-885c99c3827b"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "type": "message_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "33021dbe-97c1-493b-8f42-637fc3b305f2"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": [
+                {
+                  "tool_name": "mcp__calculator__calculator",
+                  "type": "tool_reference"
+                }
+              ],
+              "tool_use_id": "toolu_01TZAKVGw1q3H5Hi1gZfbgqw",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "timestamp": "2026-08-10T16:42:25.408Z",
+        "tool_use_result": {
+          "matches": [
+            "mcp__calculator__calculator"
+          ],
+          "query": "select:mcp__calculator__calculator",
+          "total_deferred_tools": 83
+        },
+        "type": "user",
+        "uuid": "60601c87-63d1-48aa-8414-cd5b7f2542e9"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "status": "requesting",
+        "subtype": "status",
+        "type": "system",
+        "uuid": "929e97ec-dfe0-4b35-b62a-83c027c342f6"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "message": {
+            "content": [],
+            "diagnostics": null,
+            "id": "msg_011CduQG7FGUZDLiEcbc2WK2",
+            "model": "claude-haiku-4-5-20251001",
+            "role": "assistant",
+            "stop_details": null,
+            "stop_reason": null,
+            "stop_sequence": null,
+            "type": "message",
+            "usage": {
+              "cache_creation": {
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 348
+              },
+              "cache_creation_input_tokens": 348,
+              "cache_read_input_tokens": 17278,
+              "inference_geo": "not_available",
+              "input_tokens": 10,
+              "output_tokens": 1,
+              "service_tier": "standard"
+            }
+          },
+          "type": "message_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "ttft_ms": 607,
+        "type": "stream_event",
+        "uuid": "13c31e0c-8b6c-4432-ae92-5d3b70e78797"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "signature": "<REDACTED_SIGNATURE>",
+            "thinking": "",
+            "type": "thinking"
+          },
+          "index": 0,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "a012b715-b4d0-4aab-9ec9-462a8fd58de0"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 1,
+        "estimated_tokens_delta": 1,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "91664dc5-f7f3-4452-8417-526c1bac2573"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "estimated_tokens": null,
+            "thinking": "Good",
+            "type": "thinking_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "cedbb695-9792-42df-9bbc-bee243c836ea"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 35,
+        "estimated_tokens_delta": 34,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "24fa4699-fbb0-4c72-be89-7a257258dfd6"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "estimated_tokens": null,
+            "thinking": ", now I have the calculator tool schema. Let me perform the operations:\n1. First: multiply 15 by 7\n2. Then: subtract 5 from the result",
+            "type": "thinking_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "1578667d-fb43-4b03-9d55-09d512aee91b"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 43,
+        "estimated_tokens_delta": 8,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "ea32b5c5-05b6-4cc6-967e-a42a6b887294"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "estimated_tokens": null,
+            "thinking": "\n\nLet me do the first operation.",
+            "type": "thinking_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "b61b7ad9-4020-4b51-b47f-2d0057539285"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 106,
+        "estimated_tokens_delta": 63,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "106bbe6a-3e3e-452d-bc56-75282dc16d45"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "signature": "<REDACTED_SIGNATURE>",
+            "type": "signature_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "1c21a0ef-fa76-46ac-8586-445945a2baa3"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "Good, now I have the calculator tool schema. Let me perform the operations:\n1. First: multiply 15 by 7\n2. Then: subtract 5 from the result\n\nLet me do the first operation.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduQG7FGUZDLiEcbc2WK2",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 348
+            },
+            "cache_creation_input_tokens": 348,
+            "cache_read_input_tokens": 17278,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 1,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "request_id": "req_011CduQG6imELH3EhZWHohj3",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "timestamp": "2026-08-10T16:42:26.761Z",
+        "type": "assistant",
+        "uuid": "d570b5ed-a05d-43d6-91f0-0367ebce2ad5"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "index": 0,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "6192e5bc-d31a-4eda-899a-a1d6aae973ff"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "caller": {
+              "type": "direct"
+            },
+            "id": "toolu_0111F8QYQdeiTkpRGntVoBsk",
+            "input": {},
+            "name": "mcp__calculator__calculator",
+            "type": "tool_use"
+          },
+          "index": 1,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "875440c1-1bcb-44ae-9c79-e3a6c1e73534"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "c03f0514-0585-4c23-ae79-1e5d2c0dd6a6"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "{\"operation\": \"multiply",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "9a18a8a8-8438-4239-9b67-19a249fc4b79"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "\", \"a\": 15",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "d64760c3-354f-404f-9e4d-3f35d841206c"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": ", \"b\": 7",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "d6a866aa-0736-47ff-85bc-413bae65d55a"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "}",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "9a3644ad-8a71-4bf1-a93b-37f4da1d4c04"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "caller": {
+                "type": "direct"
+              },
+              "id": "toolu_0111F8QYQdeiTkpRGntVoBsk",
               "input": {
                 "a": 15,
                 "b": 7,
@@ -544,7 +1445,7 @@
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_01DwPD3GgcGBZcg5NdzSNXsU",
+          "id": "msg_011CduQG7FGUZDLiEcbc2WK2",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -554,21 +1455,29 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 44678
+              "ephemeral_5m_input_tokens": 348
             },
-            "cache_creation_input_tokens": 44678,
-            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 348,
+            "cache_read_input_tokens": 17278,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 7,
+            "output_tokens": 1,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "request_id": "req_011CbC7Voev5n1eRQF6cEwLi",
-        "session_id": "bb4c779d-c1e5-47ef-a8f4-c29a8a4e7653",
+        "request_id": "req_011CduQG6imELH3EhZWHohj3",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "timestamp": "2026-08-10T16:42:26.851Z",
+        "tool_use_meta": [
+          {
+            "display_name": "Calculator",
+            "id": "toolu_0111F8QYQdeiTkpRGntVoBsk",
+            "server_display_name": "calculator"
+          }
+        ],
         "type": "assistant",
-        "uuid": "a31d2a29-2c3d-46a5-a359-fffe0f07333e"
+        "uuid": "de7e544e-327a-4c3f-9402-35083af790c9"
       }
     },
     {
@@ -581,7 +1490,7 @@
             "method": "tools/call",
             "params": {
               "_meta": {
-                "claudecode/toolUseId": "toolu_01LpaCWLeKNFQ8yoWYMEjid1",
+                "claudecode/toolUseId": "toolu_0111F8QYQdeiTkpRGntVoBsk",
                 "progressToken": 2
               },
               "arguments": {
@@ -595,7 +1504,7 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "9aaa0bf1-3ff0-42e9-abc2-fb668f1f26da",
+        "request_id": "eb8f6e07-a846-48d4-9155-4d9d5317f258",
         "type": "control_request"
       }
     },
@@ -605,7 +1514,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "9aaa0bf1-3ff0-42e9-abc2-fb668f1f26da",
+            "request_id": "eb8f6e07-a846-48d4-9155-4d9d5317f258",
             "response": {
               "mcp_response": {
                 "id": 2,
@@ -629,6 +1538,73 @@
     {
       "op": "read",
       "payload": {
+        "event": {
+          "index": 1,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "1d5cc096-d827-4fb7-9231-a05cc00ad7a8"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "context_management": {
+            "applied_edits": []
+          },
+          "delta": {
+            "stop_details": null,
+            "stop_reason": "tool_use",
+            "stop_sequence": null
+          },
+          "type": "message_delta",
+          "usage": {
+            "cache_creation_input_tokens": 348,
+            "cache_read_input_tokens": 17278,
+            "input_tokens": 10,
+            "iterations": [
+              {
+                "cache_creation": {
+                  "ephemeral_1h_input_tokens": 0,
+                  "ephemeral_5m_input_tokens": 348
+                },
+                "cache_creation_input_tokens": 348,
+                "cache_read_input_tokens": 17278,
+                "input_tokens": 10,
+                "output_tokens": 146,
+                "type": "message"
+              }
+            ],
+            "output_tokens": 146,
+            "output_tokens_details": {
+              "thinking_tokens": 53
+            }
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "e8b5bb24-6e56-4e80-b332-ce2ddc172e78"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "type": "message_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "d8e68b25-6eec-445f-a65d-0a6523538713"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
         "message": {
           "content": [
             {
@@ -638,15 +1614,15 @@
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01LpaCWLeKNFQ8yoWYMEjid1",
+              "tool_use_id": "toolu_0111F8QYQdeiTkpRGntVoBsk",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "bb4c779d-c1e5-47ef-a8f4-c29a8a4e7653",
-        "timestamp": "2026-05-19T14:49:21.682Z",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "timestamp": "2026-08-10T16:42:27.020Z",
         "tool_use_result": [
           {
             "text": "The result of multiply(15, 7) is 105",
@@ -654,7 +1630,318 @@
           }
         ],
         "type": "user",
-        "uuid": "9686c823-1472-4980-9221-8fd4abed53a6"
+        "uuid": "b81d57c4-e64f-40e8-9315-d6cdf55edf88"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "status": "requesting",
+        "subtype": "status",
+        "type": "system",
+        "uuid": "ee544430-4ecc-42b1-bd83-f442853ecae2"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "message": {
+            "content": [],
+            "diagnostics": null,
+            "id": "msg_011CduQGEByr7wexPetXQzBy",
+            "model": "claude-haiku-4-5-20251001",
+            "role": "assistant",
+            "stop_details": null,
+            "stop_reason": null,
+            "stop_sequence": null,
+            "type": "message",
+            "usage": {
+              "cache_creation": {
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 180
+              },
+              "cache_creation_input_tokens": 180,
+              "cache_read_input_tokens": 17626,
+              "inference_geo": "not_available",
+              "input_tokens": 8,
+              "output_tokens": 3,
+              "service_tier": "standard"
+            }
+          },
+          "type": "message_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "ttft_ms": 631,
+        "type": "stream_event",
+        "uuid": "f99dce0e-dee8-48c1-a488-e32e8a8180c9"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "signature": "<REDACTED_SIGNATURE>",
+            "thinking": "",
+            "type": "thinking"
+          },
+          "index": 0,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "a632071e-370a-4960-bd37-9cf955015fa6"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 2,
+        "estimated_tokens_delta": 2,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "bdb16e44-085d-4e33-bd56-0a12f8a8e47d"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "estimated_tokens": null,
+            "thinking": "Great! ",
+            "type": "thinking_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "76b57ac6-838b-476d-9dd8-11c1f3e840d5"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 14,
+        "estimated_tokens_delta": 12,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "4f7631ff-d0e5-4073-b562-4dc1a77e76f5"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "estimated_tokens": null,
+            "thinking": "15 \u00d7 7 = 105. Now I need to subtract 5 from 105.",
+            "type": "thinking_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "f72124b1-acbf-424d-ae20-1f55a4ad0ada"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 78,
+        "estimated_tokens_delta": 64,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "35233214-6619-4631-bd03-e401713e80b7"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "signature": "<REDACTED_SIGNATURE>",
+            "type": "signature_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "a2b23cbc-4c80-4f2f-9ae0-e485257d1cb5"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "Great! 15 \u00d7 7 = 105. Now I need to subtract 5 from 105.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduQGEByr7wexPetXQzBy",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 180
+            },
+            "cache_creation_input_tokens": 180,
+            "cache_read_input_tokens": 17626,
+            "inference_geo": "not_available",
+            "input_tokens": 8,
+            "output_tokens": 3,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "request_id": "req_011CduQGDU56gpe4GQ6gNg9W",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "timestamp": "2026-08-10T16:42:27.987Z",
+        "type": "assistant",
+        "uuid": "c0cf1d8f-4458-4b8d-a741-036177d60008"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "index": 0,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "174244c6-d10c-41cb-b9c2-36d7c65d33c6"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "caller": {
+              "type": "direct"
+            },
+            "id": "toolu_012zmqkutjE5saqvVoGSY7ux",
+            "input": {},
+            "name": "mcp__calculator__calculator",
+            "type": "tool_use"
+          },
+          "index": 1,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "efa4991e-a66a-400f-bcd5-7e7051c50c03"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "758e2e14-ca03-4275-aca2-66c028f83750"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "{\"operation\": \"subtract",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "92e61dca-c159-46b6-b710-03ec4c67be12"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "\", \"a\": 105",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "1f6906a7-60c6-4e57-9daf-08a8ac52b73c"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": ", \"b\": 5",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "9d48574e-6ee1-4ef7-8bc5-7b61b83e44b4"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "partial_json": "}",
+            "type": "input_json_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "c5673224-fdfc-4763-b2a6-c5dfc73b0e01"
       }
     },
     {
@@ -666,7 +1953,7 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01U4sNYME2jBLMUUZ6TvtJEF",
+              "id": "toolu_012zmqkutjE5saqvVoGSY7ux",
               "input": {
                 "a": 105,
                 "b": 5,
@@ -678,7 +1965,7 @@
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_01DwPD3GgcGBZcg5NdzSNXsU",
+          "id": "msg_011CduQGEByr7wexPetXQzBy",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -688,21 +1975,29 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 44678
+              "ephemeral_5m_input_tokens": 180
             },
-            "cache_creation_input_tokens": 44678,
-            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 180,
+            "cache_read_input_tokens": 17626,
             "inference_geo": "not_available",
-            "input_tokens": 10,
-            "output_tokens": 7,
+            "input_tokens": 8,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "request_id": "req_011CbC7Voev5n1eRQF6cEwLi",
-        "session_id": "bb4c779d-c1e5-47ef-a8f4-c29a8a4e7653",
+        "request_id": "req_011CduQGDU56gpe4GQ6gNg9W",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "timestamp": "2026-08-10T16:42:28.175Z",
+        "tool_use_meta": [
+          {
+            "display_name": "Calculator",
+            "id": "toolu_012zmqkutjE5saqvVoGSY7ux",
+            "server_display_name": "calculator"
+          }
+        ],
         "type": "assistant",
-        "uuid": "a1e7184e-f26d-4e83-b6fc-7e58da27a09a"
+        "uuid": "200081e4-8758-4aac-88f9-6caef64e93bc"
       }
     },
     {
@@ -715,7 +2010,7 @@
             "method": "tools/call",
             "params": {
               "_meta": {
-                "claudecode/toolUseId": "toolu_01U4sNYME2jBLMUUZ6TvtJEF",
+                "claudecode/toolUseId": "toolu_012zmqkutjE5saqvVoGSY7ux",
                 "progressToken": 3
               },
               "arguments": {
@@ -729,8 +2024,21 @@
           "server_name": "calculator",
           "subtype": "mcp_message"
         },
-        "request_id": "463385a9-9b81-4699-9927-ba68cc9fd6b7",
+        "request_id": "4569a707-fb5b-4ea3-b98a-58fa86247e55",
         "type": "control_request"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "index": 1,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "1a50f292-9fb7-433a-867e-e3a8b7f46933"
       }
     },
     {
@@ -739,7 +2047,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "463385a9-9b81-4699-9927-ba68cc9fd6b7",
+            "request_id": "4569a707-fb5b-4ea3-b98a-58fa86247e55",
             "response": {
               "mcp_response": {
                 "id": 3,
@@ -763,6 +2071,60 @@
     {
       "op": "read",
       "payload": {
+        "event": {
+          "context_management": {
+            "applied_edits": []
+          },
+          "delta": {
+            "stop_details": null,
+            "stop_reason": "tool_use",
+            "stop_sequence": null
+          },
+          "type": "message_delta",
+          "usage": {
+            "cache_creation_input_tokens": 180,
+            "cache_read_input_tokens": 17626,
+            "input_tokens": 8,
+            "iterations": [
+              {
+                "cache_creation": {
+                  "ephemeral_1h_input_tokens": 0,
+                  "ephemeral_5m_input_tokens": 180
+                },
+                "cache_creation_input_tokens": 180,
+                "cache_read_input_tokens": 17626,
+                "input_tokens": 8,
+                "output_tokens": 123,
+                "type": "message"
+              }
+            ],
+            "output_tokens": 123,
+            "output_tokens_details": {
+              "thinking_tokens": 30
+            }
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "a1467955-83cb-4a9b-bc92-fb3f4b4cfe3a"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "type": "message_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "64e4b58c-7d48-4734-aba1-b707be5a586d"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
         "message": {
           "content": [
             {
@@ -772,15 +2134,15 @@
                   "type": "text"
                 }
               ],
-              "tool_use_id": "toolu_01U4sNYME2jBLMUUZ6TvtJEF",
+              "tool_use_id": "toolu_012zmqkutjE5saqvVoGSY7ux",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
         "parent_tool_use_id": null,
-        "session_id": "bb4c779d-c1e5-47ef-a8f4-c29a8a4e7653",
-        "timestamp": "2026-05-19T14:49:21.932Z",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "timestamp": "2026-08-10T16:42:28.369Z",
         "tool_use_result": [
           {
             "text": "The result of subtract(105, 5) is 100",
@@ -788,7 +2150,186 @@
           }
         ],
         "type": "user",
-        "uuid": "a46afcd5-6f13-4214-8606-956d47d0ec17"
+        "uuid": "691fdbf0-caeb-4986-ad50-d78682902591"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "status": "requesting",
+        "subtype": "status",
+        "type": "system",
+        "uuid": "877c6ec9-b329-40d1-9304-38479e47299c"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "message": {
+            "content": [],
+            "diagnostics": null,
+            "id": "msg_011CduQGKpK8BTWTkAWknSwM",
+            "model": "claude-haiku-4-5-20251001",
+            "role": "assistant",
+            "stop_details": null,
+            "stop_reason": null,
+            "stop_sequence": null,
+            "type": "message",
+            "usage": {
+              "cache_creation": {
+                "ephemeral_1h_input_tokens": 0,
+                "ephemeral_5m_input_tokens": 155
+              },
+              "cache_creation_input_tokens": 155,
+              "cache_read_input_tokens": 17806,
+              "inference_geo": "not_available",
+              "input_tokens": 8,
+              "output_tokens": 3,
+              "service_tier": "standard"
+            }
+          },
+          "type": "message_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "ttft_ms": 584,
+        "type": "stream_event",
+        "uuid": "3c255cfa-119c-4e69-b3ed-b89db0748904"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "signature": "<REDACTED_SIGNATURE>",
+            "thinking": "",
+            "type": "thinking"
+          },
+          "index": 0,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "ba0159d5-9fe7-48d3-ba8a-ca192eec81aa"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 3,
+        "estimated_tokens_delta": 3,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "1521c929-8893-4889-bf95-be82dd5f4b62"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "estimated_tokens": null,
+            "thinking": "Perfect! The",
+            "type": "thinking_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "31b1fac0-fb16-4d56-8c32-a90e25a0e82e"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 6,
+        "estimated_tokens_delta": 3,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "c329c4ec-0000-4256-b40a-ee24ba1733dd"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "estimated_tokens": null,
+            "thinking": " calculator",
+            "type": "thinking_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "c0acc88a-0ccc-4dd4-9f5a-b4e2c78d159d"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 29,
+        "estimated_tokens_delta": 23,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "c939db1c-079b-4983-a29f-404e65cc7ad5"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "estimated_tokens": null,
+            "thinking": " tool performed both operations:\n1. 15 \u00d7 7 = 105\n2. 105 - 5 = 100\n\nThe final answer is 100.",
+            "type": "thinking_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "5894b5d8-7eec-409d-99b0-b931d8c79d0e"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 93,
+        "estimated_tokens_delta": 64,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "e7109084-6bcd-43f3-89aa-1fa347ca969c"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "signature": "<REDACTED_SIGNATURE>",
+            "type": "signature_delta"
+          },
+          "index": 0,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "b7e5f969-2638-41dd-b537-eb8ca8ec245f"
       }
     },
     {
@@ -798,13 +2339,13 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "Great! The calculations are done:\n- 15 \u00d7 7 = 105\n- 105 - 5 = 100\n\nSo the final answer is 100.",
+              "thinking": "Perfect! The calculator tool performed both operations:\n1. 15 \u00d7 7 = 105\n2. 105 - 5 = 100\n\nThe final answer is 100.",
               "type": "thinking"
             }
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_01BLdFiureh3DEprWKdGE6fx",
+          "id": "msg_011CduQGKpK8BTWTkAWknSwM",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -814,21 +2355,86 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 386
+              "ephemeral_5m_input_tokens": 155
             },
-            "cache_creation_input_tokens": 386,
-            "cache_read_input_tokens": 44678,
+            "cache_creation_input_tokens": 155,
+            "cache_read_input_tokens": 17806,
             "inference_geo": "not_available",
             "input_tokens": 8,
-            "output_tokens": 4,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "request_id": "req_011CbC7WA7UT5q2NP34LvCiy",
-        "session_id": "bb4c779d-c1e5-47ef-a8f4-c29a8a4e7653",
+        "request_id": "req_011CduQGKG58kTSqHFwxnN8x",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "timestamp": "2026-08-10T16:42:29.382Z",
         "type": "assistant",
-        "uuid": "e5c6b9b1-f044-42ff-9b19-5eb6420a2366"
+        "uuid": "0942fb7e-76bd-4cbc-9f2e-00345affdd3e"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "index": 0,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "0517efcc-7570-405e-b07e-3785c2fa8dcf"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "content_block": {
+            "text": "",
+            "type": "text"
+          },
+          "index": 1,
+          "type": "content_block_start"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "6417b417-f237-4b3c-8e66-139af6f04879"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "text": "Perfect! Here are",
+            "type": "text_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "8885b6bd-b739-4d25-a1e5-f84d46d61601"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "delta": {
+            "text": " the results:\n\n1. **15 \u00d7 7 = 105**\n2. **105 - 5 = 100**\n\n**Final answer: 100**",
+            "type": "text_delta"
+          },
+          "index": 1,
+          "type": "content_block_delta"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "833cba4c-8fce-4ecd-b105-145526f17fa6"
       }
     },
     {
@@ -837,13 +2443,13 @@
         "message": {
           "content": [
             {
-              "text": "The answer is **100**.\n\nHere's the breakdown:\n- 15 \u00d7 7 = **105**\n- 105 - 5 = **100**",
+              "text": "Perfect! Here are the results:\n\n1. **15 \u00d7 7 = 105**\n2. **105 - 5 = 100**\n\n**Final answer: 100**",
               "type": "text"
             }
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_01BLdFiureh3DEprWKdGE6fx",
+          "id": "msg_011CduQGKpK8BTWTkAWknSwM",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -853,76 +2459,149 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 386
+              "ephemeral_5m_input_tokens": 155
             },
-            "cache_creation_input_tokens": 386,
-            "cache_read_input_tokens": 44678,
+            "cache_creation_input_tokens": 155,
+            "cache_read_input_tokens": 17806,
             "inference_geo": "not_available",
             "input_tokens": 8,
-            "output_tokens": 4,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "request_id": "req_011CbC7WA7UT5q2NP34LvCiy",
-        "session_id": "bb4c779d-c1e5-47ef-a8f4-c29a8a4e7653",
+        "request_id": "req_011CduQGKG58kTSqHFwxnN8x",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "timestamp": "2026-08-10T16:42:29.512Z",
         "type": "assistant",
-        "uuid": "3bb1fe67-4dda-4205-8a71-dbb3ae522cba"
+        "uuid": "70b20ed5-8be7-4a99-9f03-910cdcd34276"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "index": 1,
+          "type": "content_block_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "49ceb2d3-0e8e-47c1-adec-90aadd02d4b0"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "context_management": {
+            "applied_edits": []
+          },
+          "delta": {
+            "stop_details": null,
+            "stop_reason": "end_turn",
+            "stop_sequence": null
+          },
+          "type": "message_delta",
+          "usage": {
+            "cache_creation_input_tokens": 155,
+            "cache_read_input_tokens": 17806,
+            "input_tokens": 8,
+            "iterations": [
+              {
+                "cache_creation": {
+                  "ephemeral_1h_input_tokens": 0,
+                  "ephemeral_5m_input_tokens": 155
+                },
+                "cache_creation_input_tokens": 155,
+                "cache_read_input_tokens": 17806,
+                "input_tokens": 8,
+                "output_tokens": 97,
+                "type": "message"
+              }
+            ],
+            "output_tokens": 97,
+            "output_tokens_details": {
+              "thinking_tokens": 48
+            }
+          }
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "ae7be1a7-e0ca-4b05-be8d-42050b28697c"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "event": {
+          "type": "message_stop"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
+        "type": "stream_event",
+        "uuid": "7df3afbe-83a2-4b86-b00b-045976e4d26c"
       }
     },
     {
       "op": "read",
       "payload": {
         "api_error_status": null,
-        "duration_api_ms": 8108,
-        "duration_ms": 6876,
+        "duration_api_ms": 6033,
+        "duration_ms": 6883,
+        "fast_mode_disabled_reason": "sdk_opt_in_required",
         "fast_mode_state": "off",
         "is_error": false,
         "modelUsage": {
           "claude-haiku-4-5-20251001": {
-            "cacheCreationInputTokens": 45064,
-            "cacheReadInputTokens": 44678,
+            "cacheCreationInputTokens": 8651,
+            "cacheReadInputTokens": 62020,
+            "canonicalModel": "claude-haiku-4-5",
             "contextWindow": 200000,
-            "costUSD": 0.0631868,
-            "inputTokens": 474,
+            "costUSD": 0.01983675,
+            "inputTokens": 36,
             "maxOutputTokens": 32000,
-            "outputTokens": 383,
+            "outputTokens": 557,
+            "provider": "firstParty",
             "webSearchRequests": 0
           }
         },
-        "num_turns": 3,
+        "num_turns": 4,
         "permission_denials": [],
-        "result": "The answer is **100**.\n\nHere's the breakdown:\n- 15 \u00d7 7 = **105**\n- 105 - 5 = **100**",
-        "session_id": "bb4c779d-c1e5-47ef-a8f4-c29a8a4e7653",
+        "result": "Perfect! Here are the results:\n\n1. **15 \u00d7 7 = 105**\n2. **105 - 5 = 100**\n\n**Final answer: 100**",
+        "session_id": "8bbeb10f-494b-4b32-a328-2848a37aaec4",
         "stop_reason": "end_turn",
         "subtype": "success",
         "terminal_reason": "completed",
-        "total_cost_usd": 0.0631868,
-        "ttft_ms": 3047,
+        "time_to_request_ms": 160,
+        "total_cost_usd": 0.01983675,
+        "ttft_ms": 2024,
+        "ttft_stream_ms": 976,
         "type": "result",
         "usage": {
           "cache_creation": {
             "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 45064
+            "ephemeral_5m_input_tokens": 8651
           },
-          "cache_creation_input_tokens": 45064,
-          "cache_read_input_tokens": 44678,
-          "inference_geo": "",
-          "input_tokens": 18,
+          "cache_creation_input_tokens": 8651,
+          "cache_read_input_tokens": 62020,
+          "inference_geo": "not_available",
+          "input_tokens": 36,
           "iterations": [
             {
               "cache_creation": {
                 "ephemeral_1h_input_tokens": 0,
-                "ephemeral_5m_input_tokens": 386
+                "ephemeral_5m_input_tokens": 155
               },
-              "cache_creation_input_tokens": 386,
-              "cache_read_input_tokens": 44678,
+              "cache_creation_input_tokens": 155,
+              "cache_read_input_tokens": 17806,
               "input_tokens": 8,
-              "output_tokens": 89,
+              "output_tokens": 97,
               "type": "message"
             }
           ],
-          "output_tokens": 372,
+          "output_tokens": 557,
           "server_tool_use": {
             "web_fetch_requests": 0,
             "web_search_requests": 0
@@ -930,9 +2609,9 @@
           "service_tier": "standard",
           "speed": "standard"
         },
-        "uuid": "9a3c05b4-09cd-4551-acec-5884b1de2410"
+        "uuid": "d1f074b0-f459-467d-965b-4331da777be6"
       }
     }
   ],
-  "sdk_version": "0.2.82"
+  "sdk_version": "0.2.129"
 }

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_multiple_bundled_subagents_keep_outer_orchestration_separate.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_multiple_bundled_subagents_keep_outer_orchestration_separate.json
@@ -10,7 +10,7 @@
             "hooks": null,
             "subtype": "initialize"
           },
-          "request_id": "req_1_59a11d31",
+          "request_id": "req_1_2c9b9d93",
           "type": "control_request"
         }
       }
@@ -18,13 +18,42 @@
     {
       "op": "read",
       "payload": {
+        "hook_event": "SessionStart",
+        "hook_id": "528b9ad5-27bd-4daa-916d-0b6164ddeb5f",
+        "hook_name": "SessionStart:startup",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "hook_started",
+        "type": "system",
+        "uuid": "307bd03b-7ed0-4061-ac2f-c9e9d93f038e"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "exit_code": 0,
+        "hook_event": "SessionStart",
+        "hook_id": "528b9ad5-27bd-4daa-916d-0b6164ddeb5f",
+        "hook_name": "SessionStart:startup",
+        "outcome": "success",
+        "output": "",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "stderr": "",
+        "stdout": "",
+        "subtype": "hook_response",
+        "type": "system",
+        "uuid": "6ec5f683-bcda-46ed-9d7e-b45c672c863e"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
         "response": {
-          "request_id": "req_1_59a11d31",
+          "request_id": "req_1_2c9b9d93",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
               "apiProvider": "firstParty",
-              "tokenSource": "none"
+              "tokenSource": "claude.ai"
             },
             "agents": [],
             "available_output_styles": [],
@@ -42,7 +71,7 @@
         "kind": "json",
         "value": {
           "message": {
-            "content": "Launch two bundled general-purpose subagents for two independent tasks. Start both Agent tool calls before waiting on either result if the tool API allows it. The first delegated subagent must use Bash and Read on release_notes_alpha.md and return only 'alpha:<version> | <owner>'. The second delegated subagent must use Bash and Read on release_notes_beta.md and return only 'beta:<version> | <owner>'. After both delegated agents finish, reply with exactly two lines in that same order. Do not answer directly without using both subagents.",
+            "content": "Launch two bundled general-purpose subagents for two independent tasks. Start both Agent tool calls before waiting on either result if the tool API allows it. The first delegated subagent must use Bash and Read on release_notes_alpha.md and return only 'alpha:<version> | <owner>'. The second delegated subagent must use Bash and Read on release_notes_beta.md and return only 'beta:<version> | <owner>'. If either agent runs in the background, use TaskOutput with block=true to wait for each result. Do not finish while either task is still running. After both delegated agents finish, reply with exactly two lines in that same order. Do not answer directly without using both subagents.",
             "role": "user"
           },
           "parent_tool_use_id": null,
@@ -63,8 +92,14 @@
         ],
         "analytics_disabled": false,
         "apiKeySource": "ANTHROPIC_API_KEY",
-        "claude_code_version": "2.1.142",
+        "capabilities": [
+          "interrupt_receipt_v1",
+          "interrupt_cancel_queued_v1",
+          "msg_lifecycle_v1"
+        ],
+        "claude_code_version": "2.1.221",
         "cwd": "<REDACTED_CWD>",
+        "fast_mode_disabled_reason": "sdk_opt_in_required",
         "fast_mode_state": "off",
         "mcp_servers": [],
         "memory_paths": {
@@ -77,64 +112,95 @@
           {
             "name": "rust-analyzer-lsp",
             "path": "<REDACTED_PATH>",
-            "source": "rust-analyzer-lsp@claude-plugins-official"
+            "source": "rust-analyzer-lsp@claude-plugins-official",
+            "version": "1.0.0"
           }
         ],
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
+        "product_feedback_disabled": false,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
         "skills": [
-          "create-braintrust-demo",
           "braintrust",
+          "create-braintrust-demo",
+          "design-sync",
+          "dataviz",
           "update-config",
+          "verify",
           "debug",
+          "code-review",
           "simplify",
           "batch",
           "fewer-permission-prompts",
-          "loop",
-          "claude-api"
-        ],
-        "slash_commands": [
-          "create-braintrust-demo",
-          "braintrust",
-          "update-config",
-          "debug",
-          "simplify",
-          "batch",
-          "fewer-permission-prompts",
+          "doctor",
           "loop",
           "claude-api",
+          "run",
+          "run-skill-generator"
+        ],
+        "slash_commands": [
+          "braintrust",
+          "create-braintrust-demo",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "run",
+          "run-skill-generator",
+          "agents",
+          "autocompact",
           "clear",
+          "color",
           "compact",
+          "config",
           "context",
+          "effort",
+          "fast",
           "heapdump",
           "init",
+          "mcp",
+          "import",
+          "model",
+          "__remote-workflow",
+          "workflow-launch-exec",
+          "reload-skills",
+          "rename",
           "review",
           "security-review",
           "usage",
           "insights",
+          "recap",
           "goal",
+          "design",
+          "design-consent",
+          "design-revoke",
           "team-onboarding"
         ],
         "subtype": "init",
         "tools": [
           "Task",
-          "AskUserQuestion",
           "Bash",
           "CronCreate",
           "CronDelete",
           "CronList",
+          "DesignSync",
           "Edit",
-          "EnterPlanMode",
           "EnterWorktree",
-          "ExitPlanMode",
           "ExitWorktree",
-          "Glob",
-          "Grep",
           "LSP",
           "Monitor",
           "NotebookEdit",
           "PushNotification",
           "Read",
+          "ReportFindings",
           "ScheduleWakeup",
+          "SendMessage",
           "Skill",
           "TaskCreate",
           "TaskGet",
@@ -148,7 +214,73 @@
           "Write"
         ],
         "type": "system",
-        "uuid": "f0edd6f7-d89d-438f-b527-1476c42dd23e"
+        "uuid": "0b56d646-fc63-4a2a-b5ab-ad585bc0fac9"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 4,
+        "estimated_tokens_delta": 4,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "13892022-438f-4b16-b19b-7c200a4c74ac"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 39,
+        "estimated_tokens_delta": 35,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "badc505b-6195-4eba-835d-08cb4ebf54f1"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 105,
+        "estimated_tokens_delta": 66,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "065dafe5-32de-4fa5-a4dd-9ac69bc53e96"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 144,
+        "estimated_tokens_delta": 39,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "35a7c2d9-814b-4596-8fee-341237221f78"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 166,
+        "estimated_tokens_delta": 22,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "6e0a3e13-56ef-4a0e-842f-e0c1b856bf2d"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 228,
+        "estimated_tokens_delta": 62,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "099f460f-d999-4ae0-a88d-3da66752607f"
       }
     },
     {
@@ -158,13 +290,13 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The user wants me to:\n1. Launch two independent subagents in parallel\n2. First subagent: reads release_notes_alpha.md and returns 'alpha:<version> | <owner>'\n3. Second subagent: reads release_notes_beta.md and returns 'beta:<version> | <owner>'\n4. Wait for both to complete\n5. Reply with exactly two lines in that order\n\nI should use the Agent tool to create two general-purpose agents that will handle these tasks independently. Since these are independent tasks, I can launch both in the same function_calls block.\n\nLet me create two agents:\n1. First agent for alpha release notes\n2. Second agent for beta release notes\n\nThe agents should use Bash and Read tools to examine the files and extract the version and owner information.",
+              "thinking": "The user wants me to:\n1. Launch two general-purpose subagents in parallel\n2. First agent: Read release_notes_alpha.md and return 'alpha:<version> | <owner>'\n3. Second agent: Read release_notes_beta.md and return 'beta:<version> | <owner>'\n4. If they run in background, use TaskOutput with block=true to wait\n5. Reply with exactly two lines in that same order\n6. Don't finish while either task is running\n\nThe user says \"Start both Agent tool calls before waiting on either result if the tool API allows it\" - this means I should make both Agent calls in the same function_calls block.\n\nLet me create two agent calls with specific, clear instructions for each.",
               "type": "thinking"
             }
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_01T47uDZvxsraKwAewJL9PLi",
+          "id": "msg_011CduPx6yeNCuicbSoGeHgC",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -174,21 +306,62 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 23765
+              "ephemeral_5m_input_tokens": 2570
             },
-            "cache_creation_input_tokens": 23765,
-            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 2570,
+            "cache_read_input_tokens": 9310,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 1,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "request_id": "req_011CbC7mvHDcDnCoTNnjsGJr",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
+        "request_id": "req_011CduPx6VNZzqpECx3Hnr3d",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:23.353Z",
         "type": "assistant",
-        "uuid": "4ed95d4e-66f4-425a-8fd8-fecb0818d3e4"
+        "uuid": "520534f1-28b8-431e-a9c7-bdcd5f00f033"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "I'll launch two general-purpose subagents in parallel to extract the version and owner information from both release notes files.",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduPx6yeNCuicbSoGeHgC",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 2570
+            },
+            "cache_creation_input_tokens": 2570,
+            "cache_read_input_tokens": 9310,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 3,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "request_id": "req_011CduPx6VNZzqpECx3Hnr3d",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:23.694Z",
+        "type": "assistant",
+        "uuid": "3e404051-a3c5-4a7d-84d7-57cc5390ec30"
       }
     },
     {
@@ -200,10 +373,11 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01J2z1oBP9XHSZgLdRGzvoRt",
+              "id": "toolu_01TcC2KKNvYMkJaHZVunzm7W",
               "input": {
                 "description": "Extract alpha version and owner",
-                "prompt": "Read the file release_notes_alpha.md using the Read tool. Extract and return ONLY the version and owner in the format: 'alpha:<version> | <owner>'. Do not include any other text or explanation."
+                "prompt": "Read the file release_notes_alpha.md and extract the version and owner. Return ONLY the string in this format: alpha:<version> | <owner>\n\nExample output: alpha:1.2.3 | john-doe\n\nDo not include any other text or explanation.",
+                "subagent_type": "general-purpose"
               },
               "name": "Agent",
               "type": "tool_use"
@@ -211,7 +385,7 @@
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_01T47uDZvxsraKwAewJL9PLi",
+          "id": "msg_011CduPx6yeNCuicbSoGeHgC",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -221,36 +395,53 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 23765
+              "ephemeral_5m_input_tokens": 2570
             },
-            "cache_creation_input_tokens": 23765,
-            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 2570,
+            "cache_read_input_tokens": 9310,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 1,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "request_id": "req_011CbC7mvHDcDnCoTNnjsGJr",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
+        "request_id": "req_011CduPx6VNZzqpECx3Hnr3d",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:24.645Z",
         "type": "assistant",
-        "uuid": "ec835647-99b0-4394-b622-83275b4aa876"
+        "uuid": "ffd09e16-aa9f-466d-867d-4700325c5481"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "background_tasks_changed",
+        "tasks": [
+          {
+            "description": "Extract alpha version and owner",
+            "task_id": "acc13030b342e6516",
+            "task_type": "local_agent"
+          }
+        ],
+        "type": "system",
+        "uuid": "c7c5e5c7-11ce-44f4-8f96-79b404e8d38b"
       }
     },
     {
       "op": "read",
       "payload": {
         "description": "Extract alpha version and owner",
-        "prompt": "Read the file release_notes_alpha.md using the Read tool. Extract and return ONLY the version and owner in the format: 'alpha:<version> | <owner>'. Do not include any other text or explanation.",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
+        "prompt": "Read the file release_notes_alpha.md and extract the version and owner. Return ONLY the string in this format: alpha:<version> | <owner>\n\nExample output: alpha:1.2.3 | john-doe\n\nDo not include any other text or explanation.",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
         "subagent_type": "general-purpose",
         "subtype": "task_started",
-        "task_id": "a4e4e0ab3cf303af7",
+        "task_id": "acc13030b342e6516",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01J2z1oBP9XHSZgLdRGzvoRt",
+        "tool_use_id": "toolu_01TcC2KKNvYMkJaHZVunzm7W",
         "type": "system",
-        "uuid": "4c2a34ef-1709-4933-b659-7a29599923ad"
+        "uuid": "40963c23-6f95-4ebe-b63f-8b2596d42145"
       }
     },
     {
@@ -259,19 +450,33 @@
         "message": {
           "content": [
             {
-              "text": "Read the file release_notes_alpha.md using the Read tool. Extract and return ONLY the version and owner in the format: 'alpha:<version> | <owner>'. Do not include any other text or explanation.",
-              "type": "text"
+              "content": [
+                {
+                  "text": "Async agent launched successfully. (This tool result is internal metadata \u2014 never quote or paste any part of it, including the agentId below, into a user-facing reply.)\nagentId: acc13030b342e6516 (internal ID - do not mention to user. Use SendMessage with to: 'acc13030b342e6516', summary: '<5-10 word recap>' to continue this agent.)\nThe agent is working in the background. You will be notified automatically when it completes. You know nothing about its results until that notification arrives \u2014 do not report, assume, or predict them; continue other work or respond to the user in the meantime.\nDo not duplicate this agent's work \u2014 avoid working with the same files or topics it is using.\noutput_file: <REDACTED_PATH>\nDo NOT Read or tail this file via the shell tool \u2014 it is the full subagent JSONL transcript and reading it will overflow your context. If the user asks for progress, say the agent is still running; you'll get a completion notification.",
+                  "type": "text"
+                }
+              ],
+              "tool_use_id": "toolu_01TcC2KKNvYMkJaHZVunzm7W",
+              "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01J2z1oBP9XHSZgLdRGzvoRt",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
-        "subagent_type": "general-purpose",
-        "task_description": "Extract alpha version and owner",
-        "timestamp": "2026-05-19T14:53:00.583Z",
+        "parent_tool_use_id": null,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:24.814Z",
+        "tool_use_result": {
+          "agentId": "acc13030b342e6516",
+          "canReadOutputFile": true,
+          "description": "Extract alpha version and owner",
+          "isAsync": true,
+          "outputFile": "<REDACTED_PATH>",
+          "prompt": "Read the file release_notes_alpha.md and extract the version and owner. Return ONLY the string in this format: alpha:<version> | <owner>\n\nExample output: alpha:1.2.3 | john-doe\n\nDo not include any other text or explanation.",
+          "resolvedModel": "claude-haiku-4-5-20251001",
+          "status": "async_launched"
+        },
         "type": "user",
-        "uuid": "776d620c-ffe1-4f32-8a13-dd22319d5615"
+        "uuid": "49908e70-0f3d-42f8-9da2-22c50e3334d2"
       }
     },
     {
@@ -283,10 +488,11 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01UyhHgNEXve8Z5eZ4ebw7fb",
+              "id": "toolu_01XkapD7V36nPRGqQVPTftn3",
               "input": {
                 "description": "Extract beta version and owner",
-                "prompt": "Read the file release_notes_beta.md using the Read tool. Extract and return ONLY the version and owner in the format: 'beta:<version> | <owner>'. Do not include any other text or explanation."
+                "prompt": "Read the file release_notes_beta.md and extract the version and owner. Return ONLY the string in this format: beta:<version> | <owner>\n\nExample output: beta:2.0.0 | jane-smith\n\nDo not include any other text or explanation.",
+                "subagent_type": "general-purpose"
               },
               "name": "Agent",
               "type": "tool_use"
@@ -294,7 +500,7 @@
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_01T47uDZvxsraKwAewJL9PLi",
+          "id": "msg_011CduPx6yeNCuicbSoGeHgC",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -304,36 +510,58 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 23765
+              "ephemeral_5m_input_tokens": 2570
             },
-            "cache_creation_input_tokens": 23765,
-            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 2570,
+            "cache_read_input_tokens": 9310,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 1,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "request_id": "req_011CbC7mvHDcDnCoTNnjsGJr",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
+        "request_id": "req_011CduPx6VNZzqpECx3Hnr3d",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:24.933Z",
         "type": "assistant",
-        "uuid": "436af7f9-c252-41f1-9109-e089a17524dd"
+        "uuid": "877b36cc-9729-4b29-911c-9036ce3e39f9"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "background_tasks_changed",
+        "tasks": [
+          {
+            "description": "Extract alpha version and owner",
+            "task_id": "acc13030b342e6516",
+            "task_type": "local_agent"
+          },
+          {
+            "description": "Extract beta version and owner",
+            "task_id": "aa2d67565d2de9f26",
+            "task_type": "local_agent"
+          }
+        ],
+        "type": "system",
+        "uuid": "c9cfe586-1fc4-49e3-b8c6-eba7358bf07b"
       }
     },
     {
       "op": "read",
       "payload": {
         "description": "Extract beta version and owner",
-        "prompt": "Read the file release_notes_beta.md using the Read tool. Extract and return ONLY the version and owner in the format: 'beta:<version> | <owner>'. Do not include any other text or explanation.",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
+        "prompt": "Read the file release_notes_beta.md and extract the version and owner. Return ONLY the string in this format: beta:<version> | <owner>\n\nExample output: beta:2.0.0 | jane-smith\n\nDo not include any other text or explanation.",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
         "subagent_type": "general-purpose",
         "subtype": "task_started",
-        "task_id": "a5d4959a2c92999f6",
+        "task_id": "aa2d67565d2de9f26",
         "task_type": "local_agent",
-        "tool_use_id": "toolu_01UyhHgNEXve8Z5eZ4ebw7fb",
+        "tool_use_id": "toolu_01XkapD7V36nPRGqQVPTftn3",
         "type": "system",
-        "uuid": "4273d349-5dfb-4601-91d9-cb21a0fdcd77"
+        "uuid": "63f27236-fe47-4216-b5d8-5fb5223f80cd"
       }
     },
     {
@@ -342,38 +570,245 @@
         "message": {
           "content": [
             {
-              "text": "Read the file release_notes_beta.md using the Read tool. Extract and return ONLY the version and owner in the format: 'beta:<version> | <owner>'. Do not include any other text or explanation.",
-              "type": "text"
+              "content": [
+                {
+                  "text": "Async agent launched successfully. (This tool result is internal metadata \u2014 never quote or paste any part of it, including the agentId below, into a user-facing reply.)\nagentId: aa2d67565d2de9f26 (internal ID - do not mention to user. Use SendMessage with to: 'aa2d67565d2de9f26', summary: '<5-10 word recap>' to continue this agent.)\nThe agent is working in the background. You will be notified automatically when it completes. You know nothing about its results until that notification arrives \u2014 do not report, assume, or predict them; continue other work or respond to the user in the meantime.\nDo not duplicate this agent's work \u2014 avoid working with the same files or topics it is using.\noutput_file: <REDACTED_PATH>\nDo NOT Read or tail this file via the shell tool \u2014 it is the full subagent JSONL transcript and reading it will overflow your context. If the user asks for progress, say the agent is still running; you'll get a completion notification.",
+                  "type": "text"
+                }
+              ],
+              "tool_use_id": "toolu_01XkapD7V36nPRGqQVPTftn3",
+              "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01UyhHgNEXve8Z5eZ4ebw7fb",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
-        "subagent_type": "general-purpose",
-        "task_description": "Extract beta version and owner",
-        "timestamp": "2026-05-19T14:53:00.816Z",
+        "parent_tool_use_id": null,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:25.117Z",
+        "tool_use_result": {
+          "agentId": "aa2d67565d2de9f26",
+          "canReadOutputFile": true,
+          "description": "Extract beta version and owner",
+          "isAsync": true,
+          "outputFile": "<REDACTED_PATH>",
+          "prompt": "Read the file release_notes_beta.md and extract the version and owner. Return ONLY the string in this format: beta:<version> | <owner>\n\nExample output: beta:2.0.0 | jane-smith\n\nDo not include any other text or explanation.",
+          "resolvedModel": "claude-haiku-4-5-20251001",
+          "status": "async_launched"
+        },
         "type": "user",
-        "uuid": "4c3c1e5b-c3a5-4959-8805-71bfb6365060"
+        "uuid": "adab733f-131c-4b08-8326-19a148213b3e"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Reading release_notes_alpha.md",
-        "last_tool_name": "Read",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
-        "subagent_type": "general-purpose",
-        "subtype": "task_progress",
-        "task_id": "a4e4e0ab3cf303af7",
-        "tool_use_id": "toolu_01J2z1oBP9XHSZgLdRGzvoRt",
+        "estimated_tokens": 1,
+        "estimated_tokens_delta": 1,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
         "type": "system",
-        "usage": {
-          "duration_ms": 2593,
-          "tool_uses": 1,
-          "total_tokens": 17832
+        "uuid": "ea50c62f-4e9c-4c22-89cf-300c5e9d053f"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 6,
+        "estimated_tokens_delta": 5,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "06f34acc-48b5-4d56-9420-b4a4d27e27a4"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 7,
+        "estimated_tokens_delta": 1,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "8e1468c4-32a7-4bf8-9aa5-438c7d7b7a5a"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 11,
+        "estimated_tokens_delta": 4,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "5cb01bbd-37b7-4088-a15c-1a918cd9aeba"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 15,
+        "estimated_tokens_delta": 4,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "309f3702-9a83-4962-8c49-9c7d529dc978"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "The user wants me to:\n1. Read the file release_notes_alpha.md\n2. Extract the version and owner\n3. Return ONLY a string in the format: alpha:<version> | <owner>\n\nLet me first read the file to see what's in it.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduPxNQLDeUvWas41k16F",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 2761
+            },
+            "cache_creation_input_tokens": 2761,
+            "cache_read_input_tokens": 7557,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 3,
+            "service_tier": "standard"
+          }
         },
-        "uuid": "2f979d67-c8e3-4536-9e71-c933ebb61850"
+        "parent_tool_use_id": "toolu_01TcC2KKNvYMkJaHZVunzm7W",
+        "request_id": "req_011CduPxMiAKMXzkXh6HxpjL",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subagent_type": "general-purpose",
+        "task_description": "Extract alpha version and owner",
+        "timestamp": "2026-08-10T16:38:26.109Z",
+        "type": "assistant",
+        "uuid": "c6fa6dfa-9d61-44f2-9451-cede5904f055"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 39,
+        "estimated_tokens_delta": 24,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "7538fb83-4f9a-404f-9033-5a0a9f8d3002"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 51,
+        "estimated_tokens_delta": 12,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "55daa2b9-db38-4e43-ac36-a1d3788ae836"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 113,
+        "estimated_tokens_delta": 62,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "e559d8b4-e6df-495c-8002-db5b8d2efb72"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "Both agents are running in the background. I need to wait for them to complete using TaskOutput with block=true. Let me fetch the ToolSearch results for TaskOutput first since it's a deferred tool.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduPxQEiKBkwuwtDNELAN",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 1248
+            },
+            "cache_creation_input_tokens": 1248,
+            "cache_read_input_tokens": 11880,
+            "inference_geo": "not_available",
+            "input_tokens": 8,
+            "output_tokens": 1,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "request_id": "req_011CduPxPfV8zqh6Qg5cHAih",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:26.779Z",
+        "type": "assistant",
+        "uuid": "2efb6a02-d680-42d2-ac37-9d58b4cbd4ab"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "I'll now wait for both agents to complete using TaskOutput.",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduPxQEiKBkwuwtDNELAN",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 1248
+            },
+            "cache_creation_input_tokens": 1248,
+            "cache_read_input_tokens": 11880,
+            "inference_geo": "not_available",
+            "input_tokens": 8,
+            "output_tokens": 1,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "request_id": "req_011CduPxPfV8zqh6Qg5cHAih",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:27.196Z",
+        "type": "assistant",
+        "uuid": "9920f67e-fde4-4aa0-94fe-9756b3201075"
       }
     },
     {
@@ -385,9 +820,9 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_016MQb2SwFuHidwpA5VLrMQK",
+              "id": "toolu_012wqkMpWmS2JxzZbSzpyYPF",
               "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-0/test_multiple_bundled_subagent0/subagent_multi_workspace/release_notes_alpha.md"
+                "file_path": "<REDACTED_PATH>"
               },
               "name": "Read",
               "type": "tool_use"
@@ -395,7 +830,7 @@
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_01SeTNhKACUet4KTZ6dxwGJQ",
+          "id": "msg_011CduPxNQLDeUvWas41k16F",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -405,23 +840,91 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 17817
+              "ephemeral_5m_input_tokens": 2761
             },
-            "cache_creation_input_tokens": 17817,
-            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 2761,
+            "cache_read_input_tokens": 7557,
             "inference_geo": "not_available",
-            "input_tokens": 3,
-            "output_tokens": 6,
+            "input_tokens": 10,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01J2z1oBP9XHSZgLdRGzvoRt",
-        "request_id": "req_011CbC7nBQJkMqztMzueMskc",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
+        "parent_tool_use_id": "toolu_01TcC2KKNvYMkJaHZVunzm7W",
+        "request_id": "req_011CduPxMiAKMXzkXh6HxpjL",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
         "subagent_type": "general-purpose",
         "task_description": "Extract alpha version and owner",
+        "timestamp": "2026-08-10T16:38:27.232Z",
         "type": "assistant",
-        "uuid": "8e0ee32f-b765-4ab9-9824-a48fa1bd2839"
+        "uuid": "ea740e58-987b-4ba0-b59f-8c36f5d5d598"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "description": "Reading release_notes_alpha.md",
+        "last_tool_name": "Read",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subagent_type": "general-purpose",
+        "subtype": "task_progress",
+        "task_id": "acc13030b342e6516",
+        "tool_use_id": "toolu_01TcC2KKNvYMkJaHZVunzm7W",
+        "type": "system",
+        "usage": {
+          "duration_ms": 2582,
+          "tool_uses": 1,
+          "total_tokens": 10334
+        },
+        "uuid": "19986f6a-0537-4a76-a30c-c6274c87d4d0"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "caller": {
+                "type": "direct"
+              },
+              "id": "toolu_012JEqjXrPviwRH8WvDJCm6J",
+              "input": {
+                "max_results": 1,
+                "query": "select:TaskOutput"
+              },
+              "name": "ToolSearch",
+              "type": "tool_use"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduPxQEiKBkwuwtDNELAN",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 1248
+            },
+            "cache_creation_input_tokens": 1248,
+            "cache_read_input_tokens": 11880,
+            "inference_geo": "not_available",
+            "input_tokens": 8,
+            "output_tokens": 1,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "request_id": "req_011CduPxPfV8zqh6Qg5cHAih",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:27.395Z",
+        "type": "assistant",
+        "uuid": "966bec39-caec-4d75-8dcb-71d2bc423edd"
       }
     },
     {
@@ -431,38 +934,94 @@
           "content": [
             {
               "content": "1\t# Alpha Release Notes\n2\t\n3\tversion = 2026.03.11-alpha\n4\towner = sdk-platform-alpha\n5\t",
-              "tool_use_id": "toolu_016MQb2SwFuHidwpA5VLrMQK",
+              "tool_use_id": "toolu_012wqkMpWmS2JxzZbSzpyYPF",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01J2z1oBP9XHSZgLdRGzvoRt",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
+        "parent_tool_use_id": "toolu_01TcC2KKNvYMkJaHZVunzm7W",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
         "subagent_type": "general-purpose",
         "task_description": "Extract alpha version and owner",
-        "timestamp": "2026-05-19T14:53:03.180Z",
+        "timestamp": "2026-08-10T16:38:27.427Z",
         "type": "user",
-        "uuid": "1b5c0ed5-61cf-4cf4-bfa8-15fd1159331f"
+        "uuid": "771b3734-029a-428e-a62c-f97d04590483"
       }
     },
     {
       "op": "read",
       "payload": {
-        "description": "Reading release_notes_beta.md",
-        "last_tool_name": "Read",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
-        "subagent_type": "general-purpose",
-        "subtype": "task_progress",
-        "task_id": "a5d4959a2c92999f6",
-        "tool_use_id": "toolu_01UyhHgNEXve8Z5eZ4ebw7fb",
-        "type": "system",
-        "usage": {
-          "duration_ms": 2473,
-          "tool_uses": 1,
-          "total_tokens": 17830
+        "message": {
+          "content": [
+            {
+              "content": [
+                {
+                  "tool_name": "TaskOutput",
+                  "type": "tool_reference"
+                }
+              ],
+              "tool_use_id": "toolu_012JEqjXrPviwRH8WvDJCm6J",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
         },
-        "uuid": "e12fdd70-4d90-4d2c-98a9-17cf96cb904e"
+        "parent_tool_use_id": null,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:27.499Z",
+        "tool_use_result": {
+          "matches": [
+            "TaskOutput"
+          ],
+          "query": "select:TaskOutput",
+          "total_deferred_tools": 19
+        },
+        "type": "user",
+        "uuid": "e0c408ae-30eb-4fe7-b6aa-fd5a81b2ee84"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "The user wants me to read the file `release_notes_beta.md` and extract the version and owner, then return it in a specific format: `beta:<version> | <owner>`.\n\nFirst, I need to find and read this file. Let me start by reading the file. Since this is a bash environment with a working directory set to `<REDACTED_PATH> I should use absolute paths.\n\nLet me try to read the file. I'll assume it's in the current working directory or search for it.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduPxPngHmuKQoGmEaRSm",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 2761
+            },
+            "cache_creation_input_tokens": 2761,
+            "cache_read_input_tokens": 7557,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 6,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": "toolu_01XkapD7V36nPRGqQVPTftn3",
+        "request_id": "req_011CduPxPAE1AkT2vMds8zpE",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subagent_type": "general-purpose",
+        "task_description": "Extract beta version and owner",
+        "timestamp": "2026-08-10T16:38:27.945Z",
+        "type": "assistant",
+        "uuid": "ada6b3a8-c88a-4f76-9100-2852eb8e937f"
       }
     },
     {
@@ -474,9 +1033,9 @@
               "caller": {
                 "type": "direct"
               },
-              "id": "toolu_01KhKqV7KugwwjFGogkArDsA",
+              "id": "toolu_01DtuA5PphRpPpmAZs9XjKqH",
               "input": {
-                "file_path": "/private/var/folders/1r/0r49yqc973s87vl4n1x_3j1m0000gn/T/pytest-of-abhijeetprasad/pytest-0/test_multiple_bundled_subagent0/subagent_multi_workspace/release_notes_beta.md"
+                "file_path": "<REDACTED_PATH>"
               },
               "name": "Read",
               "type": "tool_use"
@@ -484,7 +1043,7 @@
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_017zS1pcehe5WLx6pTzjxsKb",
+          "id": "msg_011CduPxPngHmuKQoGmEaRSm",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -494,23 +1053,54 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 17817
+              "ephemeral_5m_input_tokens": 2761
             },
-            "cache_creation_input_tokens": 17817,
-            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 2761,
+            "cache_read_input_tokens": 7557,
             "inference_geo": "not_available",
-            "input_tokens": 3,
-            "output_tokens": 5,
+            "input_tokens": 10,
+            "output_tokens": 6,
             "service_tier": "standard"
           }
         },
-        "parent_tool_use_id": "toolu_01UyhHgNEXve8Z5eZ4ebw7fb",
-        "request_id": "req_011CbC7nCMMdhAcNtSCezrMF",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
+        "parent_tool_use_id": "toolu_01XkapD7V36nPRGqQVPTftn3",
+        "request_id": "req_011CduPxPAE1AkT2vMds8zpE",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
         "subagent_type": "general-purpose",
         "task_description": "Extract beta version and owner",
+        "timestamp": "2026-08-10T16:38:28.239Z",
         "type": "assistant",
-        "uuid": "6c5722b5-2838-46df-847b-5aa82b0f3b85"
+        "uuid": "09a81b7e-7d18-4063-a266-e20a9f69cabf"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "description": "Reading release_notes_beta.md",
+        "last_tool_name": "Read",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subagent_type": "general-purpose",
+        "subtype": "task_progress",
+        "task_id": "aa2d67565d2de9f26",
+        "tool_use_id": "toolu_01XkapD7V36nPRGqQVPTftn3",
+        "type": "system",
+        "usage": {
+          "duration_ms": 3304,
+          "tool_uses": 1,
+          "total_tokens": 10340
+        },
+        "uuid": "b5805487-9a63-49e8-b511-f7a18656e9cf"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 1,
+        "estimated_tokens_delta": 1,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "ac62aec4-7977-4851-906a-278324a64e31"
       }
     },
     {
@@ -520,223 +1110,19 @@
           "content": [
             {
               "content": "1\t# Beta Release Notes\n2\t\n3\tversion = 2026.03.11-beta\n4\towner = sdk-platform-beta\n5\t",
-              "tool_use_id": "toolu_01KhKqV7KugwwjFGogkArDsA",
+              "tool_use_id": "toolu_01DtuA5PphRpPpmAZs9XjKqH",
               "type": "tool_result"
             }
           ],
           "role": "user"
         },
-        "parent_tool_use_id": "toolu_01UyhHgNEXve8Z5eZ4ebw7fb",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
+        "parent_tool_use_id": "toolu_01XkapD7V36nPRGqQVPTftn3",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
         "subagent_type": "general-purpose",
         "task_description": "Extract beta version and owner",
-        "timestamp": "2026-05-19T14:53:03.291Z",
+        "timestamp": "2026-08-10T16:38:28.415Z",
         "type": "user",
-        "uuid": "18a83028-bd30-4ffb-8da0-e59cf3485f79"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "output_file": "",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
-        "status": "completed",
-        "subtype": "task_notification",
-        "summary": "Extract alpha version and owner",
-        "task_id": "a4e4e0ab3cf303af7",
-        "tool_use_id": "toolu_01J2z1oBP9XHSZgLdRGzvoRt",
-        "type": "system",
-        "usage": {
-          "duration_ms": 3643,
-          "tool_uses": 1,
-          "total_tokens": 18028
-        },
-        "uuid": "5a7f6f45-13e2-4406-95b1-16c54bf35e85"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "content": [
-                {
-                  "text": "alpha:2026.03.11-alpha | sdk-platform-alpha",
-                  "type": "text"
-                },
-                {
-                  "text": "agentId: a4e4e0ab3cf303af7 (use SendMessage with to: 'a4e4e0ab3cf303af7' to continue this agent)\n<usage>total_tokens: 18034\ntool_uses: 1\nduration_ms: 3644</usage>",
-                  "type": "text"
-                }
-              ],
-              "tool_use_id": "toolu_01J2z1oBP9XHSZgLdRGzvoRt",
-              "type": "tool_result"
-            }
-          ],
-          "role": "user"
-        },
-        "parent_tool_use_id": null,
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
-        "timestamp": "2026-05-19T14:53:04.227Z",
-        "tool_use_result": {
-          "agentId": "a4e4e0ab3cf303af7",
-          "agentType": "general-purpose",
-          "content": [
-            {
-              "text": "alpha:2026.03.11-alpha | sdk-platform-alpha",
-              "type": "text"
-            }
-          ],
-          "prompt": "Read the file release_notes_alpha.md using the Read tool. Extract and return ONLY the version and owner in the format: 'alpha:<version> | <owner>'. Do not include any other text or explanation.",
-          "status": "completed",
-          "toolStats": {
-            "bashCount": 0,
-            "editFileCount": 0,
-            "linesAdded": 0,
-            "linesRemoved": 0,
-            "otherToolCount": 0,
-            "readCount": 1,
-            "searchCount": 0
-          },
-          "totalDurationMs": 3644,
-          "totalTokens": 18034,
-          "totalToolUseCount": 1,
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 192
-            },
-            "cache_creation_input_tokens": 192,
-            "cache_read_input_tokens": 17817,
-            "inference_geo": "",
-            "input_tokens": 6,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 192
-                },
-                "cache_creation_input_tokens": 192,
-                "cache_read_input_tokens": 17817,
-                "input_tokens": 6,
-                "output_tokens": 19,
-                "type": "message"
-              }
-            ],
-            "output_tokens": 19,
-            "server_tool_use": {
-              "web_fetch_requests": 0,
-              "web_search_requests": 0
-            },
-            "service_tier": "standard",
-            "speed": "standard"
-          }
-        },
-        "type": "user",
-        "uuid": "332fc825-fac6-4773-b776-a2ced04323e7"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "output_file": "",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
-        "status": "completed",
-        "subtype": "task_notification",
-        "summary": "Extract beta version and owner",
-        "task_id": "a5d4959a2c92999f6",
-        "tool_use_id": "toolu_01UyhHgNEXve8Z5eZ4ebw7fb",
-        "type": "system",
-        "usage": {
-          "duration_ms": 3630,
-          "tool_uses": 1,
-          "total_tokens": 18024
-        },
-        "uuid": "e6206687-1a13-4c93-b748-32c8c1f8b248"
-      }
-    },
-    {
-      "op": "read",
-      "payload": {
-        "message": {
-          "content": [
-            {
-              "content": [
-                {
-                  "text": "beta:2026.03.11-beta | sdk-platform-beta",
-                  "type": "text"
-                },
-                {
-                  "text": "agentId: a5d4959a2c92999f6 (use SendMessage with to: 'a5d4959a2c92999f6' to continue this agent)\n<usage>total_tokens: 18032\ntool_uses: 1\nduration_ms: 3630</usage>",
-                  "type": "text"
-                }
-              ],
-              "tool_use_id": "toolu_01UyhHgNEXve8Z5eZ4ebw7fb",
-              "type": "tool_result"
-            }
-          ],
-          "role": "user"
-        },
-        "parent_tool_use_id": null,
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
-        "timestamp": "2026-05-19T14:53:04.446Z",
-        "tool_use_result": {
-          "agentId": "a5d4959a2c92999f6",
-          "agentType": "general-purpose",
-          "content": [
-            {
-              "text": "beta:2026.03.11-beta | sdk-platform-beta",
-              "type": "text"
-            }
-          ],
-          "prompt": "Read the file release_notes_beta.md using the Read tool. Extract and return ONLY the version and owner in the format: 'beta:<version> | <owner>'. Do not include any other text or explanation.",
-          "status": "completed",
-          "toolStats": {
-            "bashCount": 0,
-            "editFileCount": 0,
-            "linesAdded": 0,
-            "linesRemoved": 0,
-            "otherToolCount": 0,
-            "readCount": 1,
-            "searchCount": 0
-          },
-          "totalDurationMs": 3630,
-          "totalTokens": 18032,
-          "totalToolUseCount": 1,
-          "usage": {
-            "cache_creation": {
-              "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 190
-            },
-            "cache_creation_input_tokens": 190,
-            "cache_read_input_tokens": 17817,
-            "inference_geo": "",
-            "input_tokens": 6,
-            "iterations": [
-              {
-                "cache_creation": {
-                  "ephemeral_1h_input_tokens": 0,
-                  "ephemeral_5m_input_tokens": 190
-                },
-                "cache_creation_input_tokens": 190,
-                "cache_read_input_tokens": 17817,
-                "input_tokens": 6,
-                "output_tokens": 19,
-                "type": "message"
-              }
-            ],
-            "output_tokens": 19,
-            "server_tool_use": {
-              "web_fetch_requests": 0,
-              "web_search_requests": 0
-            },
-            "service_tier": "standard",
-            "speed": "standard"
-          }
-        },
-        "type": "user",
-        "uuid": "83a8e035-9768-4e30-9eca-42282ee2f387"
+        "uuid": "b85c0302-7f91-41c5-b4d6-af32c0cc7df2"
       }
     },
     {
@@ -746,13 +1132,13 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "Perfect! Both agents have completed their tasks and returned the results in the exact format requested. Now I need to output exactly two lines in the order they were requested:\n\n1. alpha:2026.03.11-alpha | sdk-platform-alpha\n2. beta:2026.03.11-beta | sdk-platform-beta",
+              "thinking": "Perfect! I can see the file contains:\n- version = 2026.03.11-alpha\n- owner = sdk-platform-alpha\n\nSo the output should be in the format: alpha:<version> | <owner>\n\nThat would be: alpha:2026.03.11-alpha | sdk-platform-alpha\n\nThe user wants ONLY this string, no other text.",
               "type": "thinking"
             }
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_015J2dRUKbMVUiKNgbQfCsEP",
+          "id": "msg_011CduPxZaY9XZJ7Zmh8syz6",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -762,21 +1148,588 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 663
+              "ephemeral_5m_input_tokens": 671
             },
-            "cache_creation_input_tokens": 663,
-            "cache_read_input_tokens": 23765,
+            "cache_creation_input_tokens": 671,
+            "cache_read_input_tokens": 10318,
             "inference_geo": "not_available",
             "input_tokens": 8,
-            "output_tokens": 6,
+            "output_tokens": 4,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": "toolu_01TcC2KKNvYMkJaHZVunzm7W",
+        "request_id": "req_011CduPxZ4HW6z63tnZ8HBXE",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subagent_type": "general-purpose",
+        "task_description": "Extract alpha version and owner",
+        "timestamp": "2026-08-10T16:38:28.579Z",
+        "type": "assistant",
+        "uuid": "30ce338a-648f-4cb2-97eb-5f18add0834f"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "alpha:2026.03.11-alpha | sdk-platform-alpha",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduPxZaY9XZJ7Zmh8syz6",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 671
+            },
+            "cache_creation_input_tokens": 671,
+            "cache_read_input_tokens": 10318,
+            "inference_geo": "not_available",
+            "input_tokens": 8,
+            "output_tokens": 4,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": "toolu_01TcC2KKNvYMkJaHZVunzm7W",
+        "request_id": "req_011CduPxZ4HW6z63tnZ8HBXE",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subagent_type": "general-purpose",
+        "task_description": "Extract alpha version and owner",
+        "timestamp": "2026-08-10T16:38:28.580Z",
+        "type": "assistant",
+        "uuid": "fa0b7322-0c8b-47aa-8913-aeff9ec4750b"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "background_tasks_changed",
+        "tasks": [
+          {
+            "description": "Extract beta version and owner",
+            "task_id": "aa2d67565d2de9f26",
+            "task_type": "local_agent"
+          }
+        ],
+        "type": "system",
+        "uuid": "7b203606-c79f-42cc-8bc3-126503471741"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "patch": {
+          "end_time": 1786379908606,
+          "status": "completed"
+        },
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "task_updated",
+        "task_id": "acc13030b342e6516",
+        "type": "system",
+        "uuid": "e32ec718-2e9b-4ba5-9731-07b37e5dc9f5"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "output_file": "<REDACTED_PATH>",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "status": "completed",
+        "subtype": "task_notification",
+        "summary": "alpha:2026.03.11-alpha | sdk-platform-alpha",
+        "task_id": "acc13030b342e6516",
+        "tool_use_id": "toolu_01TcC2KKNvYMkJaHZVunzm7W",
+        "type": "system",
+        "usage": {
+          "duration_ms": 3954,
+          "tool_uses": 1,
+          "total_tokens": 11011
+        },
+        "uuid": "30ba9567-051b-4ea1-95a2-971f4b141a16"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 28,
+        "estimated_tokens_delta": 27,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "4eb86a99-e568-4790-a9b5-b0e3bfa53dd5"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 40,
+        "estimated_tokens_delta": 12,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "ce524b33-00d7-403d-a870-5422d95275d6"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 64,
+        "estimated_tokens_delta": 24,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "cf5e3155-689a-45ea-8041-5b327f9c9c3b"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 126,
+        "estimated_tokens_delta": 62,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "ce53b2f3-4cf6-4690-9c2c-ba71dc74982c"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "Good, now I have the TaskOutput tool loaded. I need to wait for both agents to complete. The agent IDs are:\n1. acc13030b342e6516 (alpha)\n2. aa2d67565d2de9f26 (beta)\n\nI'll call TaskOutput with block=true for both agents to wait for them to complete.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduPxasS4Cm4v56qPkAH5",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 584
+            },
+            "cache_creation_input_tokens": 584,
+            "cache_read_input_tokens": 13128,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 1,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "request_id": "req_011CbC7nTmJhJ4Fuw4g7j4e1",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
+        "request_id": "req_011CduPxZmTBjZCpFQeR2kJV",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:29.363Z",
         "type": "assistant",
-        "uuid": "05e6e861-a221-4ab5-9cad-0eb32efd7e97"
+        "uuid": "ccbab299-8640-4f94-a515-14c267014080"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "caller": {
+                "type": "direct"
+              },
+              "id": "toolu_01U1faYuYGzjHERBczX2o2tS",
+              "input": {
+                "block": true,
+                "task_id": "acc13030b342e6516",
+                "timeout": 30000
+              },
+              "name": "TaskOutput",
+              "type": "tool_use"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduPxasS4Cm4v56qPkAH5",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 584
+            },
+            "cache_creation_input_tokens": 584,
+            "cache_read_input_tokens": 13128,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 1,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "request_id": "req_011CduPxZmTBjZCpFQeR2kJV",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:29.684Z",
+        "type": "assistant",
+        "uuid": "cb7c115c-a7d6-4fe1-b1af-7f359f71399d"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "caller": {
+                "type": "direct"
+              },
+              "id": "toolu_01AwEKEBtpbHo8r1iTNerXf2",
+              "input": {
+                "block": true,
+                "task_id": "aa2d67565d2de9f26",
+                "timeout": 30000
+              },
+              "name": "TaskOutput",
+              "type": "tool_use"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduPxasS4Cm4v56qPkAH5",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 584
+            },
+            "cache_creation_input_tokens": 584,
+            "cache_read_input_tokens": 13128,
+            "inference_geo": "not_available",
+            "input_tokens": 10,
+            "output_tokens": 1,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "request_id": "req_011CduPxZmTBjZCpFQeR2kJV",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:29.867Z",
+        "type": "assistant",
+        "uuid": "4cb5f6d4-89d8-49c4-988a-5faa43d57536"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": "<retrieval_status>success</retrieval_status>\n\n<task_id>acc13030b342e6516</task_id>\n\n<task_type>local_agent</task_type>\n\n<status>completed</status>\n\n<output>\nalpha:2026.03.11-alpha | sdk-platform-alpha\n</output>",
+              "tool_use_id": "toolu_01U1faYuYGzjHERBczX2o2tS",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:29.893Z",
+        "tool_use_result": {
+          "retrieval_status": "success",
+          "task": {
+            "description": "Extract alpha version and owner",
+            "isRawTranscript": false,
+            "output": "alpha:2026.03.11-alpha | sdk-platform-alpha",
+            "prompt": "Read the file release_notes_alpha.md and extract the version and owner. Return ONLY the string in this format: alpha:<version> | <owner>\n\nExample output: alpha:1.2.3 | john-doe\n\nDo not include any other text or explanation.",
+            "result": "alpha:2026.03.11-alpha | sdk-platform-alpha",
+            "status": "completed",
+            "task_id": "acc13030b342e6516",
+            "task_type": "local_agent"
+          }
+        },
+        "type": "user",
+        "uuid": "4d0458a6-fda3-480e-a128-e9d605ffcad9"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "Great! I found the file. Now I can extract the version and owner:\n\n- version = 2026.03.11-beta\n- owner = sdk-platform-beta\n\nThe user wants the format: beta:<version> | <owner>\n\nSo the output should be: beta:2026.03.11-beta | sdk-platform-beta\n\nThe user specifically said \"Do not include any other text or explanation\" - so I should only return that line.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduPxeL3ZFB6MMjA6XfCb",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 786
+            },
+            "cache_creation_input_tokens": 786,
+            "cache_read_input_tokens": 10318,
+            "inference_geo": "not_available",
+            "input_tokens": 8,
+            "output_tokens": 8,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": "toolu_01XkapD7V36nPRGqQVPTftn3",
+        "request_id": "req_011CduPxdK27HoJgsdz2Bhtz",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subagent_type": "general-purpose",
+        "task_description": "Extract beta version and owner",
+        "timestamp": "2026-08-10T16:38:30.106Z",
+        "type": "assistant",
+        "uuid": "2724e37f-7c1c-42ef-a703-712946236d13"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "text": "beta:2026.03.11-beta | sdk-platform-beta",
+              "type": "text"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduPxeL3ZFB6MMjA6XfCb",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 786
+            },
+            "cache_creation_input_tokens": 786,
+            "cache_read_input_tokens": 10318,
+            "inference_geo": "not_available",
+            "input_tokens": 8,
+            "output_tokens": 8,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": "toolu_01XkapD7V36nPRGqQVPTftn3",
+        "request_id": "req_011CduPxdK27HoJgsdz2Bhtz",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subagent_type": "general-purpose",
+        "task_description": "Extract beta version and owner",
+        "timestamp": "2026-08-10T16:38:30.169Z",
+        "type": "assistant",
+        "uuid": "47326b37-89e0-4417-bb99-15ac9f92bfc7"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "background_tasks_changed",
+        "tasks": [],
+        "type": "system",
+        "uuid": "8db467d7-60c2-4f9a-81f1-a7a78ba91a8c"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "patch": {
+          "end_time": 1786379910367,
+          "status": "completed"
+        },
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "task_updated",
+        "task_id": "aa2d67565d2de9f26",
+        "type": "system",
+        "uuid": "7e1c0898-28d4-4fa8-a7db-0ae3da7dfa87"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "output_file": "<REDACTED_PATH>",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "status": "completed",
+        "subtype": "task_notification",
+        "summary": "beta:2026.03.11-beta | sdk-platform-beta",
+        "task_id": "aa2d67565d2de9f26",
+        "tool_use_id": "toolu_01XkapD7V36nPRGqQVPTftn3",
+        "type": "system",
+        "usage": {
+          "duration_ms": 5431,
+          "tool_uses": 1,
+          "total_tokens": 11140
+        },
+        "uuid": "cb51f637-258d-4b01-b665-19cdd9cd7304"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "content": "<retrieval_status>success</retrieval_status>\n\n<task_id>aa2d67565d2de9f26</task_id>\n\n<task_type>local_agent</task_type>\n\n<status>completed</status>\n\n<output>\nbeta:2026.03.11-beta | sdk-platform-beta\n</output>",
+              "tool_use_id": "toolu_01AwEKEBtpbHo8r1iTNerXf2",
+              "type": "tool_result"
+            }
+          ],
+          "role": "user"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:30.562Z",
+        "tool_use_result": {
+          "retrieval_status": "success",
+          "task": {
+            "description": "Extract beta version and owner",
+            "isRawTranscript": false,
+            "output": "beta:2026.03.11-beta | sdk-platform-beta",
+            "prompt": "Read the file release_notes_beta.md and extract the version and owner. Return ONLY the string in this format: beta:<version> | <owner>\n\nExample output: beta:2.0.0 | jane-smith\n\nDo not include any other text or explanation.",
+            "result": "beta:2026.03.11-beta | sdk-platform-beta",
+            "status": "completed",
+            "task_id": "aa2d67565d2de9f26",
+            "task_type": "local_agent"
+          }
+        },
+        "type": "user",
+        "uuid": "a2819fb6-e519-469f-bc55-fe9794efbf43"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 4,
+        "estimated_tokens_delta": 4,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "5c455482-d05f-4853-b326-db22f0e56f27"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 34,
+        "estimated_tokens_delta": 30,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "07ebebc0-a5dc-4cc8-a1c3-a950edbe71d9"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 58,
+        "estimated_tokens_delta": 24,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "7efb069f-df39-4bc3-82f8-cc56fb956ad1"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 64,
+        "estimated_tokens_delta": 6,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "18e499d1-343b-4b2a-b3db-7efd2d16a289"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 126,
+        "estimated_tokens_delta": 62,
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "a02dc0d1-bbf9-4da4-94ef-50209af45554"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "message": {
+          "content": [
+            {
+              "signature": "<REDACTED_SIGNATURE>",
+              "thinking": "Perfect! Both agents have completed successfully. I have the results:\n1. alpha:2026.03.11-alpha | sdk-platform-alpha\n2. beta:2026.03.11-beta | sdk-platform-beta\n\nNow I need to reply with exactly two lines in that same order, as requested by the user.",
+              "type": "thinking"
+            }
+          ],
+          "context_management": null,
+          "diagnostics": null,
+          "id": "msg_011CduPxo1gNLNavMzLF9wvX",
+          "model": "claude-haiku-4-5-20251001",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "type": "message",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 1388
+            },
+            "cache_creation_input_tokens": 1388,
+            "cache_read_input_tokens": 13712,
+            "inference_geo": "not_available",
+            "input_tokens": 8,
+            "output_tokens": 3,
+            "service_tier": "standard"
+          }
+        },
+        "parent_tool_use_id": null,
+        "request_id": "req_011CduPxnTSW2XZ7VkrWRWyi",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:32.006Z",
+        "type": "assistant",
+        "uuid": "5ef8a7ae-fea4-4fbd-85f7-50bbe895ed25"
       }
     },
     {
@@ -791,7 +1744,7 @@
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_015J2dRUKbMVUiKNgbQfCsEP",
+          "id": "msg_011CduPxo1gNLNavMzLF9wvX",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -801,76 +1754,82 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 663
+              "ephemeral_5m_input_tokens": 1388
             },
-            "cache_creation_input_tokens": 663,
-            "cache_read_input_tokens": 23765,
+            "cache_creation_input_tokens": 1388,
+            "cache_read_input_tokens": 13712,
             "inference_geo": "not_available",
             "input_tokens": 8,
-            "output_tokens": 6,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "request_id": "req_011CbC7nTmJhJ4Fuw4g7j4e1",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
+        "request_id": "req_011CduPxnTSW2XZ7VkrWRWyi",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
+        "timestamp": "2026-08-10T16:38:32.008Z",
         "type": "assistant",
-        "uuid": "5ac47ee3-9a80-4e27-818b-a9ee61003134"
+        "uuid": "9a245758-0c0b-412c-b47c-9fe2c30d2085"
       }
     },
     {
       "op": "read",
       "payload": {
         "api_error_status": null,
-        "duration_api_ms": 13622,
-        "duration_ms": 8954,
+        "duration_api_ms": 19028,
+        "duration_ms": 11270,
+        "fast_mode_disabled_reason": "sdk_opt_in_required",
         "fast_mode_state": "off",
         "is_error": false,
         "modelUsage": {
           "claude-haiku-4-5-20251001": {
-            "cacheCreationInputTokens": 60444,
-            "cacheReadInputTokens": 59399,
+            "cacheCreationInputTokens": 12769,
+            "cacheReadInputTokens": 83780,
+            "canonicalModel": "claude-haiku-4-5",
             "contextWindow": 200000,
-            "costUSD": 0.08642690000000001,
-            "inputTokens": 602,
+            "costUSD": 0.033231250000000004,
+            "inputTokens": 72,
             "maxOutputTokens": 32000,
-            "outputTokens": 866,
+            "outputTokens": 1764,
+            "provider": "firstParty",
             "webSearchRequests": 0
           }
         },
-        "num_turns": 3,
+        "num_turns": 6,
         "permission_denials": [],
         "result": "alpha:2026.03.11-alpha | sdk-platform-alpha\nbeta:2026.03.11-beta | sdk-platform-beta",
-        "session_id": "9390888b-4e10-44b7-aafa-cf339cf620c8",
+        "session_id": "37f2cd76-234e-4c18-93fd-d1455c5036ba",
         "stop_reason": "end_turn",
         "subtype": "success",
         "terminal_reason": "completed",
-        "total_cost_usd": 0.08642690000000001,
-        "ttft_ms": 3093,
+        "time_to_request_ms": 143,
+        "total_cost_usd": 0.033231250000000004,
+        "ttft_ms": 2402,
+        "ttft_stream_ms": 1114,
         "type": "result",
         "usage": {
           "cache_creation": {
             "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 24428
+            "ephemeral_5m_input_tokens": 5790
           },
-          "cache_creation_input_tokens": 24428,
-          "cache_read_input_tokens": 23765,
-          "inference_geo": "",
-          "input_tokens": 18,
+          "cache_creation_input_tokens": 5790,
+          "cache_read_input_tokens": 48030,
+          "inference_geo": "not_available",
+          "input_tokens": 36,
           "iterations": [
             {
               "cache_creation": {
                 "ephemeral_1h_input_tokens": 0,
-                "ephemeral_5m_input_tokens": 663
+                "ephemeral_5m_input_tokens": 1388
               },
-              "cache_creation_input_tokens": 663,
-              "cache_read_input_tokens": 23765,
+              "cache_creation_input_tokens": 1388,
+              "cache_read_input_tokens": 13712,
               "input_tokens": 8,
-              "output_tokens": 115,
+              "output_tokens": 116,
               "type": "message"
             }
           ],
-          "output_tokens": 520,
+          "output_tokens": 1012,
           "server_tool_use": {
             "web_fetch_requests": 0,
             "web_search_requests": 0
@@ -878,9 +1837,9 @@
           "service_tier": "standard",
           "speed": "standard"
         },
-        "uuid": "89727a5e-d984-4a9f-88ed-d3ea06cbaccb"
+        "uuid": "f6826610-5dbe-45aa-86f0-1f8c0d671913"
       }
     }
   ],
-  "sdk_version": "0.2.82"
+  "sdk_version": "0.2.129"
 }

--- a/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_user_prompt_submit_hook_creates_function_span.json
+++ b/py/src/braintrust/integrations/claude_agent_sdk/cassettes/latest/test_user_prompt_submit_hook_creates_function_span.json
@@ -19,7 +19,7 @@
             },
             "subtype": "initialize"
           },
-          "request_id": "req_1_c065fa36",
+          "request_id": "req_1_03b62051",
           "type": "control_request"
         }
       }
@@ -27,13 +27,42 @@
     {
       "op": "read",
       "payload": {
+        "hook_event": "SessionStart",
+        "hook_id": "aeb6c325-0578-441b-bcb6-44dbbe309c5e",
+        "hook_name": "SessionStart:startup",
+        "session_id": "9f08ea13-a7ed-4b10-991e-bfdcb8860166",
+        "subtype": "hook_started",
+        "type": "system",
+        "uuid": "c5aa4b0c-3d65-4cc4-8fbf-0621207f4321"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "exit_code": 0,
+        "hook_event": "SessionStart",
+        "hook_id": "aeb6c325-0578-441b-bcb6-44dbbe309c5e",
+        "hook_name": "SessionStart:startup",
+        "outcome": "success",
+        "output": "",
+        "session_id": "9f08ea13-a7ed-4b10-991e-bfdcb8860166",
+        "stderr": "",
+        "stdout": "",
+        "subtype": "hook_response",
+        "type": "system",
+        "uuid": "5e70c37a-81ca-4c65-9652-74f1c50d43b7"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
         "response": {
-          "request_id": "req_1_c065fa36",
+          "request_id": "req_1_03b62051",
           "response": {
             "account": {
               "apiKeySource": "ANTHROPIC_API_KEY",
               "apiProvider": "firstParty",
-              "tokenSource": "none"
+              "tokenSource": "claude.ai"
             },
             "agents": [],
             "available_output_styles": [],
@@ -70,13 +99,14 @@
             "hook_event_name": "UserPromptSubmit",
             "permission_mode": "bypassPermissions",
             "prompt": "Say hello in one short sentence.",
-            "session_id": "c6b8f60e-80a7-4b13-b770-331510ea4fd0",
-            "transcript_path": "<REDACTED_PATH>"
+            "prompt_id": "48396d1a-48d3-423e-a548-7c2a31c5b992",
+            "session_id": "9f08ea13-a7ed-4b10-991e-bfdcb8860166",
+            "transcript_path": "TRANSCRIPT_0"
           },
           "subtype": "hook_callback",
-          "tool_use_id": "100c74a3-aa55-4aff-b89d-8ec48528a3b7"
+          "tool_use_id": "59895247-9216-4468-b76f-c6ce1f562728"
         },
-        "request_id": "37567e48-5d59-4333-b1bd-090c7fdca6d7",
+        "request_id": "5345f1f1-1317-4afd-8861-b654134a7493",
         "type": "control_request"
       }
     },
@@ -86,7 +116,7 @@
         "kind": "json",
         "value": {
           "response": {
-            "request_id": "37567e48-5d59-4333-b1bd-090c7fdca6d7",
+            "request_id": "5345f1f1-1317-4afd-8861-b654134a7493",
             "response": {
               "hookSpecificOutput": {
                 "additionalContext": "Remember the answer should stay concise.",
@@ -111,14 +141,16 @@
         ],
         "analytics_disabled": false,
         "apiKeySource": "ANTHROPIC_API_KEY",
-        "claude_code_version": "2.1.142",
+        "capabilities": [
+          "interrupt_receipt_v1",
+          "interrupt_cancel_queued_v1",
+          "msg_lifecycle_v1"
+        ],
+        "claude_code_version": "2.1.221",
         "cwd": "<REDACTED_CWD>",
+        "fast_mode_disabled_reason": "sdk_opt_in_required",
         "fast_mode_state": "off",
         "mcp_servers": [
-          {
-            "name": "braintrust",
-            "status": "connected"
-          },
           {
             "name": "linear-server",
             "status": "connected"
@@ -134,78 +166,107 @@
           {
             "name": "rust-analyzer-lsp",
             "path": "<REDACTED_PATH>",
-            "source": "rust-analyzer-lsp@claude-plugins-official"
+            "source": "rust-analyzer-lsp@claude-plugins-official",
+            "version": "1.0.0"
           }
         ],
-        "session_id": "c6b8f60e-80a7-4b13-b770-331510ea4fd0",
+        "product_feedback_disabled": false,
+        "session_id": "9f08ea13-a7ed-4b10-991e-bfdcb8860166",
         "skills": [
-          "create-braintrust-demo",
           "braintrust",
+          "create-braintrust-demo",
+          "commit-message",
+          "sdk-benchmarking",
+          "sdk-ci-triage",
           "sdk-dependency-updates",
           "sdk-integrations",
           "sdk-vcr-workflows",
-          "sdk-ci-triage",
-          "commit-message",
-          "sdk-benchmarking",
+          "design-sync",
+          "dataviz",
           "update-config",
+          "verify",
           "debug",
+          "code-review",
           "simplify",
           "batch",
           "fewer-permission-prompts",
-          "loop",
-          "claude-api"
-        ],
-        "slash_commands": [
-          "create-braintrust-demo",
-          "braintrust",
-          "sdk-dependency-updates",
-          "sdk-integrations",
-          "sdk-vcr-workflows",
-          "sdk-ci-triage",
-          "commit-message",
-          "sdk-benchmarking",
-          "update-config",
-          "debug",
-          "simplify",
-          "batch",
-          "fewer-permission-prompts",
+          "doctor",
           "loop",
           "claude-api",
+          "run",
+          "run-skill-generator"
+        ],
+        "slash_commands": [
+          "braintrust",
+          "create-braintrust-demo",
+          "commit-message",
+          "sdk-benchmarking",
+          "sdk-ci-triage",
+          "sdk-dependency-updates",
+          "sdk-integrations",
+          "sdk-vcr-workflows",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "run",
+          "run-skill-generator",
+          "agents",
+          "autocompact",
           "clear",
+          "color",
           "compact",
+          "config",
           "context",
+          "effort",
+          "fast",
           "heapdump",
           "init",
+          "mcp",
+          "import",
+          "model",
+          "__remote-workflow",
+          "workflow-launch-exec",
+          "reload-skills",
+          "rename",
           "review",
           "security-review",
           "usage",
           "insights",
+          "recap",
           "goal",
+          "design",
+          "design-consent",
+          "design-revoke",
           "team-onboarding"
         ],
         "subtype": "init",
         "tools": [
           "Task",
-          "AskUserQuestion",
           "Bash",
           "CronCreate",
           "CronDelete",
           "CronList",
+          "DesignSync",
           "Edit",
-          "EnterPlanMode",
           "EnterWorktree",
-          "ExitPlanMode",
           "ExitWorktree",
-          "Glob",
-          "Grep",
-          "ListMcpResourcesTool",
           "LSP",
           "Monitor",
           "NotebookEdit",
           "PushNotification",
           "Read",
-          "ReadMcpResourceTool",
+          "ReportFindings",
           "ScheduleWakeup",
+          "SendMessage",
           "Skill",
           "TaskCreate",
           "TaskGet",
@@ -217,22 +278,18 @@
           "WebFetch",
           "WebSearch",
           "Write",
-          "mcp__braintrust__generate_permalink",
-          "mcp__braintrust__infer_schema",
-          "mcp__braintrust__list_recent_objects",
-          "mcp__braintrust__resolve_object",
-          "mcp__braintrust__search_docs",
-          "mcp__braintrust__sql_query",
-          "mcp__braintrust__summarize_experiment",
           "mcp__linear-server__create_attachment",
           "mcp__linear-server__create_attachment_from_upload",
+          "mcp__linear-server__create_initiative_label",
           "mcp__linear-server__create_issue_label",
           "mcp__linear-server__delete_attachment",
           "mcp__linear-server__delete_comment",
           "mcp__linear-server__delete_customer",
           "mcp__linear-server__delete_customer_need",
+          "mcp__linear-server__delete_diff_comment",
           "mcp__linear-server__delete_status_update",
           "mcp__linear-server__extract_images",
+          "mcp__linear-server__get_agent_skill",
           "mcp__linear-server__get_attachment",
           "mcp__linear-server__get_diff",
           "mcp__linear-server__get_diff_threads",
@@ -242,14 +299,19 @@
           "mcp__linear-server__get_issue_status",
           "mcp__linear-server__get_milestone",
           "mcp__linear-server__get_project",
+          "mcp__linear-server__get_release",
+          "mcp__linear-server__get_release_note",
           "mcp__linear-server__get_status_updates",
           "mcp__linear-server__get_team",
           "mcp__linear-server__get_user",
+          "mcp__linear-server__get_workspace",
+          "mcp__linear-server__list_agent_skills",
           "mcp__linear-server__list_comments",
           "mcp__linear-server__list_customers",
           "mcp__linear-server__list_cycles",
           "mcp__linear-server__list_diffs",
           "mcp__linear-server__list_documents",
+          "mcp__linear-server__list_initiative_labels",
           "mcp__linear-server__list_initiatives",
           "mcp__linear-server__list_issue_labels",
           "mcp__linear-server__list_issue_statuses",
@@ -257,22 +319,75 @@
           "mcp__linear-server__list_milestones",
           "mcp__linear-server__list_project_labels",
           "mcp__linear-server__list_projects",
+          "mcp__linear-server__list_release_notes",
+          "mcp__linear-server__list_release_pipelines",
+          "mcp__linear-server__list_releases",
           "mcp__linear-server__list_teams",
           "mcp__linear-server__list_users",
+          "mcp__linear-server__merge_diff",
           "mcp__linear-server__prepare_attachment_upload",
+          "mcp__linear-server__resolve_diff_thread",
           "mcp__linear-server__save_comment",
           "mcp__linear-server__save_customer",
           "mcp__linear-server__save_customer_need",
+          "mcp__linear-server__save_diff_comment",
           "mcp__linear-server__save_document",
           "mcp__linear-server__save_initiative",
           "mcp__linear-server__save_issue",
           "mcp__linear-server__save_milestone",
           "mcp__linear-server__save_project",
+          "mcp__linear-server__save_release",
+          "mcp__linear-server__save_release_note",
           "mcp__linear-server__save_status_update",
-          "mcp__linear-server__search_documentation"
+          "mcp__linear-server__search_documentation",
+          "mcp__linear-server__submit_diff_review"
         ],
         "type": "system",
-        "uuid": "f17dade9-e2b7-4428-b8c8-204e8d49dacf"
+        "uuid": "96637df0-4ce5-454d-8ef2-f208ee618002"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 3,
+        "estimated_tokens_delta": 3,
+        "session_id": "9f08ea13-a7ed-4b10-991e-bfdcb8860166",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "99ff8068-7b8d-4698-a4c9-d414a3d503fb"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 8,
+        "estimated_tokens_delta": 5,
+        "session_id": "9f08ea13-a7ed-4b10-991e-bfdcb8860166",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "d6381bd8-a359-484e-a557-5e9677cd8b5c"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 35,
+        "estimated_tokens_delta": 27,
+        "session_id": "9f08ea13-a7ed-4b10-991e-bfdcb8860166",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "06f2594b-c573-4b25-8c1c-ffd7054b9bbc"
+      }
+    },
+    {
+      "op": "read",
+      "payload": {
+        "estimated_tokens": 97,
+        "estimated_tokens_delta": 62,
+        "session_id": "9f08ea13-a7ed-4b10-991e-bfdcb8860166",
+        "subtype": "thinking_tokens",
+        "type": "system",
+        "uuid": "7ec9dcd5-c15f-47df-be84-5cb3ef671ed0"
       }
     },
     {
@@ -282,13 +397,13 @@
           "content": [
             {
               "signature": "<REDACTED_SIGNATURE>",
-              "thinking": "The user is asking me to say hello in one short sentence. This is a very simple request. I should provide a brief greeting.",
+              "thinking": "The user is asking me to say hello in one short sentence. This is a simple greeting request. I should respond briefly and courteously.",
               "type": "thinking"
             }
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_01PBVTQmKiV2TW6SwGDr93cc",
+          "id": "msg_011CduPywRUPsNNJnSqm4CBT",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -298,21 +413,22 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 44572
+              "ephemeral_5m_input_tokens": 7957
             },
-            "cache_creation_input_tokens": 44572,
-            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 7957,
+            "cache_read_input_tokens": 9310,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 7,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "request_id": "req_011CbC7WRWBU7Lg6co2KK6k9",
-        "session_id": "c6b8f60e-80a7-4b13-b770-331510ea4fd0",
+        "request_id": "req_011CduPyvvTbwELYfY2MCf9W",
+        "session_id": "9f08ea13-a7ed-4b10-991e-bfdcb8860166",
+        "timestamp": "2026-08-10T16:38:47.080Z",
         "type": "assistant",
-        "uuid": "1f66b247-77c6-490b-bcc5-52282c23a736"
+        "uuid": "3f8cbdd9-8fb0-44c5-a0c4-5e0e42c56216"
       }
     },
     {
@@ -321,13 +437,13 @@
         "message": {
           "content": [
             {
-              "text": "Hello! I'm ready to help you with Braintrust SDK development or other tasks.",
+              "text": "Hello! I'm Claude, and I'm ready to help you with your Braintrust SDK work.",
               "type": "text"
             }
           ],
           "context_management": null,
           "diagnostics": null,
-          "id": "msg_01PBVTQmKiV2TW6SwGDr93cc",
+          "id": "msg_011CduPywRUPsNNJnSqm4CBT",
           "model": "claude-haiku-4-5-20251001",
           "role": "assistant",
           "stop_details": null,
@@ -337,76 +453,82 @@
           "usage": {
             "cache_creation": {
               "ephemeral_1h_input_tokens": 0,
-              "ephemeral_5m_input_tokens": 44572
+              "ephemeral_5m_input_tokens": 7957
             },
-            "cache_creation_input_tokens": 44572,
-            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 7957,
+            "cache_read_input_tokens": 9310,
             "inference_geo": "not_available",
             "input_tokens": 10,
-            "output_tokens": 7,
+            "output_tokens": 3,
             "service_tier": "standard"
           }
         },
         "parent_tool_use_id": null,
-        "request_id": "req_011CbC7WRWBU7Lg6co2KK6k9",
-        "session_id": "c6b8f60e-80a7-4b13-b770-331510ea4fd0",
+        "request_id": "req_011CduPyvvTbwELYfY2MCf9W",
+        "session_id": "9f08ea13-a7ed-4b10-991e-bfdcb8860166",
+        "timestamp": "2026-08-10T16:38:47.084Z",
         "type": "assistant",
-        "uuid": "467d8d4b-0ed5-4d28-91e2-a4802d75498a"
+        "uuid": "f41ed6fb-5cd0-4c77-a157-e66cd5f9aaae"
       }
     },
     {
       "op": "read",
       "payload": {
         "api_error_status": null,
-        "duration_api_ms": 3996,
-        "duration_ms": 2960,
+        "duration_api_ms": 1149,
+        "duration_ms": 1437,
+        "fast_mode_disabled_reason": "sdk_opt_in_required",
         "fast_mode_state": "off",
         "is_error": false,
         "modelUsage": {
           "claude-haiku-4-5-20251001": {
-            "cacheCreationInputTokens": 44572,
-            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 7957,
+            "cacheReadInputTokens": 9310,
+            "canonicalModel": "claude-haiku-4-5",
             "contextWindow": 200000,
-            "costUSD": 0.056518,
-            "inputTokens": 453,
+            "costUSD": 0.01119725,
+            "inputTokens": 10,
             "maxOutputTokens": 32000,
-            "outputTokens": 70,
+            "outputTokens": 62,
+            "provider": "firstParty",
             "webSearchRequests": 0
           }
         },
         "num_turns": 1,
         "permission_denials": [],
-        "result": "Hello! I'm ready to help you with Braintrust SDK development or other tasks.",
-        "session_id": "c6b8f60e-80a7-4b13-b770-331510ea4fd0",
+        "result": "Hello! I'm Claude, and I'm ready to help you with your Braintrust SDK work.",
+        "session_id": "9f08ea13-a7ed-4b10-991e-bfdcb8860166",
         "stop_reason": "end_turn",
         "subtype": "success",
         "terminal_reason": "completed",
-        "total_cost_usd": 0.056518,
-        "ttft_ms": 2900,
+        "time_to_request_ms": 114,
+        "total_cost_usd": 0.01119725,
+        "ttft_ms": 1248,
+        "ttft_stream_ms": 883,
         "type": "result",
         "usage": {
           "cache_creation": {
             "ephemeral_1h_input_tokens": 0,
-            "ephemeral_5m_input_tokens": 44572
+            "ephemeral_5m_input_tokens": 7957
           },
-          "cache_creation_input_tokens": 44572,
-          "cache_read_input_tokens": 0,
-          "inference_geo": "",
+          "cache_creation_input_tokens": 7957,
+          "cache_read_input_tokens": 9310,
+          "inference_geo": "not_available",
           "input_tokens": 10,
           "iterations": [
             {
               "cache_creation": {
                 "ephemeral_1h_input_tokens": 0,
-                "ephemeral_5m_input_tokens": 44572
+                "ephemeral_5m_input_tokens": 7957
               },
-              "cache_creation_input_tokens": 44572,
-              "cache_read_input_tokens": 0,
+              "cache_creation_input_tokens": 7957,
+              "cache_read_input_tokens": 9310,
               "input_tokens": 10,
-              "output_tokens": 57,
+              "output_tokens": 62,
               "type": "message"
             }
           ],
-          "output_tokens": 57,
+          "output_tokens": 62,
           "server_tool_use": {
             "web_fetch_requests": 0,
             "web_search_requests": 0
@@ -414,9 +536,9 @@
           "service_tier": "standard",
           "speed": "standard"
         },
-        "uuid": "de0dea47-6c17-4191-9685-06725bcc8834"
+        "uuid": "28a477a9-740d-47d6-8688-5b681936d62f"
       }
     }
   ],
-  "sdk_version": "0.2.82"
+  "sdk_version": "0.2.129"
 }

--- a/py/src/braintrust/integrations/claude_agent_sdk/test_claude_agent_sdk.py
+++ b/py/src/braintrust/integrations/claude_agent_sdk/test_claude_agent_sdk.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextvars
+import copy
 import dataclasses
 import sys
 import types
@@ -31,8 +32,10 @@ from braintrust.integrations.claude_agent_sdk._test_transport import make_casset
 from braintrust.integrations.claude_agent_sdk.tracing import (
     ContextTracker,
     ToolSpanTracker,
+    _aggregate_model_usage,
     _build_llm_input,
     _create_client_wrapper_class,
+    _create_query_wrapper_function,
     _create_tool_wrapper_class,
     _parse_tool_name,
     _serialize_content_blocks,
@@ -49,6 +52,16 @@ from braintrust.test_helpers import find_span_by_name, find_spans_by_type, init_
 PROJECT_NAME = "test-claude-agent-sdk"
 TEST_MODEL = "claude-haiku-4-5-20251001"
 REPO_ROOT = Path(__file__).resolve().parents[5]  # py/src/braintrust/integrations/claude_agent_sdk -> repo root
+
+
+async def _concise_user_prompt_hook(input_data: Any, tool_use_id: str | None, context: Any) -> dict[str, Any]:
+    del input_data, tool_use_id, context
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": "Remember the answer should stay concise.",
+        }
+    }
 
 
 @pytest.fixture
@@ -100,6 +113,7 @@ def _make_calculator_options(handler: Any) -> Any:
     return claude_agent_sdk.ClaudeAgentOptions(
         model=TEST_MODEL,
         permission_mode="bypassPermissions",
+        include_partial_messages=True,
         mcp_servers={
             "calculator": claude_agent_sdk.create_sdk_mcp_server(
                 name="calculator",
@@ -164,8 +178,13 @@ async def test_calculator_with_multiple_operations(memory_logger):
         )
 
         result_message = None
+        received_messages: list[Any] = []
+        message_snapshots: list[dict[str, Any]] = []
         async with claude_agent_sdk.ClaudeSDKClient(options=options, transport=transport) as client:
-            await client.query("What is 15 multiplied by 7? Then subtract 5 from the result.")
+            await client.query(
+                "What is 15 multiplied by 7? Then subtract 5 from the result. "
+                "You must use the calculator MCP tool for both operations in order; do not calculate directly."
+            )
 
             # Deterministically let local MCP dispatch race ahead of application
             # consumption of the AssistantMessage containing its tool_use block.
@@ -174,8 +193,14 @@ async def test_calculator_with_multiple_operations(memory_logger):
             await asyncio.wait_for(handler_started.wait(), timeout=1)
 
             async for message in client.receive_response():
+                received_messages.append(message)
+                message_snapshots.append(copy.deepcopy(vars(message)))
                 if type(message).__name__ == "ResultMessage":
                     result_message = message
+
+        assert options.include_partial_messages is True
+        assert options.hooks is None
+        assert [vars(message) for message in received_messages] == message_snapshots
 
     spans = memory_logger.pop()
 
@@ -208,8 +233,39 @@ async def test_calculator_with_multiple_operations(memory_logger):
     llm_span_ids = {span["span_id"] for span in llm_spans}
     _assert_llm_spans_have_time_to_first_token(llm_spans)
 
-    llm_spans_with_metrics = [s for s in llm_spans if "prompt_tokens" in s.get("metrics", {})]
-    assert len(llm_spans_with_metrics) >= 1, "At least one LLM span should have token metrics"
+    expected_partial_usage = _final_partial_usage(received_messages)
+    if expected_partial_usage:
+        ordered_llm_spans = sorted(llm_spans, key=lambda span: span["metrics"]["start"])
+        assert len(ordered_llm_spans) == len(expected_partial_usage)
+        for llm_span, usage in zip(ordered_llm_spans, expected_partial_usage, strict=True):
+            assert llm_span["metrics"] | _metrics_from_exact_anthropic_usage(usage) == llm_span["metrics"]
+    elif _sdk_version_at_least("0.1.11"):
+        expected_usage_by_message_id: dict[str, dict[str, Any]] = {}
+        for message in received_messages:
+            message_id = getattr(message, "message_id", None)
+            usage = _copy_numeric_usage(getattr(message, "usage", None))
+            if isinstance(message_id, str) and usage:
+                expected_usage_by_message_id[message_id] = usage
+
+        expected_usage = list(expected_usage_by_message_id.values())
+        assert expected_usage, "Cassette must contain per-request assistant usage"
+        ordered_llm_spans = sorted(llm_spans, key=lambda span: span["metrics"]["start"])
+        assert len(ordered_llm_spans) == len(expected_usage)
+        for llm_span, usage in zip(ordered_llm_spans, expected_usage, strict=True):
+            expected_metrics = _metrics_from_exact_anthropic_usage(usage)
+            for unreliable_metric in ("completion_tokens", "tokens"):
+                expected_metrics.pop(unreliable_metric, None)
+            assert llm_span["metrics"] | expected_metrics == llm_span["metrics"]
+            assert "completion_tokens" not in llm_span["metrics"]
+            assert "tokens" not in llm_span["metrics"]
+            if "cache_creation" in usage:
+                assert "prompt_cache_creation_tokens" not in llm_span["metrics"]
+
+    assert not {
+        "prompt_tokens",
+        "completion_tokens",
+        "tokens",
+    }.intersection(task_span.get("metrics", {}))
 
     for llm_span in llm_spans:
         assert llm_span["span_attributes"]["name"] == "anthropic.messages.create"
@@ -220,7 +276,8 @@ async def test_calculator_with_multiple_operations(memory_logger):
         for metric_name in ("prompt_tokens", "completion_tokens", "tokens"):
             if metric_name in llm_span.get("metrics", {}):
                 assert llm_span["metrics"][metric_name] > 0
-    assert any(llm_span.get("metadata", {}).get("usage_service_tier") == "standard" for llm_span in llm_spans)
+    if _sdk_version_at_least("0.1.11"):
+        assert any(llm_span.get("metadata", {}).get("usage_service_tier") == "standard" for llm_span in llm_spans)
     if any("usage_inference_geo" in llm_span.get("metadata", {}) for llm_span in llm_spans):
         assert all(
             isinstance(llm_span.get("metadata", {}).get("usage_inference_geo"), str)
@@ -228,9 +285,10 @@ async def test_calculator_with_multiple_operations(memory_logger):
             if "usage_inference_geo" in llm_span.get("metadata", {})
         )
     tool_spans = [s for s in spans if s["span_attributes"]["type"] == SpanTypeAttribute.TOOL]
-    assert len(tool_spans) == 2, "Each local MCP call should create exactly one canonical tool span"
-    for tool_span in tool_spans:
-        assert tool_span["span_attributes"]["name"] == "calculator"
+    calculator_spans = [span for span in tool_spans if span["span_attributes"]["name"] == "calculator"]
+    assert len(calculator_spans) == 2, f"Expected both calculator operations, got {len(calculator_spans)}"
+    assert len(llm_spans) >= 2, f"Expected multiple provider requests, got {len(llm_spans)}"
+    for tool_span in calculator_spans:
         assert tool_span["input"] is not None
         assert tool_span["output"] is not None
         assert tool_span.get("metadata", {}).get("gen_ai.tool.call.id")
@@ -299,7 +357,10 @@ async def test_local_mcp_handler_uses_its_own_tracker_with_concurrent_client(mem
             ) as calculator_client,
             claude_agent_sdk.ClaudeSDKClient(options=other_options, transport=other_transport) as other_client,
         ):
-            await calculator_client.query("What is 15 multiplied by 7? Then subtract 5 from the result.")
+            await calculator_client.query(
+                "What is 15 multiplied by 7? Then subtract 5 from the result. "
+                "You must use the calculator MCP tool for both operations in order; do not calculate directly."
+            )
             await asyncio.wait_for(calculator_transport.wait_for_mcp_tool_call(), timeout=1)
 
             await other_client.query("Say hi")
@@ -327,6 +388,98 @@ async def test_local_mcp_handler_uses_its_own_tracker_with_concurrent_client(mem
     assert multiply_span["span_id"] in nested_span["span_parents"]
 
 
+@pytest.mark.skipif(not CLAUDE_SDK_AVAILABLE, reason="Claude Agent SDK not installed")
+@pytest.mark.asyncio
+async def test_query_helper_keeps_options_untouched_and_logs_aggregate_task_usage(memory_logger):
+    if not _sdk_version_at_least("0.1.11"):
+        pytest.skip("The 0.1.10 query() transport lifecycle is incompatible with the client cassette")
+    assert not memory_logger.pop()
+    prompt = "Say hello in one short sentence."
+
+    hooks = {"UserPromptSubmit": [claude_agent_sdk.HookMatcher(hooks=[_concise_user_prompt_hook])]}
+    options = claude_agent_sdk.ClaudeAgentOptions(
+        model=TEST_MODEL,
+        permission_mode="bypassPermissions",
+        hooks=hooks,
+    )
+    transport = make_cassette_transport(
+        cassette_name="test_user_prompt_submit_hook_creates_function_span",
+        prompt="",
+        options=options,
+    )
+    wrapped_query = _create_query_wrapper_function(claude_agent_sdk.query)
+    received_messages = [
+        message
+        async for message in wrapped_query(
+            prompt=prompt,
+            options=options,
+            transport=transport,
+        )
+    ]
+
+    assert options.hooks is hooks
+    assert received_messages
+    assert type(received_messages[-1]).__name__ == "ResultMessage"
+
+    spans = memory_logger.pop()
+    task_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.TASK), "Claude Agent")
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
+    assert len(llm_spans) == 1
+    assert not {
+        "prompt_tokens",
+        "completion_tokens",
+        "tokens",
+        "prompt_cached_tokens",
+        "prompt_cache_creation_tokens",
+        "prompt_cache_creation_5m_tokens",
+        "prompt_cache_creation_1h_tokens",
+    }.intersection(llm_spans[0].get("metrics", {}))
+
+    result_message = received_messages[-1]
+    expected_metrics = _metrics_from_result_message(result_message)
+    assert task_span["metrics"] | expected_metrics == task_span["metrics"]
+    _, expected_usage_metadata = extract_anthropic_usage(result_message.usage)
+    assert task_span["metadata"] | expected_usage_metadata == task_span["metadata"]
+
+
+@pytest.mark.skipif(not CLAUDE_SDK_AVAILABLE, reason="Claude Agent SDK not installed")
+@pytest.mark.asyncio
+async def test_connect_with_prompt_logs_aggregate_task_usage(memory_logger):
+    if not _sdk_version_at_least("0.1.11"):
+        pytest.skip("Transcript usage is not exposed by the older SDK cassette")
+    assert not memory_logger.pop()
+    prompt = "Say hello in one short sentence."
+
+    options = claude_agent_sdk.ClaudeAgentOptions(
+        model=TEST_MODEL,
+        permission_mode="bypassPermissions",
+        hooks={"UserPromptSubmit": [claude_agent_sdk.HookMatcher(hooks=[_concise_user_prompt_hook])]},
+    )
+    transport = make_cassette_transport(
+        cassette_name="test_user_prompt_submit_hook_creates_function_span",
+        prompt="",
+        options=options,
+    )
+
+    with _patched_claude_sdk(wrap_client=True):
+        client = claude_agent_sdk.ClaudeSDKClient(options=options, transport=transport)
+        try:
+            await client.connect(prompt)
+            await asyncio.sleep(0.05)
+            received_messages = [message async for message in client.receive_response()]
+        finally:
+            await client.disconnect()
+
+    spans = memory_logger.pop()
+    task_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.TASK), "Claude Agent")
+    llm_spans = find_spans_by_type(spans, SpanTypeAttribute.LLM)
+    assert len(llm_spans) == 1
+    assert not {"prompt_tokens", "completion_tokens", "tokens"}.intersection(llm_spans[0].get("metrics", {}))
+    result_message = received_messages[-1]
+    expected_metrics = _metrics_from_result_message(result_message)
+    assert task_span["metrics"] | expected_metrics == task_span["metrics"]
+
+
 def _make_message(content: str) -> dict:
     """Create a streaming format message dict."""
     return {"type": "user", "message": {"role": "user", "content": content}}
@@ -344,6 +497,99 @@ def _assert_llm_spans_have_time_to_first_token(llm_spans: list[dict[str, Any]]) 
     for llm_span in llm_spans:
         assert "time_to_first_token" in llm_span.get("metrics", {})
         assert llm_span["metrics"]["time_to_first_token"] >= 0
+
+
+def _copy_numeric_usage(usage: Any) -> dict[str, Any]:
+    if not isinstance(usage, dict):
+        return {}
+
+    copied = {
+        key: value
+        for key in (
+            "input_tokens",
+            "output_tokens",
+            "cache_read_input_tokens",
+            "cache_creation_input_tokens",
+        )
+        if isinstance((value := usage.get(key)), int) and not isinstance(value, bool) and value >= 0
+    }
+    cache_creation = usage.get("cache_creation")
+    if isinstance(cache_creation, dict):
+        copied_cache_creation = {
+            key: value
+            for key in ("ephemeral_5m_input_tokens", "ephemeral_1h_input_tokens")
+            if isinstance((value := cache_creation.get(key)), int) and not isinstance(value, bool) and value >= 0
+        }
+        if copied_cache_creation:
+            copied["cache_creation"] = copied_cache_creation
+    return copied
+
+
+def _metrics_from_result_message(message: Any) -> dict[str, float]:
+    usage = _aggregate_model_usage(getattr(message, "model_usage", None)) or _copy_numeric_usage(message.usage)
+    metrics, _ = extract_anthropic_usage(usage)
+    return metrics
+
+
+def _metrics_from_exact_anthropic_usage(usage: dict[str, Any]) -> dict[str, float]:
+    input_tokens = usage.get("input_tokens", 0)
+    output_tokens = usage.get("output_tokens")
+    cache_read_tokens = usage.get("cache_read_input_tokens", 0)
+    aggregate_cache_creation = usage.get("cache_creation_input_tokens", 0)
+    cache_creation = usage.get("cache_creation") or {}
+    cache_creation_5m = cache_creation.get("ephemeral_5m_input_tokens")
+    cache_creation_1h = cache_creation.get("ephemeral_1h_input_tokens")
+    has_cache_creation_breakdown = cache_creation_5m is not None or cache_creation_1h is not None
+    effective_cache_creation = (
+        (cache_creation_5m or 0) + (cache_creation_1h or 0)
+        if has_cache_creation_breakdown
+        else aggregate_cache_creation
+    )
+    prompt_tokens = input_tokens + cache_read_tokens + effective_cache_creation
+    metrics: dict[str, float] = {
+        "prompt_tokens": float(prompt_tokens),
+        "prompt_cached_tokens": float(cache_read_tokens),
+    }
+    if has_cache_creation_breakdown:
+        if cache_creation_5m is not None:
+            metrics["prompt_cache_creation_5m_tokens"] = float(cache_creation_5m)
+        if cache_creation_1h is not None:
+            metrics["prompt_cache_creation_1h_tokens"] = float(cache_creation_1h)
+    else:
+        metrics["prompt_cache_creation_tokens"] = float(aggregate_cache_creation)
+    if output_tokens is not None:
+        metrics["completion_tokens"] = float(output_tokens)
+        metrics["tokens"] = float(prompt_tokens + output_tokens)
+    return metrics
+
+
+def _final_partial_usage(messages: list[Any]) -> list[dict[str, Any]]:
+    active_message_by_parent: dict[str | None, str] = {}
+    usage_by_message_id: dict[str, dict[str, Any]] = {}
+    message_order: list[str] = []
+
+    for message in messages:
+        if type(message).__name__ != "StreamEvent":
+            continue
+        event = getattr(message, "event", None)
+        if not isinstance(event, dict):
+            continue
+        parent_tool_use_id = getattr(message, "parent_tool_use_id", None)
+        if event.get("type") == "message_start":
+            raw_message = event.get("message")
+            message_id = raw_message.get("id") if isinstance(raw_message, dict) else None
+            if isinstance(message_id, str):
+                active_message_by_parent[parent_tool_use_id] = message_id
+                usage_by_message_id[message_id] = _copy_numeric_usage(raw_message.get("usage"))
+                message_order.append(message_id)
+        elif event.get("type") == "message_delta":
+            message_id = active_message_by_parent.get(parent_tool_use_id)
+            if message_id is not None:
+                usage_by_message_id[message_id].update(_copy_numeric_usage(event.get("usage")))
+        elif event.get("type") == "message_stop":
+            active_message_by_parent.pop(parent_tool_use_id, None)
+
+    return [usage_by_message_id[message_id] for message_id in message_order]
 
 
 def _sdk_cassette_name(base: str, *, min_version: str) -> str:
@@ -515,6 +761,7 @@ async def test_user_prompt_submit_hook_creates_function_span(memory_logger):
                 "hook_event_name": input_data.get("hook_event_name"),
                 "prompt": input_data.get("prompt"),
                 "tool_use_id": tool_use_id,
+                "transcript_path": input_data.get("transcript_path"),
             }
         )
         return {
@@ -540,13 +787,15 @@ async def test_user_prompt_submit_hook_creates_function_span(memory_logger):
             options=options,
         )
 
+        received_messages: list[Any] = []
         async with claude_agent_sdk.ClaudeSDKClient(options=options, transport=transport) as client:
             await client.query(prompt)
             async for message in client.receive_response():
+                received_messages.append(message)
                 if type(message).__name__ == "ResultMessage":
                     break
 
-    assert hook_invocations, "Expected the UserPromptSubmit hook to be invoked"
+    assert len(hook_invocations) == 1, "Expected the caller's UserPromptSubmit hook exactly once"
 
     spans = memory_logger.pop()
     task_span = find_span_by_name(find_spans_by_type(spans, SpanTypeAttribute.TASK), "Claude Agent")
@@ -567,6 +816,11 @@ async def test_user_prompt_submit_hook_creates_function_span(memory_logger):
     assert hook_span["input"]["prompt"] == prompt
     assert hook_span["output"]["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
     assert llm_spans, "Expected at least one LLM span for the Claude response"
+    for llm_span in llm_spans:
+        assert not {"prompt_tokens", "completion_tokens", "tokens"}.intersection(llm_span.get("metrics", {}))
+    result_message = received_messages[-1]
+    expected_metrics = _metrics_from_result_message(result_message)
+    assert task_span["metrics"] | expected_metrics == task_span["metrics"]
     assert any(
         isinstance(llm_span.get("input"), list)
         and llm_span["input"]
@@ -858,6 +1112,7 @@ async def test_multiple_bundled_subagents_keep_outer_orchestration_separate(memo
             options=options,
         )
 
+        received_messages: list[Any] = []
         async with claude_agent_sdk.ClaudeSDKClient(options=options, transport=transport) as client:
             await client.query(
                 "Launch two bundled general-purpose subagents for two independent tasks. "
@@ -866,10 +1121,13 @@ async def test_multiple_bundled_subagents_keep_outer_orchestration_separate(memo
                 "'alpha:<version> | <owner>'. "
                 "The second delegated subagent must use Bash and Read on release_notes_beta.md and return only "
                 "'beta:<version> | <owner>'. "
+                "If either agent runs in the background, use TaskOutput with block=true to wait for each result. "
+                "Do not finish while either task is still running. "
                 "After both delegated agents finish, reply with exactly two lines in that same order. "
                 "Do not answer directly without using both subagents."
             )
             async for message in client.receive_response():
+                received_messages.append(message)
                 if type(message).__name__ == "ResultMessage":
                     break
 
@@ -881,6 +1139,12 @@ async def test_multiple_bundled_subagents_keep_outer_orchestration_separate(memo
     root_task_span = find_span_by_name(task_spans, "Claude Agent")
     subagent_spans = [s for s in task_spans if s["span_attributes"]["name"] != "Claude Agent"]
     assert len(subagent_spans) >= 2, f"Expected at least two delegated task spans, got {len(subagent_spans)}"
+
+    for llm_span in llm_spans:
+        assert not {"prompt_tokens", "completion_tokens", "tokens"}.intersection(llm_span.get("metrics", {}))
+    result_message = received_messages[-1]
+    expected_metrics = _metrics_from_result_message(result_message)
+    assert root_task_span["metrics"] | expected_metrics == root_task_span["metrics"]
 
     outer_llm_spans = [llm_span for llm_span in llm_spans if root_task_span["span_id"] in llm_span["span_parents"]]
     assert outer_llm_spans, "Expected outer orchestration LLM spans under the root task"
@@ -2019,6 +2283,32 @@ def test_extract_anthropic_usage_normalizes_claude_result_message_usage():
         "tokens": 10.0,
     }
     assert metadata == {}
+
+
+def test_aggregate_model_usage_includes_all_agents_and_ignores_invalid_fields():
+    usage = _aggregate_model_usage(
+        {
+            "claude-opus": {
+                "inputTokens": 5,
+                "outputTokens": 3,
+                "cacheReadInputTokens": 11,
+                "cacheCreationInputTokens": 2,
+            },
+            "claude-haiku": types.SimpleNamespace(
+                inputTokens=7,
+                outputTokens=4,
+                cacheReadInputTokens=None,
+                cacheCreationInputTokens=-1,
+            ),
+        }
+    )
+
+    assert usage == {
+        "input_tokens": 12,
+        "output_tokens": 7,
+        "cache_read_input_tokens": 11,
+        "cache_creation_input_tokens": 2,
+    }
 
 
 @pytest.mark.parametrize(

--- a/py/src/braintrust/integrations/claude_agent_sdk/tracing.py
+++ b/py/src/braintrust/integrations/claude_agent_sdk/tracing.py
@@ -3,6 +3,7 @@ import collections
 import contextvars
 import dataclasses
 import json
+import math
 import threading
 import time
 from collections.abc import AsyncGenerator, AsyncIterable
@@ -575,6 +576,91 @@ def _message_starts_subagent_tool(message: Any) -> bool:
     return False
 
 
+def _token_count(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if not math.isfinite(value) or value < 0 or int(value) != value:
+        return None
+    return int(value)
+
+
+def _copy_usage(usage: Any) -> dict[str, Any] | None:
+    if usage is None:
+        return None
+    if not isinstance(usage, dict):
+        try:
+            usage = vars(usage)
+        except TypeError:
+            return None
+
+    copied: dict[str, Any] = {}
+    for key in (
+        "input_tokens",
+        "output_tokens",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+    ):
+        value = _token_count(usage.get(key))
+        if value is not None:
+            copied[key] = value
+
+    cache_creation = usage.get("cache_creation")
+    if cache_creation is not None and not isinstance(cache_creation, dict):
+        try:
+            cache_creation = vars(cache_creation)
+        except TypeError:
+            cache_creation = None
+    if isinstance(cache_creation, dict):
+        copied_cache_creation = {}
+        for key in ("ephemeral_5m_input_tokens", "ephemeral_1h_input_tokens"):
+            value = _token_count(cache_creation.get(key))
+            if value is not None:
+                copied_cache_creation[key] = value
+        if copied_cache_creation:
+            copied["cache_creation"] = copied_cache_creation
+
+    return copied or None
+
+
+def _merge_usage(base: dict[str, Any] | None, override: dict[str, Any] | None) -> dict[str, Any] | None:
+    if base is None or override is None:
+        return override or base
+    merged = {**base, **override}
+    base_cache = base.get("cache_creation")
+    override_cache = override.get("cache_creation")
+    if isinstance(base_cache, dict) or isinstance(override_cache, dict):
+        merged["cache_creation"] = {
+            **(base_cache if isinstance(base_cache, dict) else {}),
+            **(override_cache if isinstance(override_cache, dict) else {}),
+        }
+    return merged
+
+
+def _aggregate_model_usage(model_usage: Any) -> dict[str, int] | None:
+    """Aggregate the SDK's all-agent model usage into Anthropic usage fields."""
+    if not isinstance(model_usage, dict):
+        return None
+
+    field_names = {
+        "inputTokens": "input_tokens",
+        "outputTokens": "output_tokens",
+        "cacheReadInputTokens": "cache_read_input_tokens",
+        "cacheCreationInputTokens": "cache_creation_input_tokens",
+    }
+    totals: dict[str, int] = {}
+    for raw_usage in model_usage.values():
+        if not isinstance(raw_usage, dict):
+            try:
+                raw_usage = vars(raw_usage)
+            except TypeError:
+                continue
+        for source_name, target_name in field_names.items():
+            value = _token_count(raw_usage.get(source_name))
+            if value is not None:
+                totals[target_name] = totals.get(target_name, 0) + value
+    return totals or None
+
+
 @dataclasses.dataclass
 class _AgentContext:
     """Per-subagent-context state, keyed by parent_tool_use_id (None = orchestrator)."""
@@ -582,6 +668,7 @@ class _AgentContext:
     llm_span: Any | None = None
     llm_parent_export: str | None = None
     llm_output: list[dict[str, Any]] | None = None
+    llm_message_id: str | None = None
     next_llm_start: float | None = None
     task_span: Any | None = None
     task_confirmed: bool = False
@@ -596,6 +683,7 @@ class ContextTracker:
         prompt: Any,
         query_start_time: float | None = None,
         captured_messages: list[dict[str, Any]] | None = None,
+        include_partial_messages: bool = False,
     ) -> None:
         self._root_span = root_span
         self._root_span_export = root_span.export()
@@ -610,6 +698,11 @@ class ContextTracker:
         self._final_results: list[dict[str, Any]] = []
         self._result_output: Any | None = None
         self._task_events: list[dict[str, Any]] = []
+        self._include_partial_messages = include_partial_messages
+        self._active_partial_message_id_by_parent: dict[str | None, str] = {}
+        self._latest_partial_message_id_by_parent: dict[str | None, str] = {}
+        self._usage_by_message_id: dict[str, dict[str, Any]] = {}
+        self._final_output_usage_message_ids: set[str] = set()
 
         _thread_local.tool_span_tracker = self._tool_tracker
 
@@ -617,9 +710,8 @@ class ContextTracker:
 
     def add(self, message: Any) -> None:
         """Consume one SDK message and update spans accordingly."""
-        if self._captured_messages is not None:
-            if self._captured_messages:
-                self._root_span.log(input=self._captured_messages)
+        if self._captured_messages:
+            self._root_span.log(input=self._captured_messages)
             self._captured_messages = None
 
         message_type = type(message).__name__
@@ -629,6 +721,8 @@ class ContextTracker:
             self._handle_user(message)
         elif message_type == MessageClassName.RESULT:
             self._handle_result(message)
+        elif message_type == "StreamEvent":
+            self._handle_stream_event(message)
         elif message_type in SYSTEM_MESSAGE_TYPES:
             self._handle_system(message)
 
@@ -657,6 +751,10 @@ class ContextTracker:
                 ctx.task_span = None
         self._task_order.clear()
         self._tool_tracker.cleanup_all()
+        self._active_partial_message_id_by_parent.clear()
+        self._latest_partial_message_id_by_parent.clear()
+        self._usage_by_message_id.clear()
+        self._final_output_usage_message_ids.clear()
         if getattr(_thread_local, "tool_span_tracker", None) is self._tool_tracker:
             delattr(_thread_local, "tool_span_tracker")
 
@@ -747,14 +845,45 @@ class ContextTracker:
             resolved_key = user_parent if user_parent is not None else self._active_key
             self._get_context(resolved_key).next_llm_start = time.time()
 
+    def _handle_stream_event(self, message: Any) -> None:
+        event = getattr(message, "event", None)
+        if not isinstance(event, dict):
+            return
+        parent_tool_use_id = getattr(message, "parent_tool_use_id", None)
+        event_type = event.get("type")
+        if event_type == "message_start":
+            raw_message = event.get("message")
+            if not isinstance(raw_message, dict):
+                return
+            message_id = raw_message.get("id")
+            if not isinstance(message_id, str):
+                return
+            self._active_partial_message_id_by_parent[parent_tool_use_id] = message_id
+            self._latest_partial_message_id_by_parent[parent_tool_use_id] = message_id
+            usage = _copy_usage(raw_message.get("usage"))
+            if usage:
+                self._usage_by_message_id[message_id] = usage
+            return
+
+        message_id = self._active_partial_message_id_by_parent.get(parent_tool_use_id)
+        if message_id is None:
+            return
+        if event_type == "message_delta":
+            update = _copy_usage(event.get("usage"))
+            if update:
+                usage = _merge_usage(self._usage_by_message_id.get(message_id), update) or {}
+                self._usage_by_message_id[message_id] = usage
+                if "output_tokens" in update:
+                    self._final_output_usage_message_ids.add(message_id)
+                    ctx = self._contexts.get(parent_tool_use_id)
+                    if ctx is not None and ctx.llm_span is not None and ctx.llm_message_id == message_id:
+                        metrics, _ = extract_anthropic_usage(usage)
+                        ctx.llm_span.log(metrics=metrics or None)
+        elif event_type == "message_stop":
+            self._active_partial_message_id_by_parent.pop(parent_tool_use_id, None)
+
     def _handle_result(self, message: Any) -> None:
         self._active_key = None
-        if hasattr(message, "usage"):
-            usage_metrics, usage_metadata = extract_anthropic_usage(message.usage)
-            ctx = self._get_context(None)
-            if ctx.llm_span and (usage_metrics or usage_metadata):
-                ctx.llm_span.log(metrics=usage_metrics or None, metadata=usage_metadata or None)
-
         result_value = getattr(message, "result", None)
         if result_value is not None:
             self._result_output = result_value
@@ -771,8 +900,16 @@ class ContextTracker:
             }.items()
             if v is not None
         }
-        if result_metadata:
-            self._root_span.log(metadata=result_metadata)
+        result_metrics: dict[str, float] = {}
+        if not self._include_partial_messages:
+            raw_usage = getattr(message, "usage", None)
+            _, usage_metadata = extract_anthropic_usage(raw_usage)
+            result_metadata.update(usage_metadata)
+            aggregate_usage = _aggregate_model_usage(getattr(message, "model_usage", None))
+            usage = aggregate_usage or _copy_usage(raw_usage)
+            result_metrics, _ = extract_anthropic_usage(usage)
+        if result_metadata or result_metrics:
+            self._root_span.log(metadata=result_metadata or None, metrics=result_metrics or None)
 
         if getattr(message, "is_error", None) is True:
             error_text = (
@@ -838,13 +975,22 @@ class ContextTracker:
         parent_export: str | None,
         ctx: _AgentContext,
     ) -> tuple[dict[str, Any] | None, bool]:
-        """Start a new LLM span or extend the existing one via merge."""
+        """Start one LLM span per provider message ID and merge its snapshots."""
         current_message = _serialize_assistant_message(message)
+        message_id = getattr(message, "message_id", None)
+        if not isinstance(message_id, str):
+            message_id = self._latest_partial_message_id_by_parent.get(getattr(message, "parent_tool_use_id", None))
+        same_provider_message = (
+            isinstance(message_id, str)
+            and message_id == ctx.llm_message_id
+            or message_id is None
+            and ctx.llm_message_id is None
+            and ctx.next_llm_start is None
+        )
 
-        # Merge path.
         if (
             ctx.llm_span
-            and ctx.next_llm_start is None
+            and same_provider_message
             and ctx.llm_parent_export == parent_export
             and current_message is not None
         ):
@@ -855,9 +1001,9 @@ class ContextTracker:
             if merged is not None:
                 ctx.llm_output = [merged]
                 ctx.llm_span.log(output=ctx.llm_output)
+            self._log_assistant_usage(message, ctx, message_id)
             return merged, True
 
-        # New span path.
         resolved_start = ctx.next_llm_start or time.time()
         first_token_time = time.time()
 
@@ -876,8 +1022,30 @@ class ContextTracker:
         ctx.llm_span = span
         ctx.llm_parent_export = parent_export
         ctx.llm_output = [final_content] if final_content is not None else None
+        ctx.llm_message_id = message_id if isinstance(message_id, str) else None
         ctx.next_llm_start = None
+        self._log_assistant_usage(message, ctx, ctx.llm_message_id)
         return final_content, False
+
+    def _log_assistant_usage(
+        self,
+        message: Any,
+        ctx: _AgentContext,
+        message_id: str | None,
+    ) -> None:
+        if ctx.llm_span is None or not self._include_partial_messages:
+            return
+        raw_message_usage = getattr(message, "usage", None)
+        usage = _merge_usage(
+            _copy_usage(raw_message_usage),
+            self._usage_by_message_id.get(message_id) if message_id else None,
+        )
+        if not usage:
+            return
+        has_final_output = message_id in self._final_output_usage_message_ids if message_id else False
+        metrics, _ = extract_anthropic_usage(usage, include_output=has_final_output)
+        _, metadata = extract_anthropic_usage(raw_message_usage, include_output=False)
+        ctx.llm_span.log(metrics=metrics or None, metadata=metadata or None)
 
     def _process_task_event(self, message: Any, agent_span_export: str | None) -> None:
         """Handle TaskStarted / TaskProgress / TaskNotification system messages."""
@@ -925,6 +1093,7 @@ class RequestTracker:
         prompt: Any,
         query_start_time: float | None = None,
         captured_messages: list[dict[str, Any]] | None = None,
+        include_partial_messages: bool = False,
     ) -> None:
         self._root_span = start_span(
             name=CLAUDE_AGENT_TASK_SPAN_NAME,
@@ -937,6 +1106,7 @@ class RequestTracker:
             prompt=prompt,
             query_start_time=query_start_time,
             captured_messages=captured_messages,
+            include_partial_messages=include_partial_messages,
         )
         self._pretraced_message_types: collections.deque[str] = collections.deque()
         self._finished = False
@@ -1100,6 +1270,10 @@ def _prepare_prompt_for_tracing(prompt: Any) -> tuple[Any, str | None, list[dict
     return prompt, str(prompt), None
 
 
+def _include_partial_messages(options: Any) -> bool:
+    return getattr(options, "include_partial_messages", False) is True
+
+
 async def _stream_messages_with_tracing(
     generator: AsyncIterable[Any],
     *,
@@ -1138,10 +1312,15 @@ def _create_query_wrapper_function(original_query: Any) -> Any:
             kwargs = dict(kwargs)
             kwargs["prompt"] = prompt
 
+        options = kwargs.get("options")
+        if options is None and len(args) > 1:
+            options = args[1]
+
         request_tracker = RequestTracker(
             prompt=traced_prompt,
             query_start_time=query_start_time,
             captured_messages=captured_messages,
+            include_partial_messages=_include_partial_messages(options),
         )
         generator = _bind_request_tracker_to_query(original_query(*args, **kwargs), request_tracker)
 
@@ -1160,7 +1339,8 @@ def _create_client_wrapper_class(original_client_class: Any) -> Any:
 
     class WrappedClaudeSDKClient(Wrapper):
         def __init__(self, *args: Any, **kwargs: Any):
-            # Create the original client instance
+            options = args[0] if args else kwargs.get("options")
+            self.__include_partial_messages = _include_partial_messages(options)
             client = original_client_class(*args, **kwargs)
             super().__init__(client)
             self.__client = client
@@ -1201,6 +1381,18 @@ def _create_client_wrapper_class(original_client_class: Any) -> Any:
                 hook_callbacks[callback_id] = wrapped_callback
                 self.__instrumented_hook_callbacks.add(marker)
 
+        def __prepare_request_prompt(
+            self, args: tuple[Any, ...], kwargs: dict[str, Any]
+        ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+            self.__query_start_time = time.time()
+            prompt = args[0] if args else kwargs.get("prompt")
+            prompt, self.__last_prompt, self.__captured_messages = _prepare_prompt_for_tracing(prompt)
+            if args:
+                return (prompt, *args[1:]), kwargs
+            prepared_kwargs = dict(kwargs)
+            prepared_kwargs["prompt"] = prompt
+            return args, prepared_kwargs
+
         def __start_request_tracker(self) -> RequestTracker:
             if self.__request_tracker is not None:
                 self.__finish_request_tracker()
@@ -1209,6 +1401,7 @@ def _create_client_wrapper_class(original_client_class: Any) -> Any:
                 prompt=self.__last_prompt,
                 query_start_time=self.__query_start_time,
                 captured_messages=self.__captured_messages,
+                include_partial_messages=self.__include_partial_messages,
             )
             query = getattr(self.__client, "_query", None)
             _install_query_message_tracing(query)
@@ -1228,25 +1421,28 @@ def _create_client_wrapper_class(original_client_class: Any) -> Any:
             self.__request_tracker = None
 
         async def connect(self, *args: Any, **kwargs: Any) -> Any:
-            result = await self.__client.connect(*args, **kwargs)
-            _install_query_message_tracing(getattr(self.__client, "_query", None))
+            prompt = args[0] if args else kwargs.get("prompt")
+            if prompt is not None:
+                args, kwargs = self.__prepare_request_prompt(args, kwargs)
+                self.__start_request_tracker()
+            try:
+                result = await self.__client.connect(*args, **kwargs)
+            except Exception as exc:
+                if self.__request_tracker is not None:
+                    self.__request_tracker.log_error(exc)
+                self.__finish_request_tracker()
+                raise
+
+            query = getattr(self.__client, "_query", None)
+            _install_query_message_tracing(query)
+            if query is not None and self.__request_tracker is not None:
+                query._braintrust_request_tracker = self.__request_tracker
             self.__instrument_hook_callbacks()
             return result
 
         async def query(self, *args: Any, **kwargs: Any) -> Any:
             """Wrap query to capture the prompt and start time for tracing."""
-            # Capture the time when query is called (when LLM call starts)
-            self.__query_start_time = time.time()
-
-            # Capture the prompt for use in receive_response
-            prompt = args[0] if args else kwargs.get("prompt")
-            prompt, self.__last_prompt, self.__captured_messages = _prepare_prompt_for_tracing(prompt)
-
-            if args:
-                args = (prompt,) + args[1:]
-            else:
-                kwargs["prompt"] = prompt
-
+            args, kwargs = self.__prepare_request_prompt(args, kwargs)
             self.__instrument_hook_callbacks()
             self.__start_request_tracker()
 


### PR DESCRIPTION
resolves #564
resolves https://linear.app/braintrustdata/issue/SDK-52/claude-agent-sdk-handle-result-logs-main-agent-usage-under-counts

## AI Summary

`ResultMessage.usage` is cumulative across a Claude Agent SDK query, so attaching it to the final `anthropic.messages.create` span misattributes root and subagent tokens and produces incorrect prompt-cache costs.

Token accounting now follows the caller's existing `include_partial_messages` setting without mutating options, injecting hooks, or reading transcript files:

```
include_partial_messages=True
  message_start/message_delta -> exact per-request usage on each LLM span
  result                      -> query metadata only

include_partial_messages=False or omitted
  assistant -> no token metrics on individual LLM spans
  result    -> aggregate all-agent usage on the root "Claude Agent" task span
```

For aggregate task usage, the integration prefers `ResultMessage.model_usage`, which includes root agents and subagents across models, and falls back to `ResultMessage.usage` when model usage is unavailable. Allowlisted result usage metadata such as `service_tier` and `inference_geo` is preserved on the task span.

Caller-provided options and hooks remain unchanged, and yielded SDK messages are not modified. The behavior is covered through both the one-shot `query()` helper and `ClaudeSDKClient`, including direct `connect(prompt)` calls, multiple provider requests, bundled subagents, hooks, and concurrent/racing MCP tool handling.

Anthropic usage normalization now emits either TTL-specific cache-creation metrics or the legacy aggregate cache-creation metric, never both. Prompt totals use the same representation, and total token counts are emitted only when completion usage is known.

Transport cassettes and tests cover the latest Claude Agent SDK and the pinned 0.1.10 compatibility version.