### PR TITLE
fix(framework): pass eval case fields to scorers

### DIFF
--- a/py/src/braintrust/framework.py
+++ b/py/src/braintrust/framework.py
@@ -211,13 +211,16 @@ class EvalHooks(abc.ABC, Generic[Expected]):
 
 class EvalScorerArgs(SerializableDataClass, Generic[Input, Output, Expected]):
     """
-    Arguments passed to an evaluator scorer. This includes the input, expected output, actual output, and metadata.
+    Arguments passed to an evaluator scorer. This includes the input, expected output, actual output, metadata,
+    tags, and evaluation case ID.
     """
 
     input: Input
     output: Output
     expected: Expected | None = None
     metadata: Metadata | None = None
+    id: str | None = None
+    tags: Sequence[str] | None = None
 
 
 OneOrMoreScores = float | int | bool | None | ScoreLike | Sequence[ScoreLike]
@@ -1748,6 +1751,8 @@ async def _run_evaluator_internal_impl(
                     "metadata": metadata,
                     "output": output,
                     "trace": trace,
+                    "id": datum.id,
+                    "tags": tags,
                 }
                 score_promises = [
                     asyncio.create_task(await_or_run_scorer(root_span, score, name, **scorer_kwargs))

--- a/py/src/braintrust/test_framework.py
+++ b/py/src/braintrust/test_framework.py
@@ -227,6 +227,30 @@ async def test_run_evaluator_basic():
 
 
 @pytest.mark.asyncio
+async def test_eval_case_id_and_tags_are_passed_to_scorers():
+    scorer_args = None
+
+    def scorer(input_value, output, expected, *, id=None, tags=None):
+        nonlocal scorer_args
+        scorer_args = {"id": id, "tags": tags}
+        return 1
+
+    evaluator = Evaluator(
+        project_name="test-project",
+        eval_name="test-evaluator",
+        data=[EvalCase(id="dataset-row-id", input=1, expected=2, tags=["dataset-tag"])],
+        task=lambda input_value: input_value * 2,
+        scores=[scorer],
+        experiment_name=None,
+        metadata=None,
+    )
+
+    await run_evaluator(experiment=None, evaluator=evaluator, position=None, filters=[])
+
+    assert scorer_args == {"id": "dataset-row-id", "tags": ["dataset-tag"]}
+
+
+@pytest.mark.asyncio
 async def test_run_evaluator_forwards_base_experiment_id_to_summary(with_memory_logger, with_simulate_login):
     def exact_match(input_value, output, expected):
         return 1.0 if output == expected else 0.0


### PR DESCRIPTION
## Summary

- expose evaluation case `id` and `tags` on `EvalScorerArgs`
- forward the row ID and post-task tags to scorer and classifier callbacks
- add regression coverage for dataset row values

This aligns the Python behavior with the [JavaScript SDK fix](https://github.com/braintrustdata/braintrust-sdk-javascript/pull/2357).
