### PR TITLE
fix(litellm): trace prompt caching metrics

### DIFF
--- a/py/src/braintrust/integrations/litellm/cassettes/1.74.0/test_litellm_prompt_caching_metrics.yaml
+++ b/py/src/braintrust/integrations/litellm/cassettes/1.74.0/test_litellm_prompt_caching_metrics.yaml
@@ -1,0 +1,712 @@
+interactions:
+- request:
+    body: '{"model": "claude-haiku-4-5-20251001", "messages": [{"role": "user", "content":
+      [{"type": "text", "text": "Reply with OK."}]}], "max_tokens": 5, "system": [{"type":
+      "text", "text": "Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context.  LiteLLM
+      version: 1.74.0.", "cache_control": {"type": "ephemeral"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - prompt-caching-2024-07-31
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '21851'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - litellm/1.74.0
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: '{"model":"claude-haiku-4-5-20251001","id":"msg_011CeAkPjLkgBsy9cjX3kjb9","type":"message","role":"assistant","content":[{"type":"text","text":"OK."}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":10,"cache_creation_input_tokens":6016,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":6016,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard","inference_geo":"not_available"}}'
+    headers:
+      anthropic-organization-id:
+      - 27796668-7351-40ac-acc4-024aee8995a5
+      anthropic-ratelimit-input-tokens-limit:
+      - '10000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '9997000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2026-08-18T19:15:20Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2026-08-18T19:15:20Z'
+      anthropic-ratelimit-requests-limit:
+      - '20000'
+      anthropic-ratelimit-requests-remaining:
+      - '19999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-08-18T19:15:20Z'
+      anthropic-ratelimit-tokens-limit:
+      - '12000000'
+      anthropic-ratelimit-tokens-remaining:
+      - '11997000'
+      anthropic-ratelimit-tokens-reset:
+      - '2026-08-18T19:15:20Z'
+      anthropic-workspace-id:
+      - wrkspc_018bFG1FgNVWqx5pthtdGTzS
+      cf-cache-status:
+      - DYNAMIC
+      cf-ray:
+      - a2d33f227973c730-YYZ
+      connection:
+      - keep-alive
+      content-length:
+      - '465'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      date:
+      - Tue, 18 Aug 2026 19:15:20 GMT
+      request-id:
+      - req_011CeAkPinWgt8mwpdvKsdN3
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-ad503ec6967ae581d1841c4b97040b45-6cfc2f0b6ee31eaf-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-robots-tag:
+      - none
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"model": "claude-haiku-4-5-20251001", "messages": [{"role": "user", "content":
+      [{"type": "text", "text": "Reply with OK."}]}], "max_tokens": 5, "system": [{"type":
+      "text", "text": "Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context.  LiteLLM
+      version: 1.74.0.", "cache_control": {"type": "ephemeral"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - prompt-caching-2024-07-31
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '21851'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - litellm/1.74.0
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: '{"model":"claude-haiku-4-5-20251001","id":"msg_011CeAkPnFNeZ7TDmLq7U7Up","type":"message","role":"assistant","content":[{"type":"text","text":"OK."}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":6016,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard","inference_geo":"not_available"}}'
+    headers:
+      anthropic-organization-id:
+      - 27796668-7351-40ac-acc4-024aee8995a5
+      anthropic-ratelimit-input-tokens-limit:
+      - '10000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '10000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2026-08-18T19:15:21Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2026-08-18T19:15:21Z'
+      anthropic-ratelimit-requests-limit:
+      - '20000'
+      anthropic-ratelimit-requests-remaining:
+      - '19999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-08-18T19:15:20Z'
+      anthropic-ratelimit-tokens-limit:
+      - '12000000'
+      anthropic-ratelimit-tokens-remaining:
+      - '12000000'
+      anthropic-ratelimit-tokens-reset:
+      - '2026-08-18T19:15:21Z'
+      anthropic-workspace-id:
+      - wrkspc_018bFG1FgNVWqx5pthtdGTzS
+      cf-cache-status:
+      - DYNAMIC
+      cf-ray:
+      - a2d33f26ccbb5905-YYZ
+      connection:
+      - keep-alive
+      content-length:
+      - '462'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      date:
+      - Tue, 18 Aug 2026 19:15:21 GMT
+      request-id:
+      - req_011CeAkPmj7qUxnrbPBw6TXx
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-dca5ba4cdb372214e617ae0a0df1ed0c-dcea5730ce617404-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-robots-tag:
+      - none
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/litellm/cassettes/latest/test_litellm_prompt_caching_metrics.yaml
+++ b/py/src/braintrust/integrations/litellm/cassettes/latest/test_litellm_prompt_caching_metrics.yaml
@@ -1,0 +1,708 @@
+interactions:
+- request:
+    body: '{"model": "claude-haiku-4-5-20251001", "messages": [{"role": "user", "content":
+      [{"type": "text", "text": "Reply with OK."}]}], "max_tokens": 5, "system": [{"type":
+      "text", "text": "Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context.  LiteLLM
+      version: latest.", "cache_control": {"type": "ephemeral"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '21851'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - litellm/1.97.0
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: '{"model":"claude-haiku-4-5-20251001","id":"msg_011CeAkPmVySAq7Xm35hrmPy","type":"message","role":"assistant","content":[{"type":"text","text":"OK."}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":10,"cache_creation_input_tokens":6011,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":6011,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard","inference_geo":"not_available"}}'
+    headers:
+      anthropic-organization-id:
+      - 27796668-7351-40ac-acc4-024aee8995a5
+      anthropic-ratelimit-input-tokens-limit:
+      - '10000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '9997000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2026-08-18T19:15:21Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2026-08-18T19:15:21Z'
+      anthropic-ratelimit-requests-limit:
+      - '20000'
+      anthropic-ratelimit-requests-remaining:
+      - '19999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-08-18T19:15:20Z'
+      anthropic-ratelimit-tokens-limit:
+      - '12000000'
+      anthropic-ratelimit-tokens-remaining:
+      - '11997000'
+      anthropic-ratelimit-tokens-reset:
+      - '2026-08-18T19:15:21Z'
+      anthropic-workspace-id:
+      - wrkspc_018bFG1FgNVWqx5pthtdGTzS
+      cf-cache-status:
+      - DYNAMIC
+      cf-ray:
+      - a2d33f25b9704c9b-YYZ
+      connection:
+      - keep-alive
+      content-length:
+      - '465'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      date:
+      - Tue, 18 Aug 2026 19:15:21 GMT
+      request-id:
+      - req_011CeAkPkzxiDaQA2ohD1F2o
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-d915a9f69d4751d5c062736833d8d7fe-4a1fa96e02a855b2-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-robots-tag:
+      - none
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"model": "claude-haiku-4-5-20251001", "messages": [{"role": "user", "content":
+      [{"type": "text", "text": "Reply with OK."}]}], "max_tokens": 5, "system": [{"type":
+      "text", "text": "Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context. Braintrust
+      LiteLLM prompt caching regression context. Braintrust LiteLLM prompt caching
+      regression context. Braintrust LiteLLM prompt caching regression context.  LiteLLM
+      version: latest.", "cache_control": {"type": "ephemeral"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '21851'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - litellm/1.97.0
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: '{"model":"claude-haiku-4-5-20251001","id":"msg_011CeAkPpmvtQomrrQhzi571","type":"message","role":"assistant","content":[{"type":"text","text":"OK."}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":6011,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard","inference_geo":"not_available"}}'
+    headers:
+      anthropic-organization-id:
+      - 27796668-7351-40ac-acc4-024aee8995a5
+      anthropic-ratelimit-input-tokens-limit:
+      - '10000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '10000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2026-08-18T19:15:21Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2026-08-18T19:15:22Z'
+      anthropic-ratelimit-requests-limit:
+      - '20000'
+      anthropic-ratelimit-requests-remaining:
+      - '19999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-08-18T19:15:21Z'
+      anthropic-ratelimit-tokens-limit:
+      - '12000000'
+      anthropic-ratelimit-tokens-remaining:
+      - '12000000'
+      anthropic-ratelimit-tokens-reset:
+      - '2026-08-18T19:15:21Z'
+      anthropic-workspace-id:
+      - wrkspc_018bFG1FgNVWqx5pthtdGTzS
+      cf-cache-status:
+      - DYNAMIC
+      cf-ray:
+      - a2d33f2a787e4c9b-YYZ
+      connection:
+      - keep-alive
+      content-length:
+      - '462'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      date:
+      - Tue, 18 Aug 2026 19:15:22 GMT
+      request-id:
+      - req_011CeAkPpCCU4gV2WGvhgzHQ
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      traceresponse:
+      - 00-284e8ad7d1584c15c1e57647728d6a2f-75c617d1441648bc-01
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-robots-tag:
+      - none
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/py/src/braintrust/integrations/litellm/test_litellm.py
+++ b/py/src/braintrust/integrations/litellm/test_litellm.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import time
+import uuid
 
 import litellm
 import pytest
@@ -19,6 +20,8 @@ TEST_MODEL = "gpt-4o-mini"  # cheapest model for tests
 TEST_TEXT_MODEL = "gpt-3.5-turbo-instruct"
 TEST_PROMPT = "What's 12 + 12?"
 TEST_SYSTEM_PROMPT = "You are a helpful assistant that only responds with numbers."
+TEST_CACHE_MODEL = "anthropic/claude-haiku-4-5-20251001"
+TEST_CACHEABLE_PROMPT = "Braintrust LiteLLM prompt caching regression context. " * 400
 TEST_AUDIO_FILE = os.path.join(os.path.dirname(__file__), "..", "..", "fixtures", "test_audio.wav")
 
 RERANK_MODEL = "cohere/rerank-english-v3.0"
@@ -73,6 +76,79 @@ def test_litellm_completion_metrics(memory_logger) -> None:
     assert span["metadata"]["model"] == TEST_MODEL
     assert span["metadata"]["provider"] == "openai"
     assert TEST_PROMPT in str(span["input"])
+
+
+@pytest.mark.vcr
+def test_litellm_prompt_caching_metrics(memory_logger) -> None:
+    package_version = os.environ.get("BRAINTRUST_TEST_PACKAGE_VERSION", "direct")
+    cacheable_prompt = f"{TEST_CACHEABLE_PROMPT}\n\nCache salt: {uuid.uuid4().hex}\n"
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": cacheable_prompt,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+        {"role": "user", "content": "Reply with OK."},
+    ]
+
+    response = litellm.completion(model=TEST_CACHE_MODEL, messages=messages, max_tokens=5)
+    assert response.choices[0].message.content
+
+    spans = memory_logger.pop()
+    assert len(spans) == 1
+    first_metrics = spans[0]["metrics"]
+    first_has_ttl_breakdown = (
+        "prompt_cache_creation_5m_tokens" in first_metrics or "prompt_cache_creation_1h_tokens" in first_metrics
+    )
+    first_cache_creation_tokens = (
+        first_metrics.get("prompt_cache_creation_5m_tokens", 0)
+        + first_metrics.get("prompt_cache_creation_1h_tokens", 0)
+        if first_has_ttl_breakdown
+        else first_metrics.get("prompt_cache_creation_tokens", 0)
+    )
+
+    assert first_cache_creation_tokens > 0
+    assert first_metrics["prompt_cached_tokens"] == 0
+    if first_has_ttl_breakdown:
+        assert "prompt_cache_creation_tokens" not in first_metrics
+
+    second_metrics = None
+    for attempt in range(3):
+        response = litellm.completion(model=TEST_CACHE_MODEL, messages=messages, max_tokens=5)
+        assert response.choices[0].message.content
+
+        spans = memory_logger.pop()
+        assert len(spans) == 1
+        second_metrics = spans[0]["metrics"]
+        if second_metrics.get("prompt_cached_tokens", 0) > 0:
+            break
+        if attempt < 2:
+            time.sleep(1)
+
+    assert second_metrics is not None
+    assert second_metrics["prompt_cached_tokens"] > 0
+    second_has_ttl_breakdown = (
+        "prompt_cache_creation_5m_tokens" in second_metrics or "prompt_cache_creation_1h_tokens" in second_metrics
+    )
+    if second_has_ttl_breakdown:
+        assert "prompt_cache_creation_tokens" not in second_metrics
+
+    if package_version == "latest":
+        assert first_has_ttl_breakdown
+        assert second_has_ttl_breakdown
+
+    unsupported_cache_metrics = {
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "prompt_cache_write_tokens",
+    }
+    assert unsupported_cache_metrics.isdisjoint(first_metrics)
+    assert unsupported_cache_metrics.isdisjoint(second_metrics)
 
 
 @pytest.mark.vcr

--- a/py/src/braintrust/integrations/litellm/tracing.py
+++ b/py/src/braintrust/integrations/litellm/tracing.py
@@ -44,6 +44,9 @@ TOKEN_NAME_MAP: dict[str, str] = {
     "tokens": "tokens",
     "input_tokens": "prompt_tokens",
     "output_tokens": "completion_tokens",
+    # provider prompt caching aliases preserved by LiteLLM
+    "cache_creation_input_tokens": "prompt_cache_creation_tokens",
+    "cache_read_input_tokens": "prompt_cached_tokens",
 }
 
 TOKEN_PREFIX_MAP: dict[str, str] = {
@@ -862,12 +865,51 @@ def _extract_transcription_text(response: Any) -> str | None:
 
 
 def _parse_metrics_from_usage(usage: Any) -> dict[str, Any]:
-    """Parse usage metrics from API response."""
-    return _parse_openai_usage_metrics(
-        usage,
+    """Parse usage metrics from API response, including provider prompt caching aliases."""
+    usage_dict = _try_to_dict(usage)
+    metrics = _parse_openai_usage_metrics(
+        usage_dict,
         token_name_map=TOKEN_NAME_MAP,
         token_prefix_map=TOKEN_PREFIX_MAP,
     )
+
+    # LiteLLM exposes cache writes under both OpenAI-style token details and
+    # provider-native Anthropic aliases. Normalize all of them to the metric
+    # names defined by the Braintrust instrumentation spec.
+    cache_write_tokens = metrics.pop("prompt_cache_write_tokens", None)
+    if is_numeric(cache_write_tokens):
+        metrics.setdefault("prompt_cache_creation_tokens", cache_write_tokens)
+
+    if not isinstance(usage_dict, dict):
+        return metrics
+
+    cache_creation_details = []
+    for token_details_name in ("prompt_tokens_details", "input_tokens_details"):
+        token_details = _get_field(usage_dict, token_details_name)
+        details = _get_field(token_details, "cache_creation_token_details")
+        if details is not None:
+            cache_creation_details.append(details)
+
+    provider_cache_creation = _get_field(usage_dict, "cache_creation")
+    if provider_cache_creation is not None:
+        cache_creation_details.append(provider_cache_creation)
+
+    ttl_metric_names = {
+        "ephemeral_5m_input_tokens": "prompt_cache_creation_5m_tokens",
+        "ephemeral_1h_input_tokens": "prompt_cache_creation_1h_tokens",
+    }
+    has_ttl_breakdown = False
+    for details in cache_creation_details:
+        for source_name, metric_name in ttl_metric_names.items():
+            value = _get_field(details, source_name)
+            if is_numeric(value):
+                metrics[metric_name] = value
+                has_ttl_breakdown = True
+
+    if has_ttl_breakdown:
+        metrics.pop("prompt_cache_creation_tokens", None)
+
+    return metrics
 
 
 _RERANK_BILLED_UNITS_MAP: dict[str, str] = {


### PR DESCRIPTION
resolves https://linear.app/braintrustdata/issue/SDK-188/native-support-for-prompt-caching-metrics-when-using-litellm-gateway

Normalize cache reads and cache creation, including TTL-specific breakdowns, to Braintrust metric names without duplicate aggregate writes. Add cassette-backed coverage for cache creation and reuse across supported LiteLLM versions.