### PR TITLE
fix(agno): allowlist tool call metadata

### DIFF
--- a/py/src/braintrust/integrations/agno/test_agno.py
+++ b/py/src/braintrust/integrations/agno/test_agno.py
@@ -131,8 +131,9 @@ def test_agno_agent_tools_metadata_placement(memory_logger):
     Agent = agent_module.Agent
     OpenAIChat = openai_module.OpenAIChat
 
-    def get_weather(city: str) -> str:
+    def get_weather(agent: Agent, city: str) -> str:
         """Return the current weather for *city*."""
+        assert agent.name == "Weather Agent"
         return f"The weather in {city} is 72F and sunny."
 
     assert not memory_logger.pop()
@@ -148,6 +149,10 @@ def test_agno_agent_tools_metadata_placement(memory_logger):
     assert response and response.content
 
     spans = memory_logger.pop()
+    tool_spans = [s for s in spans if s["span_attributes"]["type"].value == "tool"]
+    assert len(tool_spans) == 1
+    assert tool_spans[0]["input"] == {"city": "Paris"}
+    assert tool_spans[0]["metadata"] == {"name": "get_weather", "entrypoint": "get_weather"}
     llm_spans = [s for s in spans if s["span_attributes"]["type"].value == "llm"]
     assert llm_spans, "expected at least one llm span"
 

--- a/py/src/braintrust/integrations/agno/tracing.py
+++ b/py/src/braintrust/integrations/agno/tracing.py
@@ -1245,7 +1245,12 @@ def _get_function_name(instance) -> str:
 
 
 def _function_call_metadata(instance: Any) -> dict[str, Any]:
-    """Best-effort metadata extraction for a FunctionCall. Contains instrumentation errors."""
+    """Allowlist tool identity fields, containing instrumentation errors.
+
+    Never collect ``_build_entrypoint_args()`` for logging: injected runtime
+    objects (including Agent, Team, and RunContext) can contain credentials or
+    private state. Agno owns injecting those objects when executing the tool.
+    """
     metadata: dict[str, Any] = {}
     try:
         metadata["name"] = instance.function.name
@@ -1253,12 +1258,6 @@ def _function_call_metadata(instance: Any) -> dict[str, Any]:
         pass
     try:
         metadata["entrypoint"] = instance.function.entrypoint.__name__
-    except Exception:
-        pass
-    try:
-        entrypoint_args = instance._build_entrypoint_args()
-        if entrypoint_args:
-            metadata.update(entrypoint_args)
     except Exception:
         pass
     return metadata


### PR DESCRIPTION
Keep Agno-injected Agent, Team, and RunContext objects out of tool spans

Fixes #733