### PR TITLE
feat: initialize datasets by id

### DIFF
--- a/py/src/braintrust/devserver/dataset.py
+++ b/py/src/braintrust/devserver/dataset.py
@@ -5,16 +5,6 @@ from braintrust._generated_types import RunEvalData, RunEvalData1, RunEvalData2
 from braintrust.logger import BraintrustState
 
 
-async def get_dataset_by_id(state: BraintrustState, dataset_id: str) -> dict[str, str]:
-    """Fetch dataset information by ID."""
-    # The public client is synchronous; the devserver currently runs this call inline.
-    response = state.api_client().datasets.get_dataset_id(dataset_id)
-    return {
-        "project_id": response["project_id"],
-        "dataset": response["name"],
-    }
-
-
 # NOTE: To make this performant, we'll have to make these functions work with async i/o
 async def get_dataset(state: BraintrustState, data: RunEvalData | RunEvalData1 | RunEvalData2 | dict[str, Any]) -> Any:
     """
@@ -40,11 +30,9 @@ async def get_dataset(state: BraintrustState, data: RunEvalData | RunEvalData1 |
             )
         elif "dataset_id" in data:
             # Dataset reference by ID
-            dataset_info = await get_dataset_by_id(state, data["dataset_id"])
             return init_dataset(
                 state=state,
-                project_id=dataset_info["project_id"],
-                name=dataset_info["dataset"],
+                dataset_id=data["dataset_id"],
                 **({"version": data["dataset_version"]} if "dataset_version" in data else {}),
                 **({"environment": data["dataset_environment"]} if "dataset_environment" in data else {}),
                 # _internal_btql is optional

--- a/py/src/braintrust/devserver/test_dataset.py
+++ b/py/src/braintrust/devserver/test_dataset.py
@@ -33,7 +33,10 @@ class _DatasetAPIHandler(http.server.BaseHTTPRequestHandler):
             self._send_json({"id": "dataset-reference", "project_id": "project-id", "name": "dataset-name"})
         elif parsed_url.path == "/v1/project/project-id":
             self._send_json({"id": "project-id", "name": "project-name"})
-        elif parsed_url.path == "/environment-object/dataset/dataset-id/prod%2Fstable":
+        elif parsed_url.path in {
+            "/environment-object/dataset/dataset-id/prod%2Fstable",
+            "/environment-object/dataset/dataset-reference/prod%2Fstable",
+        }:
             self._send_json({"object_version": "2"})
         else:
             self._send_json({"error": "not found"}, status=404)
@@ -48,7 +51,10 @@ class _DatasetAPIHandler(http.server.BaseHTTPRequestHandler):
             self._send_json({"id": "project-id", "name": "project-name"})
         elif parsed_url.path == "/v1/dataset":
             self._send_json({"id": "dataset-id", "project_id": "project-id", "name": "dataset-name"})
-        elif parsed_url.path == "/v1/dataset/dataset-id/fetch":
+        elif parsed_url.path in {
+            "/v1/dataset/dataset-id/fetch",
+            "/v1/dataset/dataset-reference/fetch",
+        }:
             self._send_json({"events": []})
         elif parsed_url.path == "/btql":
             self._send_json({"data": []})
@@ -122,14 +128,19 @@ async def test_get_dataset_resolves_environment_to_pinned_version(
     )
 
     assert list(dataset) == []
+    expected_dataset_id = reference.get("dataset_id", "dataset-id")
     assert (
         "GET",
-        "/environment-object/dataset/dataset-id/prod%2Fstable",
+        f"/environment-object/dataset/{expected_dataset_id}/prod%2Fstable",
         expected_query,
         None,
     ) in _DatasetAPIHandler.requests
     assert _request_body("/btql")["version"] == "2"
     assert _request_body("/btql")["query"]["limit"] == 10
+    if "dataset_id" in reference:
+        assert not any(
+            method == "POST" and path == "/v1/dataset" for method, path, _query, _body in _DatasetAPIHandler.requests
+        )
 
 
 @pytest.mark.asyncio
@@ -156,7 +167,8 @@ async def test_get_dataset_prefers_explicit_version_over_environment(
     assert not any(
         path.startswith("/environment-object/") for _method, path, _query, _body in _DatasetAPIHandler.requests
     )
-    assert _request_body("/v1/dataset/dataset-id/fetch")["version"] == "1"
+    expected_dataset_id = reference.get("dataset_id", "dataset-id")
+    assert _request_body(f"/v1/dataset/{expected_dataset_id}/fetch")["version"] == "1"
 
 
 @pytest.mark.asyncio

--- a/py/src/braintrust/logger.py
+++ b/py/src/braintrust/logger.py
@@ -1677,12 +1677,14 @@ def init_dataset(
     _internal_btql: dict[str, Any] | None = None,
     state: BraintrustState | None = None,
     environment: str | None = None,
+    dataset_id: str | None = None,
 ) -> "Dataset":
     """
-    Create a new dataset in a specified project. If the project does not exist, it will be created.
+    Create or load a dataset. When creating a dataset, its project will be created if it does not exist.
 
-    :param project_name: The name of the project to create the dataset in. Must specify at least one of `project_name` or `project_id`.
+    :param project: The name of the project to create the dataset in.
     :param name: The name of the dataset to create. Defaults to `logs` if not specified.
+    :param dataset_id: The id of an existing dataset to load. If specified, this takes precedence over `project`, `project_id`, and `name`.
     :param description: An optional description of the dataset.
     :param version: An optional version of the dataset (to read). If not specified, the latest version will be used.
     :param environment: The environment to load the dataset from. If both `version` and `environment` are provided, `version` takes precedence.
@@ -1711,16 +1713,20 @@ def init_dataset(
     def compute_metadata():
         state.login(org_name=org_name, api_key=api_key, app_url=app_url)
         api_client = state.api_client()
-        if project_id is not None:
-            resp_project = api_client.projects.get_project_id(project_id)
+        if dataset_id is not None:
+            resp_dataset = api_client.datasets.get_dataset_id(dataset_id)
+            resp_project = api_client.projects.get_project_id(resp_dataset["project_id"])
         else:
-            resp_project = api_client.projects.post_project(body={"name": project, "org_name": state.org_name})
-        body = _populate_args(
-            {"project_id": resp_project["id"], "name": name or "logs"},
-            description=description,
-            metadata=metadata,
-        )
-        resp_dataset = api_client.datasets.post_dataset(body=body)
+            if project_id is not None:
+                resp_project = api_client.projects.get_project_id(project_id)
+            else:
+                resp_project = api_client.projects.post_project(body={"name": project, "org_name": state.org_name})
+            body = _populate_args(
+                {"project_id": resp_project["id"], "name": name or "logs"},
+                description=description,
+                metadata=metadata,
+            )
+            resp_dataset = api_client.datasets.post_dataset(body=body)
         return ProjectDatasetMetadata(
             project=ObjectMetadata(id=resp_project["id"], name=resp_project["name"], full_info=dict(resp_project)),
             dataset=ObjectMetadata(id=resp_dataset["id"], name=resp_dataset["name"], full_info=dict(resp_dataset)),

--- a/py/src/braintrust/test_logger.py
+++ b/py/src/braintrust/test_logger.py
@@ -3745,6 +3745,33 @@ class TestDatasetGeneratedAPI(TestCase):
         )
         mock_state.app_conn.assert_not_called()
 
+    def test_init_dataset_looks_up_explicit_dataset_id(self):
+        mock_state = MagicMock()
+        api_client = mock_state.api_client.return_value
+        api_client.datasets.get_dataset_id.return_value = {
+            "id": "test-dataset-id",
+            "project_id": "test-project-id",
+            "name": "test-dataset",
+        }
+        api_client.projects.get_project_id.return_value = {
+            "id": "test-project-id",
+            "name": "test-project",
+        }
+
+        dataset = braintrust.init_dataset(
+            dataset_id="test-dataset-id",
+            use_output=False,
+            state=mock_state,
+        )
+
+        self.assertEqual(dataset.id, "test-dataset-id")
+        self.assertEqual(dataset.name, "test-dataset")
+        self.assertEqual(dataset.project.name, "test-project")
+        api_client.datasets.get_dataset_id.assert_called_once_with("test-dataset-id")
+        api_client.projects.get_project_id.assert_called_once_with("test-project-id")
+        api_client.datasets.post_dataset.assert_not_called()
+        api_client.projects.post_project.assert_not_called()
+
     def test_init_dataset_looks_up_explicit_project_id(self):
         mock_state = MagicMock()
         api_client = mock_state.api_client.return_value


### PR DESCRIPTION
resolves https://linear.app/braintrustdata/issue/SDK-243/support-dataset-ids-in-python-initdataset

Allow init_dataset callers to load an existing dataset directly by `dataset_id`. Reuse this path in the devserver to avoid redundant dataset registration.